### PR TITLE
fix: dispatch approved decisions to the executor; record MCP approver (#20, #19)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -587,6 +587,17 @@ resolved since before this API existed. `GET /api/v1/sessions/{id}` and
 same relationship `docs/api/README.md`'s "Sessions" section already draws
 between a session and `TaskModel`.
 
+### `approve` dispatches in the same request, not on a later event
+
+An `approved` outcome that leaves the task in `waiting_executor` is offered to
+its executor before the response returns — `AgentHub.dispatch_available`, the
+same mechanism `approve_codex_task` (MCP) now also calls, rather than each
+transport hand-rolling `is_connected` + `dispatch_next` + `send` (issues
+#18/#20). An offline or already-busy executor is unaffected: the task stays
+`waiting_executor` and is picked up the same way it always was — the next
+`mark_task_finished` call (issue #17) or the executor's own reconnect.
+`reject` and `request-revision` never dispatch; both resolve to `CANCELLED`.
+
 ### Every decision this build serves is critical
 
 Approval is withheld only at `PolicyLevel.SENSITIVE`, so `risk` is `sensitive`

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -1035,6 +1035,11 @@ paths:
 
         Only a `pending` decision may be approved; a decision already resolved,
         or otherwise no longer awaiting approval, answers `409`.
+
+        If the task's executor is connected and has a free concurrency slot,
+        it is dispatched the task in the same request — not left for a later,
+        unrelated event to discover it. An offline or already-busy executor
+        is unaffected: the task stays `waiting_executor`.
       security:
         - bearerAuth: []
       parameters:

--- a/docs/issues/001-mobile-api-foundation/RESUME.md
+++ b/docs/issues/001-mobile-api-foundation/RESUME.md
@@ -1,18 +1,35 @@
-# RESUME — WK-20260820-gh-5-projects-api (epic #1)
+# RESUME — WK-20260821-gh-20-19-approve-dispatch (epic #1)
 
-- work_id: WK-20260820-gh-5-projects-api
-- data: 2026-08-20
-- branch: `feature/gh-5/projects-operational-summary-api` (committed, not pushed)
+- work_id: WK-20260821-gh-20-19-approve-dispatch
+- data: 2026-08-21
+- branch: `feature/gh-20/dispatch-approved-task-to-executor` (pushed; PR open against `development`)
 
 ## Next Step (DO THIS FIRST)
 
-Operator review and push/merge decision for `integration/gh-5-6-7-8-contract-align`
-(see `handoff.md`'s 2026-08-20 "integration-gh-5-6-7-8" entry) — the four
-branches below are combined and conflict-resolved there, full suite green.
+Two independent operator decisions are open, oldest first:
+
+1. Push/merge decision for `integration/gh-5-6-7-8-contract-align` (see
+   `handoff.md`'s 2026-08-20 "integration-gh-5-6-7-8" entry) — unchanged since
+   that session, still combined and full-suite green, still not merged.
+2. Review the PR for this session's work (issues #20/#19, duplicate #18):
+   `POST /api/v1/decisions/{id}/approve` never dispatched the approved task to
+   its executor; MCP's `approve_codex_task` never recorded who approved a
+   decision. See `docs/napkin-lessons.md`'s 2026-08-21 entry for the fix
+   shape and why the dispatch logic landed in `AgentHub.dispatch_available`
+   rather than in `store.decide_task_approval` itself. Commented on #18
+   (duplicate) cross-linking the PR and #20; not closed — operator's call.
+
 Once merged, next unblocked pick is #10, #11, #13 or #14 (no dependency
 ordering declared between any of #5-#14).
 
 ## Current state
+
+Delivered, pushed, PR open against `development`:
+
+| issue | branch |
+|---|---|
+| #20 (duplicate: #18) — approve never dispatched to the executor | `feature/gh-20/dispatch-approved-task-to-executor` |
+| #19 — MCP approve never recorded the deciding actor | same branch, same PR |
 
 Merged to `development`: #2, #3, #4, #9, #12, #15, #16, #17.
 
@@ -52,7 +69,7 @@ of `development`).
 | council round on #6/#7/#8 once reviewed and approved (council.md's own precondition) | next session, after operator approval |
 | #10 (conversations), #11 (artifacts), #13 (event stream), #14 (contract tests) — no attempt yet; empty placeholder branches exist for #10/#11/#13 | next session |
 | Postgres never exercised (production is SQLite) | next session |
-| pre-existing `test_agent_ws_handshake.py` order-dependency (4 tests fail in full-suite runs, pass alone) on plain `development` itself | next session |
+| pre-existing `test_agent_ws_handshake.py` failure (4 tests) on plain `development` itself — root cause now pinned: not test order, but a stray gitignored `codex_bridge.db` file the fixture's real (non-isolated) app writes to; see 2026-08-21 napkin-lessons entry | next session |
 | gh-7's own branch carries a duplicate empty `/health:` path key in its `openapi.yaml` (own-branch bug, found while integrating, dropped from the integration branch, not fixed on gh-7 itself) | next session, if gh-7 is ever merged standalone |
 
 ## Checks
@@ -61,3 +78,8 @@ Per-branch `python3 -m pytest -q`: #5 381, #6 382, #7 400, #8 388 (each
 against its own `development` base). Combined run on
 `integration/gh-5-6-7-8-contract-align` — see `handoff.md`'s 2026-08-20
 "integration-gh-5-6-7-8" entry for the result.
+
+`feature/gh-20/dispatch-approved-task-to-executor`: `python3 -m pytest -q` →
+499 passed, 4 failed (the pre-existing `test_agent_ws_handshake.py` failures
+above, reproduced identically with none of this branch's changes applied —
+not a regression).

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -536,3 +536,86 @@ diffed its paths list against a clean base. Dropped from the integration
 branch; not fixed on gh-7 itself, since an integration branch should not
 alter what its source branches contain. Filed in this session's `RESUME.md`
 for whoever eventually merges gh-7 standalone.
+
+## 2026-08-21 — gh-20 (duplicate: gh-18) and gh-19, recovering a lost session
+
+A prior session (ephemeral cloud container, 2026-08-20) implemented this same
+fix but never got it out: `git push` hit 403/404 and the container recycled
+before anything could be recovered — no branch, no diff, nothing survived.
+This session redid the work from a cold read of the two issues rather than
+trying to reconstruct what the lost session did, since there was nothing to
+reconstruct from.
+
+**#20 (duplicate: #18)**: `POST /api/v1/decisions/{id}/approve` called
+`store.decide_task_approval` and returned 200 without ever touching
+`AgentHub` — an approved task landed `waiting_executor` and stayed there
+until an unrelated event (another task finishing on the same executor,
+a reconnect) happened to nudge the queue. The MCP transport's
+`approve_codex_task` already did this correctly
+(`is_connected` + `dispatch_next` + `send`, hand-rolled inline). Rather than
+duplicate that sequence a third time in `decisions.py`, extracted it into
+`AgentHub.dispatch_available` (`gateway/app/services/agent_hub.py`) — the
+same shape issue #17 already established with `mark_task_finished` for the
+finish/cancel side — and converted **both** known callers onto it: the new
+REST call site, and MCP's `approve_codex_task` (its inline version deleted,
+not left "for compatibility" — design-standards.md §7). `mark_task_finished`
+itself was refactored onto `dispatch_available` too, so the method has three
+callers, not one dressed up as general.
+
+Considered putting the dispatch inside `store.decide_task_approval` itself,
+per the issue's own suggestion and §7's "an extension point with zero
+adopters is dead code" framing. Decided against: `store.py` has no import of
+`AgentHub` anywhere in the codebase today (the dependency only ever runs the
+other way, `agent_hub.py` imports `store`), and every existing hub-effect —
+`mark_task_finished`, `sessions.py`'s `restart_session` — already lives on
+the caller side of a `decide_task_approval`/`restart_finished_task` return,
+never inside the store function itself. Inverting that for one caller would
+have been the actual novel architecture change here, not a reuse of an
+existing pattern.
+
+Found but explicitly left alone: `sessions.py`'s `restart_session` is a
+*third* hand-rolled `is_connected` + `dispatch_next` + `send` sequence,
+predating this fix, not mentioned in scope by #18 or #20. Not converted onto
+`dispatch_available` — doing so would be the same kind of scope creep the
+2026-08-20 gh-5/6/7/8 integration session declined for gh-7's duplicate
+`/health:` key. Left as a note for whoever next touches that function.
+
+**#19**: MCP's `approve_codex_task` recorded only the generic
+`task.approval_decision` event (written inside `decide_task_approval` for
+every caller); the actor-attributed `task.decision_resolved_by_actor` event
+the REST path's `_resolve()` records was missing, so an MCP approval could be
+seen in `audit_events` but never attributed to who approved it — the same gap
+the #17 council already found and fixed for MCP's `cancel_codex_task`
+(`task.stopped_by_actor`), one action later. Fixed by mirroring that call
+exactly, `via: "mcp"`.
+
+Both issues turned out to be one PR: same call site, same audit gap, found by
+the same retroactive council pass. Tested against a real `AgentHub`, not a
+stub, per #18's own DoD — `tests/integration/test_decisions.py`'s fixture now
+wires a real hub (disconnected by default, so every pre-existing test's
+"approval leaves the task at `waiting_executor`" assertion stays true
+unchanged) and `tests/integration/test_store_and_mcp.py` gained its own
+real-hub tests for the MCP path (the existing `DummyHub` there always returns
+`None` from `dispatch_next`, which is exactly why it could not have caught
+either bug).
+
+`python3 -m pytest -q` → 499 passed, 4 failed
+(`tests/integration/test_agent_ws_handshake.py`, all four). Verified this
+failure is not this session's: reproduces identically with none of this
+session's changes applied (`git stash`), and — the more interesting finding —
+depends entirely on whether a stray, gitignored `codex_bridge.db` file
+already exists in the working tree with its schema created. That file is the
+*real* production sqlite target (`gateway/app/core/config.py`'s
+`database_url` default, `sqlite+aiosqlite:///./codex_bridge.db`), and
+`test_agent_ws_handshake.py`'s `client` fixture imports the real
+`gateway.app.main.app` rather than building an isolated in-memory app like
+every other integration test file does — so its outcome depends on
+leftover disk state from whatever last ran the real app's startup event, not
+on anything in the test suite itself. Confirmed by deleting the file and
+re-running clean `development` with zero changes: same 4 failures. The
+"order-dependency" framing in the 2026-08-19/20 entries above is real but
+incomplete — it's not only test execution order, it's shared physical state
+across pytest invocations. Not fixed here (unrelated to #18/#19/#20, and
+`.gitignore` already keeps the file out of the repo); worth its own issue —
+the fix is almost certainly giving `test_agent_ws_handshake.py` its own
+isolated app/engine the way every other integration test file already does.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -619,3 +619,39 @@ across pytest invocations. Not fixed here (unrelated to #18/#19/#20, and
 `.gitignore` already keeps the file out of the repo); worth its own issue —
 the fix is almost certainly giving `test_agent_ws_handshake.py` its own
 isolated app/engine the way every other integration test file already does.
+
+## 2026-08-21 — council round 2 on #20/PR #21, closure
+
+Round 2 (§4 of `.docs/agents/council.md`): one surviving round-1 finding on
+PR #21's same-request dispatch closed. `decisions.py`'s `_resolve()` fetches
+`updated` from `store.decide_task_approval`, then — for an `approved` outcome
+— calls `hub.dispatch_available(updated.executor_id)`, which (for a
+connected, idle executor) dispatches in the same request and bumps
+`task.revision` again through its *own* session
+(`AgentHub.session_factory`), not the request's. `updated` was never
+refreshed afterward, so the `200` response's `revision` and its `ETag`
+header both reported the pre-dispatch revision while the task's real DB
+revision was one higher — a client trusting that ETag for its next
+`If-Match` got a spurious `409` on a revision it was just handed as current.
+Round 1's own tests exercised the dispatch (`state == running`) but never
+asserted on the response body's `revision`/ETag, which is exactly why the
+gap survived round 1.
+
+Fixed by carrying over this codebase's own established pattern for the same
+hazard: `sessions.py`'s `restart_session` already calls `await
+session.refresh(updated)` right after its own `dispatch_next`/`send` pair,
+for the identical reason (a dispatch that ran in-request bumped the row a
+second time). `_resolve()` now does the same, right after
+`hub.dispatch_available`, before `_decision_dto(updated)`/`etag_for(updated.
+revision)` build the response.
+
+New test:
+`tests/integration/test_decisions.py::test_approve_response_revision_matches_the_post_dispatch_task_after_same_request_dispatch`.
+Verified failing against the pre-fix code (`git stash` on `decisions.py`
+alone, test kept): asserted `response.json()["revision"] == updated.revision`
+where the response reported `2` against the DB's actual `3`. Passes with the
+fix restored.
+
+`python3 -m pytest -q` → 500 passed, 4 failed (same
+`tests/integration/test_agent_ws_handshake.py` four, unchanged from the
+2026-08-20 baseline — the extra passing test is this round's own).

--- a/gateway/app/api/routes/decisions.py
+++ b/gateway/app/api/routes/decisions.py
@@ -285,6 +285,19 @@ async def _resolve(
             )
 
         updated = await store.decide_task_approval(session, task.id, outcome, reason)
+        if updated.state == TaskState.WAITING_EXECUTOR.value:
+            # Issue #20 (duplicate: #18): this was the only caller of
+            # `decide_task_approval` that never nudged the queue afterward —
+            # the MCP transport's `approve_codex_task` has done this since
+            # before this REST API existed. `dispatch_available` is the
+            # shared entry point both now use (`AgentHub.dispatch_available`);
+            # it already no-ops for an offline or at-capacity executor, so no
+            # extra guard is needed here. `reject`/`request-revision` never
+            # reach this branch: `decide_task_approval` only sets
+            # `WAITING_EXECUTOR` for an `APPROVED` outcome.
+            from gateway.app.main import hub  # imported late: main includes this router
+
+            await hub.dispatch_available(updated.executor_id)
         await record_event(
             session,
             "task",

--- a/gateway/app/api/routes/decisions.py
+++ b/gateway/app/api/routes/decisions.py
@@ -298,6 +298,15 @@ async def _resolve(
             from gateway.app.main import hub  # imported late: main includes this router
 
             await hub.dispatch_available(updated.executor_id)
+            # `dispatch_available` runs in its own session (`AgentHub`'s
+            # `session_factory`) and, when it dispatches, bumps `revision`
+            # again via `store.update_task_state`. `updated` is still the
+            # pre-dispatch row in this session's identity map, so without a
+            # refresh the response below (`_decision_dto`/`etag_for`) would
+            # hand the client a revision one behind the task's real state —
+            # the same hazard `routes/sessions.py:restart_session` guards
+            # against with the same call after its own dispatch.
+            await session.refresh(updated)
         await record_event(
             session,
             "task",

--- a/gateway/app/mcp/server.py
+++ b/gateway/app/mcp/server.py
@@ -274,16 +274,41 @@ async def handle_mcp_call(
         require_scope("codexbridge.task.approve")
         if principal is not None and not (principal.can_approve_sensitive or principal.is_admin()):
             raise HTTPException(status_code=403, detail="approval_not_allowed")
+        decision = ApprovalDecision(arguments["decision"])
         task = await store.decide_task_approval(
             session,
             arguments["task_id"],
-            ApprovalDecision(arguments["decision"]),
+            decision,
             arguments.get("reason"),
         )
-        if task.state in {TaskState.QUEUED.value, TaskState.WAITING_EXECUTOR.value} and hub.is_connected(task.executor_id):
-            dispatch_payload = await hub.dispatch_next(task.executor_id)
-            if dispatch_payload is not None:
-                await hub.send(task.executor_id, hub_envelope(task.executor_id, "task.dispatch", dispatch_payload))
+        if task.state == TaskState.WAITING_EXECUTOR.value:
+            # Issue #20: was `is_connected(...)` + `dispatch_next` + `send`
+            # hand-rolled here — the REST `POST /api/v1/decisions/{id}/approve`
+            # (`gateway/app/api/routes/decisions.py`) never had an equivalent
+            # and left an approved task stranded in `waiting_executor` (#18,
+            # duplicate). Both now call the same `AgentHub.dispatch_available`,
+            # which already no-ops for an offline/at-capacity executor.
+            await hub.dispatch_available(task.executor_id)
+        # Issue #19: the REST path's `_resolve()` (`routes/decisions.py`)
+        # already records this actor-attributed event alongside the generic
+        # `task.approval_decision` `decide_task_approval` itself writes; this
+        # transport never did, so an approval via MCP/ChatGPT could be seen in
+        # `audit_events` but never attributed to who approved it. Mirrors
+        # `cancel_codex_task`'s own `task.stopped_by_actor` fix for the same
+        # gap (issue #17 council).
+        await record_event(
+            session,
+            "task",
+            task.id,
+            "task.decision_resolved_by_actor",
+            {
+                "actor_id": principal.user_id,
+                "actor_email": principal.email,
+                "via": "mcp",
+                "outcome": decision.value,
+            },
+        )
+        await session.commit()
         payload = {"task_id": task.id, "state": task.state, "approval_state": task.approval_state}
         result = _text_result(f"Approval decision recorded for task {task.id}.", payload)
     elif tool_name == "list_recent_tasks":

--- a/gateway/app/services/agent_hub.py
+++ b/gateway/app/services/agent_hub.py
@@ -124,6 +124,30 @@ class AgentHub:
                 "continue_session_id": task.session_id,
             }
 
+    async def dispatch_available(self, executor_id: str) -> None:
+        """Dispatches the next queued/waiting task to `executor_id`, if one is
+        ready, and sends it right now.
+
+        Shared entry point for every caller that moves a task into a
+        dispatchable state (`QUEUED`/`WAITING_EXECUTOR`) and needs the queue
+        nudged in the same turn, rather than left for an unrelated event to
+        discover it later. `dispatch_next` already gates on the executor being
+        connected (`executor_id not in self.connections`) and on its
+        concurrency slot, so callers don't repeat either check themselves —
+        that hand-rolled `is_connected` + `dispatch_next` + `send` sequence is
+        exactly what issues #18/#20 found duplicated (correctly, in the MCP
+        transport's `approve_codex_task`) and missing (in the REST
+        `POST /api/v1/decisions/{id}/approve`, `gateway/app/api/routes/
+        decisions.py`). Both callers now share this method instead of a third
+        caller re-implementing the sequence by hand.
+        """
+        dispatch_payload = await self.dispatch_next(executor_id)
+        if dispatch_payload is not None:
+            await self.send(
+                executor_id,
+                hub_envelope(executor_id, AgentMessageType.TASK_DISPATCH.value, dispatch_payload),
+            )
+
     async def mark_task_finished(self, executor_id: str, task_id: str) -> None:
         """Releases the slot `task_id` held and, if the executor is still
         connected, immediately dispatches whatever is next in its queue.
@@ -140,12 +164,7 @@ class AgentHub:
         every caller gets it, including ones not yet written.
         """
         self.running_tasks.setdefault(executor_id, set()).discard(task_id)
-        dispatch_payload = await self.dispatch_next(executor_id)
-        if dispatch_payload is not None:
-            await self.send(
-                executor_id,
-                hub_envelope(executor_id, AgentMessageType.TASK_DISPATCH.value, dispatch_payload),
-            )
+        await self.dispatch_available(executor_id)
 
 
 def hub_envelope(executor_id: str, message_type: str, payload: dict) -> AgentEnvelope:

--- a/tests/integration/test_decisions.py
+++ b/tests/integration/test_decisions.py
@@ -25,6 +25,7 @@ from gateway.app.db.base import Base
 from gateway.app.db.session import get_session
 from gateway.app.models.entities import AuditEventModel
 from gateway.app.services import store
+from gateway.app.services.agent_hub import AgentHub
 from shared.protocol import (
     ExecutorRegistration,
     ProjectRegistration,
@@ -33,6 +34,20 @@ from shared.protocol import (
     TaskPriority,
     TaskState,
 )
+
+
+class _DummyWebSocket:
+    """Stands in for the executor's websocket in `AgentHub.register` — real
+    enough that `AgentHub.send` (`connection.websocket.send_json(...)`) works
+    without an actual socket, same pattern as
+    `tests/integration/test_agent_ack_handling.py`'s own `_DummyWebSocket`.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
 
 
 ALICE_TOKEN = "token-alice"              # sees project p1 only; no approve scope
@@ -169,8 +184,26 @@ async def api(users_file, monkeypatch):
 
     app.dependency_overrides[get_session] = override
 
+    # A real AgentHub (issues #18/#20's DoD: tested against the real hub, not
+    # a stub) over this test's own in-memory DB. `_resolve()` reaches it via
+    # `from gateway.app.main import hub` — a late import, same convention as
+    # `routes/sessions.py` — so it must be `gateway.app.main.hub` specifically
+    # that gets replaced, or the route would touch the real production hub
+    # (bound to a different database) instead of this test's.
+    #
+    # No executor is registered as connected by default: every test that
+    # predates issues #18/#20 asserts an approval leaves the task at
+    # `waiting_executor`, which is only still true when nothing dispatches it
+    # — i.e. E1 offline, the same as before this fixture wired a hub in at
+    # all. Tests exercising the new dispatch behaviour connect E1 themselves.
+    hub = AgentHub(factory)
+    import gateway.app.main as main_module
+
+    monkeypatch.setattr(main_module, "hub", hub, raising=False)
+
     client = TestClient(app, raise_server_exceptions=False)
     client.factory = factory  # type: ignore[attr-defined]
+    client.hub = hub          # type: ignore[attr-defined]
     yield client
     await engine.dispose()
 
@@ -556,6 +589,110 @@ async def test_approve_records_the_deciding_actor(api) -> None:
     payload = json.loads(events[0].payload_json)
     assert payload["actor_id"] == "approver"
     assert payload["outcome"] == "approved"
+
+
+# --------------------------------------------------------------------------
+# Dispatch on approve — issue #20 (duplicate: #18)
+#
+# `POST .../approve` used to call `store.decide_task_approval` and stop,
+# leaving an approved task sitting in `waiting_executor` even when its
+# executor was connected and idle — nothing woke the queue for it until an
+# unrelated event happened to. These exercise the real `AgentHub`
+# (`api.hub`), not a stub, per the issue's own DoD.
+# --------------------------------------------------------------------------
+
+
+async def test_approving_dispatches_to_a_connected_idle_executor(api) -> None:
+    task = await make_decision(api.factory, "p1")
+    await api.hub.register("E1", _DummyWebSocket())
+
+    response = api.post(
+        f"/api/v1/decisions/{task.id}/approve",
+        headers={**auth(APPROVER_TOKEN), "If-Match": f'"{task.revision}"'},
+        json={"confirm": True},
+    )
+    assert response.status_code == 200
+
+    async with api.factory() as s:
+        updated = await store.get_task(s, task.id)
+    # Dispatched, not just approved: `AgentHub.dispatch_next` moves a
+    # dispatched task straight to RUNNING. Left at `waiting_executor` would
+    # mean the fix's own bug — the exact failure #18/#20 describe.
+    assert updated.state == TaskState.RUNNING.value
+
+    connection = api.hub.connections["E1"]
+    sent_types = [msg["type"] for msg in connection.websocket.sent]
+    assert "task.dispatch" in sent_types
+
+
+async def test_approving_leaves_the_task_waiting_when_the_executor_is_offline(api) -> None:
+    """No regression on the pre-existing (disconnected) case: `api.hub` has
+    no registered executor, matching every other test in this file."""
+    task = await make_decision(api.factory, "p1")
+
+    response = api.post(
+        f"/api/v1/decisions/{task.id}/approve",
+        headers={**auth(APPROVER_TOKEN), "If-Match": f'"{task.revision}"'},
+        json={"confirm": True},
+    )
+    assert response.status_code == 200
+
+    async with api.factory() as s:
+        updated = await store.get_task(s, task.id)
+    assert updated.state == TaskState.WAITING_EXECUTOR.value
+    assert api.hub.connections == {}
+
+
+async def test_approving_when_the_executor_is_at_capacity_does_not_bypass_the_concurrency_gate(api) -> None:
+    task = await make_decision(api.factory, "p1")
+    await api.hub.register("E1", _DummyWebSocket())
+    # E1's `max_concurrent_tasks` is the default (1) — occupy that one slot
+    # with an unrelated task before approving.
+    api.hub.running_tasks["E1"] = {"some-other-task-already-running"}
+
+    response = api.post(
+        f"/api/v1/decisions/{task.id}/approve",
+        headers={**auth(APPROVER_TOKEN), "If-Match": f'"{task.revision}"'},
+        json={"confirm": True},
+    )
+    assert response.status_code == 200
+
+    async with api.factory() as s:
+        updated = await store.get_task(s, task.id)
+    assert updated.state == TaskState.WAITING_EXECUTOR.value, "the fix must not bypass the capacity check"
+
+    # Unchanged behaviour once the slot frees: the existing
+    # `mark_task_finished` path (issue #17) still picks it up.
+    await api.hub.mark_task_finished("E1", "some-other-task-already-running")
+    async with api.factory() as s:
+        after_slot_freed = await store.get_task(s, task.id)
+    assert after_slot_freed.state == TaskState.RUNNING.value
+
+
+async def test_reject_never_dispatches(api) -> None:
+    task = await make_decision(api.factory, "p1")
+    await api.hub.register("E1", _DummyWebSocket())
+
+    response = api.post(
+        f"/api/v1/decisions/{task.id}/reject",
+        headers={**auth(APPROVER_TOKEN), "If-Match": f'"{task.revision}"'},
+        json={"reason": "not now"},
+    )
+    assert response.status_code == 200
+    assert api.hub.connections["E1"].websocket.sent == []
+
+
+async def test_request_revision_never_dispatches(api) -> None:
+    task = await make_decision(api.factory, "p1")
+    await api.hub.register("E1", _DummyWebSocket())
+
+    response = api.post(
+        f"/api/v1/decisions/{task.id}/request-revision",
+        headers={**auth(APPROVER_TOKEN), "If-Match": f'"{task.revision}"'},
+        json={"reason": "needs another pass"},
+    )
+    assert response.status_code == 200
+    assert api.hub.connections["E1"].websocket.sent == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/integration/test_decisions.py
+++ b/tests/integration/test_decisions.py
@@ -625,6 +625,39 @@ async def test_approving_dispatches_to_a_connected_idle_executor(api) -> None:
     assert "task.dispatch" in sent_types
 
 
+async def test_approve_response_revision_matches_the_post_dispatch_task_after_same_request_dispatch(
+    api,
+) -> None:
+    """Council round-1 finding on this issue: `_resolve` fetches `updated`
+    before `hub.dispatch_available` runs, and `dispatch_available` bumps
+    `revision` again through its own session (`AgentHub.session_factory`) —
+    same-request dispatch, not a later event, moves the task to `running`.
+    Without refreshing `updated` afterward, the response body's `revision`
+    and its `ETag` header both report the pre-dispatch revision while the
+    task's real DB revision is one higher, so a client trusting that ETag
+    for its next `If-Match` gets a spurious 409 on a revision it was just
+    handed as current.
+    """
+    task = await make_decision(api.factory, "p1")
+    await api.hub.register("E1", _DummyWebSocket())
+
+    response = api.post(
+        f"/api/v1/decisions/{task.id}/approve",
+        headers={**auth(APPROVER_TOKEN), "If-Match": f'"{task.revision}"'},
+        json={"confirm": True},
+    )
+    assert response.status_code == 200
+
+    async with api.factory() as s:
+        updated = await store.get_task(s, task.id)
+    # Same-request dispatch happened (state is running, not waiting_executor,
+    # confirming the queue was nudged before the response was built) — so the
+    # response must reflect *that* revision, not the pre-dispatch one.
+    assert updated.state == TaskState.RUNNING.value
+    assert response.json()["revision"] == updated.revision
+    assert response.headers["ETag"] == f'"{updated.revision}"'
+
+
 async def test_approving_leaves_the_task_waiting_when_the_executor_is_offline(api) -> None:
     """No regression on the pre-existing (disconnected) case: `api.hub` has
     no registered executor, matching every other test in this file."""

--- a/tests/integration/test_store_and_mcp.py
+++ b/tests/integration/test_store_and_mcp.py
@@ -12,6 +12,7 @@ from gateway.app.db.base import Base
 from gateway.app.mcp.server import handle_mcp_call
 from gateway.app.models.entities import AuditEventModel
 from gateway.app.services import store
+from gateway.app.services.agent_hub import AgentHub
 from shared.protocol import ApprovalDecision, ExecutorRegistration, ProjectRegistration, SubmitTaskRequest, TaskMode, TaskPriority, TaskState
 
 
@@ -421,3 +422,186 @@ async def test_startup_recovery_marks_pending_control_states_as_lost(
     assert recovered["lost"] == 1
     reloaded = await store.get_task(db_session, task.id)
     assert reloaded.state == TaskState.LOST.value
+
+
+# --------------------------------------------------------------------------
+# approve_codex_task via MCP — issues #18/#19/#20
+#
+# `DummyHub` above is a stub (`dispatch_next` always returns `None`), which is
+# exactly why it could not have caught #20's REST-side gap or proven this
+# transport's own dispatch still works after `approve_codex_task` was
+# refactored onto `AgentHub.dispatch_available`. These use a real `AgentHub`
+# over its own database, same as `tests/integration/test_agent_ack_handling.py`.
+# --------------------------------------------------------------------------
+
+
+class _DummyWebSocket:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+@pytest.fixture
+async def mcp_hub_factory():
+    """A session factory over a fresh database, seeded like `db_session` but
+    exposed as a factory rather than one open session — `AgentHub` needs to
+    open sessions of its own."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        await store.upsert_registry(
+            session,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="T610",
+                    display_name="T610",
+                    machine_token="token-1",
+                    allowed_projects=["p1"],
+                    max_concurrent_tasks=1,
+                )
+            ],
+            projects=[
+                ProjectRegistration(project_id="p1", name="Projeto 1", path="/srv/p1", max_timeout_seconds=600),
+            ],
+        )
+    yield session_factory
+    await engine.dispose()
+
+
+async def _make_sensitive_task(factory):
+    async with factory() as session:
+        task = await store.create_task(
+            session,
+            SubmitTaskRequest(
+                executor_id="T610",
+                project_id="p1",
+                instruction="fazer deploy em production",
+                mode=TaskMode.IMPLEMENT,
+                timeout_seconds=300,
+                priority=TaskPriority.NORMAL,
+                run_when_available=True,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            ),
+            executor_online=False,
+        )
+    assert task.state == TaskState.AWAITING_APPROVAL.value
+    return task
+
+
+@pytest.mark.asyncio
+async def test_mcp_approve_dispatches_to_a_connected_idle_executor(mcp_hub_factory):
+    """Issue #20 asks this of the REST path specifically because the MCP
+    transport already got it right; this pins that MCP's own behaviour
+    survives the refactor onto the shared `AgentHub.dispatch_available`
+    (`gateway/app/mcp/server.py`'s `approve_codex_task` no longer hand-rolls
+    `is_connected` + `dispatch_next` + `send`)."""
+    task = await _make_sensitive_task(mcp_hub_factory)
+
+    hub = AgentHub(mcp_hub_factory)
+    await hub.register("T610", _DummyWebSocket())
+
+    async with mcp_hub_factory() as session:
+        response = await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "approve_codex_task",
+                    "arguments": {"task_id": task.id, "decision": "approved"},
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+    assert response["result"]["structuredContent"]["approval_state"] == "approved"
+
+    async with mcp_hub_factory() as session:
+        reloaded = await store.get_task(session, task.id)
+    # RUNNING, not just WAITING_EXECUTOR: `dispatch_next` moves a dispatched
+    # task straight to RUNNING. Stuck at WAITING_EXECUTOR would mean the same
+    # bug #18/#20 describe, just relocated to the transport this issue is not
+    # about.
+    assert reloaded.state == TaskState.RUNNING.value
+
+    connection = hub.connections["T610"]
+    sent_types = [msg["type"] for msg in connection.websocket.sent]
+    assert "task.dispatch" in sent_types
+
+
+@pytest.mark.asyncio
+async def test_mcp_approve_records_the_deciding_actor(mcp_hub_factory):
+    """Issue #19: only the generic `task.approval_decision` (written inside
+    `store.decide_task_approval` itself, for every caller) used to land for
+    an MCP approval — the actor-attributed `task.decision_resolved_by_actor`
+    event the REST path's `_resolve()` records was missing here, so an audit
+    reader could see *that* an MCP approval happened but never *who* did it.
+    """
+    task = await _make_sensitive_task(mcp_hub_factory)
+    hub = AgentHub(mcp_hub_factory)  # T610 left offline; this test is about the audit trail, not dispatch
+
+    async with mcp_hub_factory() as session:
+        await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "approve_codex_task",
+                    "arguments": {"task_id": task.id, "decision": "approved", "reason": "looks safe"},
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+
+    async with mcp_hub_factory() as session:
+        events = (
+            await session.execute(select(AuditEventModel).where(AuditEventModel.entity_id == task.id))
+        ).scalars().all()
+
+    actor_events = [e for e in events if e.event_type == "task.decision_resolved_by_actor"]
+    assert len(actor_events) == 1
+    assert '"actor_id": "admin"' in actor_events[0].payload_json
+    assert '"actor_email": "admin@example.com"' in actor_events[0].payload_json
+    assert '"via": "mcp"' in actor_events[0].payload_json
+    assert '"outcome": "approved"' in actor_events[0].payload_json
+
+    # The generic event `decide_task_approval` itself records must still be
+    # there too — this issue adds an event, it does not replace one.
+    generic_events = [e for e in events if e.event_type == "task.approval_decision"]
+    assert len(generic_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_reject_and_request_revision_do_not_dispatch(mcp_hub_factory):
+    task = await _make_sensitive_task(mcp_hub_factory)
+    hub = AgentHub(mcp_hub_factory)
+    await hub.register("T610", _DummyWebSocket())
+
+    async with mcp_hub_factory() as session:
+        await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "approve_codex_task",
+                    "arguments": {"task_id": task.id, "decision": "rejected", "reason": "not now"},
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+
+    async with mcp_hub_factory() as session:
+        reloaded = await store.get_task(session, task.id)
+    assert reloaded.state == TaskState.CANCELLED.value
+    assert hub.connections["T610"].websocket.sent == []


### PR DESCRIPTION
## Summary

- Fixes #20: `POST /api/v1/decisions/{id}/approve` called `store.decide_task_approval` and returned 200, but never touched `AgentHub` — an approved task landed in `waiting_executor` and stayed there until an unrelated event happened to nudge the queue. The MCP transport's `approve_codex_task` already dispatched correctly. Extracted the shared sequence into `AgentHub.dispatch_available` (`gateway/app/services/agent_hub.py`) — the same shape issue #17 established with `mark_task_finished` — and converted **both** call sites (REST `decisions.py`, MCP `server.py`) onto it. `mark_task_finished` itself now also calls `dispatch_available`.
- Fixes #19: MCP's `approve_codex_task` never recorded the actor-attributed `task.decision_resolved_by_actor` audit event the REST path's `_resolve()` already records — only the generic `task.approval_decision` landed via MCP. Fixed by mirroring the REST event (`via: "mcp"`), the same gap the #17 council already closed for MCP's `cancel_codex_task`.
- **#18 is a duplicate of #20** — opened independently by the operator, same council round, same root cause, same fix. This PR closes it too, but #18 is left open; see the comment posted on it cross-linking here and to #20. Closing #18 is left to the operator.

## Design note

Considered putting the dispatch inside `store.decide_task_approval` itself, per #18's own suggestion. Decided against it: `store.py` has no import of `AgentHub` anywhere in the codebase (the dependency only ever runs the other way — `agent_hub.py` imports `store`), and every existing hub-effect (`mark_task_finished`, `sessions.py`'s `restart_session`) already lives on the caller side of a store-function return, never inside the store function. Inverting that for one caller would have been a bigger, unrelated architecture change. Full reasoning in `docs/napkin-lessons.md`'s 2026-08-21 entry.

Found but explicitly out of scope: `sessions.py`'s `restart_session` is a *third* hand-rolled `is_connected` + `dispatch_next` + `send` sequence, not mentioned by #18/#20 and not converted here — noted in `docs/issues/001-mobile-api-foundation/RESUME.md` for a future pass.

## Test plan

- [x] `tests/integration/test_decisions.py` — real `AgentHub` wired into the fixture (disconnected by default, so every pre-existing test's "approval leaves the task at `waiting_executor`" assertion is unchanged). New coverage: connected+idle dispatch, offline (no dispatch), at-capacity (no bypass of the concurrency gate; picked up once the slot frees via existing `mark_task_finished`), and `reject`/`request-revision` (never dispatch).
- [x] `tests/integration/test_store_and_mcp.py` — equivalent real-`AgentHub` coverage for the MCP transport, plus the new `task.decision_resolved_by_actor` audit event. The file's existing `DummyHub` always returns `None` from `dispatch_next`, which is why it couldn't have caught either bug.
- [x] `python3 -m pytest -q` → **499 passed, 4 failed**. The 4 failures (`tests/integration/test_agent_ws_handshake.py`) are pre-existing and unrelated to this change — confirmed by reproducing them identically on plain `development` with none of this branch's changes applied. Root cause pinned and logged in `docs/napkin-lessons.md`: that test file's fixture uses the real `gateway.app.main.app`/engine rather than an isolated in-memory app (unlike every other integration test file), so its outcome depends on a stray, gitignored `codex_bridge.db` file's on-disk state rather than anything in this diff.
- [x] `docs/api/README.md` and `docs/api/codex-bridge.openapi.yaml` updated to document the new dispatch-on-approve behavior (doc-only change, no schema/endpoint modification).