### PR TITLE
feat(gh-10): expose conversations and contextual messaging API

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -857,6 +857,120 @@ it on sign-in.
 
 ---
 
+## Conversations (issue #10)
+
+`GET /api/v1/conversations`, `GET .../{id}`, `GET .../{id}/messages`,
+`POST .../{id}/messages`, `POST /api/v1/conversations`.
+
+A **conversation** is a thread linked to at least one product entity. A
+**context reference** names the entity: `project` (`ProjectModel`), `session`
+/ `decision` / `mission` (all the same `TaskModel` row, under the three
+vocabularies "Decisions" and "Missions" above already use), or `issue`
+(`IssueModel`, issue #8).
+
+### `artifact` is not a context type
+
+The issue's Objective names conversations "linked to projects, decisions,
+missions, issues, sessions and artifacts". Five of those six have a backing
+model this build can check a reference against; `artifact` does not —
+`ArtifactModel` has not shipped (issue #11) — so a reference of that type
+could not be validated for existence or for project visibility, which is
+exactly what the acceptance criterion below asks every context reference to
+get. Rather than accept an unverifiable reference, `artifact` is omitted from
+`ConversationContextType` until issue #11 gives it something to check
+against, the same discipline issue #8 applied to "missions, conversations and
+decisions" as issue links and issue #7 applied to `dependencies` /
+`relatedEntities`: no backing entity, no field. See
+`gateway/app/services/conversation_types.py`'s module docstring.
+
+This does not remove artifacts from the feature: "attachment references
+through artifact/file identifiers" is a *message* concept.
+`Message.attachments` carries opaque artifact/file ids on each message,
+recorded and returned unvalidated for the same reason
+`Issue.dependencies` records ids without this build owning a dependency
+graph — and is unaffected by the restriction above.
+
+### Every context reference is resolved and authorization-checked, not just stored
+
+`POST /api/v1/conversations` resolves each `context` entry through the same
+`*_for_projects` getter its analog already uses — `get_project_for_caller`,
+`get_task_for_projects`, `get_issue_for_projects` — the same functions
+`GET /api/v1/sessions/{id}` and `POST /api/v1/epics/{epicId}/issues/{issueId}`
+already rely on to make a hidden resource indistinguishable from a
+nonexistent one. A context reference the caller cannot see therefore answers
+`404`, never a `400` that would confirm the id exists to someone who was not
+given it — issue #10's acceptance criterion ("unauthorized entity references
+are rejected without disclosing hidden resources") verbatim.
+
+There is no independent `projectId` field on the create request. The
+conversation's project is *derived* from `context`: every reference must
+resolve to the same project, or the request is rejected with
+`400 validation_failed` / `mixed_project`. A conversation is always about one
+project's worth of work, the same assumption every other collection in this
+API already makes.
+
+### Unread and last-activity, without a "mark as read" endpoint
+
+Issue #10 names no such endpoint, so `ConversationReadStateModel` can only
+move as a side effect of an endpoint that already exists:
+
+- `GET .../messages` advances the caller's cursor to the newest message
+  **actually returned in that page**, not to "now". A client paging forward
+  from the oldest message must not have later, unfetched messages marked
+  seen just because an earlier page was fetched.
+- `POST .../messages` advances the sender's own cursor to the message just
+  sent, so posting never leaves the sender's own conversation reported back
+  to them as unread.
+- `POST /conversations` marks its creator caught up immediately — they were
+  just looking at what they wrote.
+
+`unread` is therefore a field that genuinely changes, in both directions,
+under exercise by this build's own endpoints — not a flag that can only ever
+read one way, the same discipline `probes.CAPABILITIES` and issue #7's
+dropped `dependencies` field are already held to elsewhere in this document.
+An empty conversation (`lastActivityAt: null`) is never unread, for anyone.
+
+### Ordering: the conversation list is stable, never "most recent first"
+
+`GET /api/v1/conversations` orders by `createdAt`/`id` — creation order —
+**never** by `lastActivityAt`. Sorting by an activity timestamp would move a
+conversation's position in the list the instant a new message lands, which
+can skip or repeat rows across a client's paginated walk: the direct opposite
+of this issue's own acceptance criterion ("pagination preserves stable
+ordering"). `lastActivityAt` is still reported on every item, for a client
+that wants to sort the page itself.
+
+`GET .../messages` is oldest-first — the order a thread reads in, the same
+reasoning `GET /api/v1/missions/{id}/timeline` already gives for a mission's
+timeline, and unlike every newest-first collection elsewhere in this API.
+
+### No `revision`, no `ETag`, no `If-Match`
+
+Every other writable entity in this contract publishes a monotonic
+`revision` because something can mutate it out from under a concurrent
+reader. Nothing here can: a conversation is never edited after creation (no
+`PATCH`), and a message is immutable once posted. `ProjectModel` is this
+contract's other GET-only, revision-less entity, for the same reason — see
+"Optimistic concurrency" below, which this section is a deliberate exception
+to, not an oversight.
+
+### Idempotency, reused rather than reinvented
+
+`POST /api/v1/conversations` and `POST .../{id}/messages` both accept
+`Idempotency-Key` and follow `POST /api/v1/issues`'s reserve-then-complete
+shape exactly, including the same convention
+`POST /api/v1/epics/{epicId}/issues/{issueId}` established: the idempotency
+record's `endpoint` is the literal route template, not the path with the
+concrete id interpolated in — the fingerprint (which does embed the
+conversation id and body) is what tells a key reused for a genuinely
+different operation apart from a legitimate retry, so a same-key,
+different-fingerprint call is answered `409`, never silently replayed. This
+is issue #10's "message creation is idempotent for offline retries"
+acceptance criterion, and the mechanism that also prevents the duplicate
+messages the issue's own test coverage requirement names.
+
+---
+
 ## Cross-cutting rules every endpoint inherits
 
 Implemented in `gateway/app/api/` (issue #12). An endpoint does not re-invent

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.4.0
+  version: 1.5.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -1839,6 +1839,230 @@ paths:
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
 
+  /api/v1/conversations:
+    get:
+      operationId: listConversations
+      tags: [conversations]
+      summary: Conversations the caller may see, newest-created first
+      description: |
+        Ordered by creation time, never by `lastActivityAt` — sorting by an
+        activity timestamp would move a conversation's position in the list
+        the instant a new message lands, which can skip or repeat rows across
+        a paginated walk. See `docs/api/README.md` "Conversations (issue
+        #10)". A client that wants "most recently active first" sorts the
+        page client-side using `lastActivityAt`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+        - name: projectId
+          in: query
+          required: false
+          description: Repeatable. Restricts to these projects, intersected with what the caller may see.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProjectId'
+      responses:
+        '200':
+          description: A page of conversations.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Conversation'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    post:
+      operationId: createConversation
+      tags: [conversations]
+      summary: Start a conversation
+      description: |
+        `context` must name at least one product entity — the acceptance
+        criterion this field exists to satisfy. Every reference is resolved
+        and authorization-checked the same way `POST /api/v1/epics/{epicId}/issues/{issueId}`
+        checks both sides of its link: a reference to an entity the caller
+        cannot see answers `404`, indistinguishable from a reference to one
+        that does not exist. Every reference must resolve to the same
+        project, or the request is rejected (`400`); there is no `projectId`
+        field of its own — the project is derived from `context`.
+
+        With `Idempotency-Key`, a retry returns the first response rather
+        than creating a second conversation.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConversationRequest'
+      responses:
+        '201':
+          description: The created conversation.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/conversations/{conversationId}:
+    get:
+      operationId: getConversation
+      tags: [conversations]
+      summary: One conversation
+      description: |
+        `conversationId` outside the caller's visible projects answers
+        `404`, never `403` — the same probing-prevention rule a single hidden
+        session answers with.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The conversation.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/conversations/{conversationId}/messages:
+    get:
+      operationId: listMessages
+      tags: [conversations]
+      summary: A conversation's messages, oldest first
+      description: |
+        Oldest first, unlike every newest-first collection elsewhere in this
+        API — a thread is read forward from where it starts, the same
+        reasoning `GET /api/v1/missions/{missionId}/timeline` uses.
+
+        Fetching a page advances the caller's read cursor to the newest
+        message *in that page*, not to "now" — a client that has only fetched
+        an early page must not have later, unfetched messages marked as seen.
+        `docs/api/README.md` "Conversations (issue #10)" has the full
+        reasoning behind `unread`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of messages.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Message'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    post:
+      operationId: postMessage
+      tags: [conversations]
+      summary: Post a message
+      description: |
+        `Idempotency-Key` is what makes an offline retry safe: a mobile
+        client that loses the network right after sending cannot know
+        whether the message landed, and retrying with the same key returns
+        the first response rather than posting a second copy. This is issue
+        #10's acceptance criterion ("message creation is idempotent for
+        offline retries") verbatim.
+
+        `attachments` are opaque artifact/file identifiers, recorded and
+        returned unvalidated — no `ArtifactModel` exists yet (issue #11). See
+        `docs/api/README.md` "Conversations (issue #10)".
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMessageRequest'
+      responses:
+        '201':
+          description: The created message.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
   /health:
     get:
       operationId: getHealth
@@ -3204,6 +3428,128 @@ components:
         blockedReason:
           type: [string, 'null']
           maxLength: 20000
+
+    ConversationContextType:
+      type: string
+      enum: [project, session, decision, mission, issue]
+      description: |
+        `session`, `decision` and `mission` all name the same `TaskModel` row
+        under three vocabularies — see `docs/api/README.md`'s "Decisions" and
+        "Missions" sections. `artifact` is deliberately absent: no
+        `ArtifactModel` exists yet (issue #11), so a reference of that type
+        could not be checked for existence or for project visibility. See
+        `docs/api/README.md` "Conversations (issue #10)".
+
+    ContextReference:
+      type: object
+      description: One product entity a conversation is about.
+      required: [type, id]
+      properties:
+        type:
+          $ref: '#/components/schemas/ConversationContextType'
+        id:
+          $ref: '#/components/schemas/Id'
+
+    Conversation:
+      type: object
+      description: |
+        A thread linked to at least one product entity. `projectId` is
+        derived from `context`, not supplied independently — every reference
+        in `context` resolves to the same project.
+      required: [id, projectId, context, unread, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        title:
+          type: [string, 'null']
+          maxLength: 255
+        context:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ContextReference'
+        unread:
+          type: boolean
+          description: |
+            Whether the caller has unseen activity. `false` for a
+            conversation with no messages yet. Advances only through
+            `GET .../messages` (up to the newest message actually fetched)
+            and `POST .../messages` (the sender's own cursor) — issue #10
+            names no "mark as read" endpoint. See `docs/api/README.md`
+            "Conversations (issue #10)".
+        lastActivityAt:
+          type: [string, 'null']
+          format: date-time
+          description: Timestamp of the most recent message, or `null` when there are none yet.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        createdBy:
+          type: [string, 'null']
+          description: Email, or id when no email is on record, of who started this.
+
+    CreateConversationRequest:
+      type: object
+      required: [context]
+      properties:
+        title:
+          type: string
+          maxLength: 255
+        context:
+          type: array
+          minItems: 1
+          maxItems: 16
+          description: |
+            At least one context reference is required — the acceptance
+            criterion this field exists to satisfy. Every reference must
+            resolve to the same project.
+          items:
+            $ref: '#/components/schemas/ContextReference'
+
+    Message:
+      type: object
+      required: [id, conversationId, body, attachments, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        conversationId:
+          $ref: '#/components/schemas/Id'
+        author:
+          type: [string, 'null']
+          description: Email, or id when no email is on record, of who sent this.
+        body:
+          type: string
+          maxLength: 50000
+          description: Markdown source, stored and returned unrendered. Rendering is the client's responsibility.
+        attachments:
+          type: array
+          description: |
+            Opaque artifact/file identifiers. Unvalidated: no `ArtifactModel`
+            exists yet (issue #11), so these are recorded and returned
+            exactly as sent.
+          items:
+            type: string
+            maxLength: 255
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+
+    CreateMessageRequest:
+      type: object
+      required: [body]
+      properties:
+        body:
+          type: string
+          minLength: 1
+          maxLength: 50000
+          description: Markdown source.
+        attachments:
+          type: array
+          maxItems: 20
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
 
     LogLine:
       type: object

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,17 +1,16 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-08-20 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge map`
+> Generated: 2026-08-21 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge/.claude/worktrees/agent-a0b0474577bded53e`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge/.claude/worktrees/agent-a0b0474577bded53e map`
 
 ## Summary
 
-- 91 file(s) · 786 symbol(s) indexed
-- Languages: config (2), python (87), shell (2)
+- 94 file(s) · 841 symbol(s) indexed
+- Languages: config (2), python (90), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
 
-- `AGENTS.md`
 - `docs/required-reading.md`
 - `docs/project-rules.md`
 - `docs/software-overview.md`
@@ -60,6 +59,7 @@ gateway/
       routes/
         __init__.py  — "HTTP routers for the mobile contract surface."
         auth.py  — "Sign-in, renewal, revocation, and what the actor may actually do."
+        conversations.py  — "Conversations and contextual messaging — issue #10."
         decisions.py  — "Operational decisions: sensitive tasks held for a human to resolve — issue #6."
         epics.py  — "Epics — issue #8."
         issues.py  — "Issues — issue #8."
@@ -92,6 +92,7 @@ gateway/
       __init__.py
       agent_hub.py
       audit.py
+      conversation_types.py  — "Closed vocabulary for conversation context references, and their error."
       issue_types.py  — "Closed vocabularies for epics and issues, and the error they fail with."
       metrics.py
       store.py
@@ -118,6 +119,7 @@ tests/
     test_agent_ws_handshake.py  — "The `/agent/ws` handshake stops carrying the token in the URL — issue #15."
     test_api_conventions.py  — "Representative-endpoint compliance for the cross-cutting API rules (issue #12)."
     test_auth.py  — "The mobile credential lifecycle — issue #4."
+    test_conversations.py  — "Conversations and contextual messaging — issue #10."
     test_decisions.py  — "Operational decisions — issue #6."
     test_epics_issues.py  — "Epics and issues — issue #8."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
@@ -276,6 +278,19 @@ tests/
 - `refresh(body, response, session)` *(async function)* — "Rotate a refresh token into a new pair."
 - `revoke(request, response, body, session)` *(async function)* — "Sign out: end the grant now rather than at expiry."
 - `current_actor(response, principal)` *(async function)* — "Who is calling, and what this build will let them do."
+
+### `gateway/app/api/routes/conversations.py`
+
+> Conversations and contextual messaging — issue #10.
+
+- **`ContextReference`** *(class)*
+- **`CreateConversationRequest`** *(class)*
+- **`CreateMessageRequest`** *(class)*
+- `list_conversations(response, project_id, cursor, limit, principal, session)` *(async function)* — "Conversations the caller may see, newest-created first."
+- `get_conversation(conversation_id, response, principal, session)` *(async function)*
+- `list_messages(conversation_id, response, cursor, limit, principal, session)` *(async function)* — "A conversation's messages, oldest first."
+- `create_conversation(payload, response, idempotency_key, principal, session)` *(async function)* — "Start a conversation. Every context reference is resolved and checked here."
+- `post_message(conversation_id, payload, response, idempotency_key, principal, session)` *(async function)* — "Post a message. `Idempotency-Key` is what makes an offline retry safe."
 
 ### `gateway/app/api/routes/decisions.py`
 
@@ -487,6 +502,9 @@ tests/
 - **`TaskModel`** *(class)*
 - **`EpicModel`** *(class)*
 - **`IssueModel`** *(class)*
+- **`ConversationModel`** *(class)* — "A contextual thread linked to at least one product entity — issue #10."
+- **`ConversationMessageModel`** *(class)* — "One message in a conversation. Immutable once written — no update path."
+- **`ConversationReadStateModel`** *(class)* — "How far one actor has read into one conversation."
 - **`TaskLogModel`** *(class)*
 - **`AuditEventModel`** *(class)*
 - **`MessageReceiptModel`** *(class)*
@@ -511,6 +529,13 @@ tests/
 ### `gateway/app/services/audit.py`
 
 - `record_event(session, entity_type, entity_id, event_type, payload)` *(async function)*
+
+### `gateway/app/services/conversation_types.py`
+
+> Closed vocabulary for conversation context references, and their error.
+
+- **`ConversationPlanningError`** *(class)* — "A create input that fails validation inside the store itself."
+  - `__init__(self, field, code, message)` *(method)*
 
 ### `gateway/app/services/issue_types.py`
 
@@ -581,6 +606,15 @@ tests/
 - `list_issues_page(session)` *(async function)*
 - `update_issue(session, issue_id)` *(async function)*
 - `link_issue_to_epic(session)` *(async function)* — "Attach `issue_id` to `epic_id`. Both must already exist in one project."
+- `create_conversation(session)` *(async function)* — "Create a conversation from an already-resolved, already-authorized context."
+- `get_conversation(session, conversation_id)` *(async function)*
+- `get_conversation_for_projects(session, conversation_id, project_ids)` *(async function)* — "A conversation the caller may see, or None. Mirrors `get_epic_for_projects`."
+- `list_conversations_page(session)` *(async function)* — "Conversations the caller may see, newest-created first, over-fetched by one."
+- `conversation_read_states(session)` *(async function)* — "`{conversation_id: last_read_at}` for one actor, over the given ids."
+- `conversation_unread()` — "Whether an actor has unseen activity in a conversation."
+- `mark_conversation_read(session)` *(async function)* — "Advance (never retreat) one actor's read cursor on one conversation."
+- `create_conversation_message(session)` *(async function)* — "Append a message. Immutable once written — there is no update path."
+- `list_conversation_messages_page(session)` *(async function)* — "A conversation's messages, oldest first — the order a thread reads in."
 
 ### `scripts/apply_migrations.py`
 
@@ -811,6 +845,44 @@ tests/
 - `test_the_report_and_the_endpoints_agree(api, who)` *(async function)* — "The claim the whole endpoint exists for."
 - `test_the_administrative_action_describes_what_the_list_endpoint_does(api)` *(async function)* — "`sessions.readAllProjects` is administrative because it crosses projects."
 - `test_the_administrative_action_describes_what_the_missions_list_endpoint_does(api)` *(async function)* — "`missions.readAllProjects` mirrors `sessions.readAllProjects` — same widening."
+
+### `tests/integration/test_conversations.py`
+
+> Conversations and contextual messaging — issue #10.
+
+- `users_file(tmp_path)`
+- `api(users_file, monkeypatch)` *(async function)*
+- `auth(token)`
+- `make_task(factory, project_id)` *(async function)*
+- `make_issue(factory, project_id, **kwargs)` *(async function)*
+- `make_conversation(factory)` *(async function)*
+- `create_payload(context, title)`
+- `test_conversations_require_a_token(api)` *(async function)*
+- `test_reader_cannot_create_a_conversation_or_post_a_message(api)` *(async function)*
+- `test_reader_can_still_list_get_and_read_messages(api)` *(async function)*
+- `test_a_conversation_in_an_invisible_project_is_not_found(api)` *(async function)* — "404, never 403 — confirming existence is what probing is for."
+- `test_create_requires_at_least_one_context_reference(api)` *(async function)*
+- `test_create_rejects_an_unknown_context_type(api)` *(async function)*
+- `test_create_with_a_context_reference_in_a_hidden_project_is_not_found(api)` *(async function)* — "Unauthorized entity references are rejected without disclosing hidden resources."
+- `test_create_with_an_unknown_context_id_is_not_found(api)` *(async function)* — "A reference to something that does not exist answers exactly like a hidden one."
+- `test_create_rejects_context_references_spanning_two_projects(api)` *(async function)*
+- `test_create_accepts_a_session_decision_or_mission_reference_to_the_same_task(api)` *(async function)* — "session/decision/mission all name the same TaskModel row."
+- `test_create_derives_project_id_from_the_context_and_deduplicates(api)` *(async function)*
+- `test_a_project_outside_the_caller_visibility_is_not_found_when_used_as_context(api)` *(async function)*
+- `test_a_retried_conversation_create_does_not_create_a_second_conversation(api)` *(async function)*
+- `test_post_message_stores_markdown_and_attachments_verbatim(api)` *(async function)*
+- `test_post_message_rejects_an_empty_body(api)` *(async function)*
+- `test_a_retried_message_post_does_not_create_a_second_message(api)` *(async function)* — "Message creation is idempotent for offline retries — the acceptance criterion."
+- `test_the_same_key_with_a_different_body_is_a_conflict(api)` *(async function)* — "Reusing a key for a different payload is a client bug, not a silent replay."
+- `test_a_message_without_an_idempotency_key_is_never_deduplicated(api)` *(async function)* — "No key means no replay protection — each call is a genuinely new message."
+- `test_a_new_message_makes_the_conversation_unread_for_others(api)` *(async function)*
+- `test_fetching_messages_marks_the_conversation_read(api)` *(async function)*
+- `test_an_early_page_of_messages_does_not_mark_later_ones_read(api)` *(async function)* — "Fetching the oldest page must not silently mark newer, unfetched messages seen."
+- `test_an_empty_conversation_is_never_unread(api)` *(async function)*
+- `test_the_conversation_list_cursor_walks_every_conversation_once(api)` *(async function)*
+- `test_the_message_list_cursor_walks_every_message_once_oldest_first(api)` *(async function)*
+- `test_a_conversation_cursor_from_a_different_project_is_rejected(api)` *(async function)*
+- `test_list_conversations_filters_by_project(api)` *(async function)*
 
 ### `tests/integration/test_decisions.py`
 

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -751,3 +751,50 @@ one of `.docs/agents/council.md` §4's own triggers. Self-reviewed against
 audit/notification-parity instruction this session carried. Committed, not
 merged, not deployed — a PR against `development` is opened for operator
 review per standing policy.
+
+## 2026-08-21 — council round 2 on gh-10 (PR #22), MAX_ATTACHMENT_ID_LENGTH finding closed
+
+Round 1 on PR #22 left one surviving finding: `conversation_types.py` declares
+`MAX_ATTACHMENT_ID_LENGTH = 255` but nothing enforced it —
+`CreateMessageRequest.attachments` only bounded list *count*
+(`max_length=20`), not per-item length, so an attachment id of any length
+was accepted, stored, and echoed back unmodified. Its three siblings in the
+same module (`MAX_CONTEXT_REFERENCES`, `MAX_MESSAGE_BODY_LENGTH`,
+`MAX_ATTACHMENTS_PER_MESSAGE`) were all wired in; this one was declared and
+forgotten — the same "constant exists, nothing reads it" shape earlier
+rounds have caught elsewhere in this codebase.
+
+Fixed at the same layer as its two closest siblings
+(`MAX_MESSAGE_BODY_LENGTH`, `MAX_ATTACHMENTS_PER_MESSAGE`), not the
+`ContextReference` Pydantic-field layer: `store.create_conversation_message`
+now loops the deduplicated attachment list and raises
+`ConversationPlanningError("/attachments/{index}", "too_long", ...)` for any
+id over 255 characters, caught by `routes/conversations.py:post_message`'s
+existing `except ConversationPlanningError` and turned into the same
+structured `400 VALIDATION_FAILED` body every other planning error in this
+feature already returns. No new validation style introduced.
+
+New test: `tests/integration/test_conversations.py::test_post_message_rejects_an_oversized_attachment_id`
+— posts a 256-character attachment id, asserts `400` with
+`details[0] == {"field": "/attachments/0", "code": "too_long", ...}`.
+Confirmed failing against the pre-fix `store.py` (`201`, not `400`) before
+confirming it passes with the fix.
+
+`python3 -m pytest -q` → 518 passed, 4 failed (same
+`tests/integration/test_agent_ws_handshake.py` order/CWD-sensitive flake
+this file's 2026-08-19 and 2026-08-21 entries already document, not
+introduced by this diff) — 522 total, matching the round-1 baseline (521)
+plus this one new test. One false lead during verification: two `pytest -q`
+invocations issued back-to-back raced on the same file-backed
+`codex_bridge.db` in the repo root and produced a spurious all-green result
+and a spurious `no such table: executors` result on different runs; removing
+the stale db file and running once, alone, reproduced the documented
+baseline exactly. Lesson for next session: never trust a full-suite result
+from a run that overlapped another `pytest` process against the same
+default sqlite file — confirm no other `pytest` process is alive first.
+
+Not re-council-reviewed beyond this round-2 closure itself, per the same
+"no `pre-commit` hook wired in this checkout" note the gh-10 round-1 entry
+above already recorded. Committed to
+`feature/gh-10/expose-conversations-and-contextual-messaging-ap` and pushed
+to `origin`, updating PR #22 in place — no new PR, no merge, no deploy.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -655,3 +655,99 @@ fix restored.
 `python3 -m pytest -q` → 500 passed, 4 failed (same
 `tests/integration/test_agent_ws_handshake.py` four, unchanged from the
 2026-08-20 baseline — the extra passing test is this round's own).
+
+## 2026-08-21 — gh-10, conversations and contextual messaging API (recovery)
+
+Recovery session: a prior cloud-container attempt at #10 finished the
+implementation, tests green, then lost the work when `git push` failed
+403/404 and the container was recycled before recovery. `feature/gh-10/...`
+on `origin` carried only a stale unrelated commit from 2026-08-14 — no real
+work to resume — so this session deleted and recreated the branch fresh off
+`development` (`16ce28e`, already carrying the gh-5/6/7/8 integration merge)
+rather than trying to reconstruct anything. Nothing from the lost attempt was
+recovered; this is a from-scratch implementation, not a continuation.
+
+**Design decision, made explicit rather than left implicit:** issue #10's
+Objective names conversations "linked to projects, decisions, missions,
+issues, sessions and artifacts", but `ArtifactModel` does not exist yet
+(issue #11). Rather than accept an unvalidatable `artifact` context
+reference — which would silently fail the issue's own acceptance criterion
+("unauthorized entity references are rejected without disclosing hidden
+resources") for exactly that one type — `ConversationContextType` omits it.
+Same discipline #8 applied to issue-side "missions/conversations/decisions"
+links and #7 applied to `dependencies`/`relatedEntities`: no backing entity,
+no field, documented at the point of omission
+(`gateway/app/services/conversation_types.py`, `docs/api/README.md`). Message
+*attachments* are a different, already-satisfiable concept — opaque
+artifact/file ids on a message, unvalidated for the same reason
+`Issue.dependencies` doesn't own a graph — and are implemented in full.
+
+**Unread without a "mark read" endpoint**, since the issue's endpoint list
+has none: `GET .../messages` advances the caller's per-conversation read
+cursor to the newest message *actually returned in that page*, not to
+`now()`. Marking to `now()` was the first draft and is wrong — a client that
+has only fetched the oldest page of a long thread would have every later,
+unfetched message marked seen. `POST .../messages` advances the sender's own
+cursor to the message just posted, so a client never sees its own send
+reported back as unread. Both are exercised in
+`tests/integration/test_conversations.py::test_an_early_page_of_messages_does_not_mark_later_ones_read`,
+which would have caught the `now()` version.
+
+**Datetime naive/aware bug**, caught by the test suite rather than by
+review: `store.mark_conversation_read` compared `_as_utc(state.last_read_at)`
+(normalized) against `at` (not normalized) — fine when `at` defaulted to
+`datetime.now(timezone.utc)`, and a `TypeError: can't compare offset-naive
+and offset-aware datetimes` the moment a caller passed a DB-sourced
+timestamp instead, which SQLite always hands back naive
+(`gateway/app/api/timestamps.py`'s module docstring already documents this
+exact split for `utc_z`). `routes/conversations.py:list_messages` is exactly
+such a caller (`newest_fetched = max(m.created_at for m in page)`). Fixed by
+normalizing `at` through `_as_utc` once, at the top of the function, rather
+than at each comparison site.
+
+**Ordering:** `GET /conversations` sorts by `createdAt`/`id`, never
+`lastActivityAt`, even though "most recently active first" is the more
+obviously useful default for a conversation list. A live-reordering sort key
+moves a row's position mid-pagination, which the acceptance criterion
+("pagination preserves stable ordering") rules out directly — the same
+`createdAt`/`id` convention every other collection in this API already uses.
+`lastActivityAt` is still reported per item for client-side sorting.
+`GET .../messages` is oldest-first, matching `store.list_task_events_page`'s
+mission-timeline precedent and reasoning, not the newest-first collection
+convention.
+
+**No `revision`/`ETag`/`If-Match` anywhere in this feature** — a deliberate
+reading of the cross-cutting "every write mutator bumps revision" rule, not
+a gap: nothing here is ever `PATCH`ed (no update endpoint for either a
+conversation or a message), so nothing can go stale under a concurrent
+write. `ProjectModel` is the contract's other precedent for a GET-only,
+revision-less entity. Checked specifically against this session's own
+instruction to diff new call sites against the closest analog rather than
+only against #10's stated acceptance criteria — the closest analog for
+"should this mutation carry `If-Match`" is #6/#7's state-transition
+endpoints (`approve`, `cancel`), and neither conversations nor messages are
+state transitions on an entity the client read a specific version of; they
+are appends. No sibling behavior was half-copied here because the
+behavior genuinely does not apply.
+
+`python3 -m pytest -q` → 521 passed (495 on `development` + 26 new,
+`tests/integration/test_conversations.py`), run twice for stability.
+`tests/integration/test_agent_ws_handshake.py`'s four tests
+(`test_the_header_is_bound_and_reaches_the_registry_check` and siblings) are
+a pre-existing, order/CWD-sensitive flake already documented in this file's
+2026-08-19 entry and reproduced independently this session on a fresh `git
+clone` of `origin/development` itself — not introduced by this diff. They
+failed once in this session's full-suite run and passed in every other run
+(standalone and full-suite); left alone per standing policy on baseline
+failures. `governancekit --root . map` regenerated after the store.py/routes
+additions landed; the codemap-staleness contract gate caught both an initial
+omission and a second one after further edits.
+
+Not council-reviewed, for the same reason the gh-5 session recorded:
+`.git/hooks/pre-commit` does not exist in this checkout, so the mechanical
+gate is not wired here, and this is a same-shaped new-feature delivery, not
+one of `.docs/agents/council.md` §4's own triggers. Self-reviewed against
+`.docs/agents/reviewer.md`'s BLOCKER criteria and against the specific
+audit/notification-parity instruction this session carried. Committed, not
+merged, not deployed — a PR against `development` is opened for operator
+review per standing policy.

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -46,6 +46,11 @@ ADMIN_SCOPE = "codexbridge.admin"
 # Distinct from CANCEL_SCOPE: stopping a session and writing a project plan are
 # different capabilities an operator may grant separately.
 ISSUES_WRITE_SCOPE = "codexbridge.issues.write"
+# Creating a conversation or posting a message to one (issue #10). Distinct
+# from ISSUES_WRITE_SCOPE for the same reason that scope is distinct from
+# CANCEL_SCOPE: writing a project plan and starting a discussion about it are
+# different capabilities an operator may grant separately.
+CONVERSATIONS_WRITE_SCOPE = "codexbridge.conversations.write"
 
 READ = "read"
 OPERATIONAL = "operational"
@@ -227,6 +232,27 @@ EPICS_LINK_ISSUE = Action(
     summary="Attach an issue to an epic.",
 )
 
+CONVERSATIONS_READ = Action(
+    name="conversations.read",
+    category=READ,
+    scope=READ_SCOPE,
+    summary="List conversations and read one, within the actor's projects.",
+)
+
+CONVERSATIONS_CREATE = Action(
+    name="conversations.create",
+    category=OPERATIONAL,
+    scope=CONVERSATIONS_WRITE_SCOPE,
+    summary="Start a conversation linked to at least one product entity.",
+)
+
+CONVERSATIONS_POST_MESSAGE = Action(
+    name="conversations.postMessage",
+    category=OPERATIONAL,
+    scope=CONVERSATIONS_WRITE_SCOPE,
+    summary="Post a message to a conversation.",
+)
+
 # Order is the reported order. Grouped by class, read first, so a client that
 # renders the list without sorting produces something sensible.
 CATALOGUE: tuple[Action, ...] = (
@@ -239,6 +265,7 @@ CATALOGUE: tuple[Action, ...] = (
     MISSIONS_EXPLAIN,
     EPICS_READ,
     ISSUES_READ,
+    CONVERSATIONS_READ,
     SESSIONS_STOP,
     SESSIONS_PAUSE,
     SESSIONS_RESUME,
@@ -248,6 +275,8 @@ CATALOGUE: tuple[Action, ...] = (
     ISSUES_CREATE,
     ISSUES_UPDATE,
     EPICS_LINK_ISSUE,
+    CONVERSATIONS_CREATE,
+    CONVERSATIONS_POST_MESSAGE,
     SESSIONS_READ_ALL_PROJECTS,
     DECISIONS_READ,
     DECISIONS_DECIDE,

--- a/gateway/app/api/routes/conversations.py
+++ b/gateway/app/api/routes/conversations.py
@@ -1,0 +1,530 @@
+"""Conversations and contextual messaging — issue #10.
+
+A **conversation** is a thread linked to one or more product entities — a
+project, a session/decision/mission (all the same `TaskModel`, under three
+vocabularies — see `docs/api/README.md`'s "Decisions" and "Missions"
+sections), or an issue. Every conversation carries at least one such
+**context reference**, resolved and authorization-checked the same way
+`epics.py:link_issue` resolves both sides of an epic-issue link: the route
+loads each referenced entity through the existing `*_for_projects` getter, so
+a reference to an entity the caller cannot see is indistinguishable from a
+reference to one that does not exist — both answer `404`, never a `400` that
+would confirm existence to someone who was not given it.
+
+## Why `artifact` is not a context type
+
+See `gateway/app/services/conversation_types.py`'s module docstring. In
+short: five of the six entity kinds issue #10 names have a backing model
+this build can check a reference against; `artifact` does not (issue #11
+has not shipped `ArtifactModel`), so it is omitted from the context type
+vocabulary rather than accepted and left unverifiable — which would be
+exactly the acceptance criterion this validation exists to satisfy, broken
+for one type. Message **attachments** are unaffected: they are opaque
+artifact/file identifiers on the message itself, recorded and returned
+unvalidated for the same reason `IssueModel.dependencies_json` does not own
+a graph.
+
+## Unread and last-activity, without a "mark as read" endpoint
+
+Issue #10 names no such endpoint, so the read cursor
+(`ConversationReadStateModel`) can only move as a side effect of an endpoint
+that already exists:
+
+- `GET .../messages` advances the caller's cursor to the newest message
+  **actually returned in that page** — not to "now". A client paging forward
+  from the oldest message must not have messages it has not fetched yet
+  marked as seen just because it fetched an earlier page.
+- `POST .../messages` advances the sender's own cursor to the message just
+  sent, so posting does not leave the sender's own conversation reported
+  back to them as unread.
+- Creating a conversation marks its creator caught up immediately: they were
+  just looking at what they wrote.
+
+`unread` is therefore a real, changing value rather than a field that can
+only ever read one way — the same discipline `docs/api/README.md` already
+applies to `probes.CAPABILITIES` and to issue #7's dropped `dependencies`
+field: no permanently-stuck field ships.
+
+## Ordering: conversations list is stable, not "most recent first"
+
+`GET /conversations` orders by `createdAt`/`id` — creation order — never by
+`lastActivityAt`. Sorting by an activity timestamp would move a
+conversation's position in the list the instant a new message lands, which
+can skip or repeat rows across a paginated walk. That is the direct opposite
+of the acceptance criterion ("pagination preserves stable ordering").
+`lastActivityAt` is still reported on every item for a client that wants to
+sort the page itself. `GET .../messages` is oldest-first, the same
+reasoning `store.list_task_events_page` gives for a mission's timeline: a
+thread is read forward from where it starts, unlike every newest-first
+collection elsewhere in this API.
+
+## Idempotency, reused rather than reinvented
+
+`POST /conversations` and `POST .../messages` both accept `Idempotency-Key`
+and follow `routes/issues.py:create_issue`'s reserve-then-complete shape
+exactly, including the endpoint-is-a-constant-template convention
+`routes/epics.py:link_issue` establishes: the idempotency `endpoint` key is
+the literal route template, not the interpolated path, because the
+fingerprint (which does embed the concrete ids and body) is what tells a key
+reused for a genuinely different operation apart — a same-key,
+different-fingerprint retry is answered `409`, never silently replayed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, Header, Query, Response
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.app.api import idempotency, pagination, permissions, timestamps
+from gateway.app.api.auth import require_action, visible_projects
+from gateway.app.api.errors import NOT_FOUND, VALIDATION_FAILED, ApiError
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.session import get_session
+from gateway.app.services import store
+from gateway.app.services.conversation_types import CONTEXT_TYPES, ConversationPlanningError
+
+
+router = APIRouter(prefix="/api/v1")
+
+CONVERSATIONS_ENDPOINT = "/api/v1/conversations"
+
+
+def _conversation_not_found() -> ApiError:
+    return ApiError(status_code=404, code=NOT_FOUND, message="No such conversation.")
+
+
+def _context_not_found(context_type: str) -> ApiError:
+    # Same message-shape rule epics.py/issues.py use for a hidden project: a
+    # context reference the caller cannot see must answer exactly like one
+    # that does not exist.
+    return ApiError(status_code=404, code=NOT_FOUND, message=f"No such {context_type}.")
+
+
+def _invalid_context_type(value: str) -> ApiError:
+    return ApiError(
+        status_code=400,
+        code=VALIDATION_FAILED,
+        message=f"context[].type must be one of {sorted(CONTEXT_TYPES)}.",
+        details=[
+            {
+                "field": "/context",
+                "code": "invalid_context_type",
+                "message": f"{value!r} is not a supported context type.",
+            }
+        ],
+    )
+
+
+def _mixed_project_context() -> ApiError:
+    return ApiError(
+        status_code=400,
+        code=VALIDATION_FAILED,
+        message="Every context reference must resolve to the same project.",
+        details=[
+            {
+                "field": "/context",
+                "code": "mixed_project",
+                "message": "context references named more than one project.",
+            }
+        ],
+    )
+
+
+def _planning_error(exc: ConversationPlanningError) -> ApiError:
+    return ApiError(
+        status_code=400,
+        code=VALIDATION_FAILED,
+        message=exc.message,
+        details=[{"field": exc.field, "code": exc.code, "message": exc.message}],
+    )
+
+
+def _conversation_dto(conversation, *, unread: bool) -> dict:
+    return {
+        "id": conversation.id,
+        "projectId": conversation.project_id,
+        "title": conversation.title,
+        "context": json.loads(conversation.context_json or "[]"),
+        "unread": unread,
+        "lastActivityAt": timestamps.utc_z(conversation.last_activity_at),
+        "createdAt": timestamps.utc_z(conversation.created_at),
+        "createdBy": conversation.created_by_email or conversation.created_by_user_id,
+    }
+
+
+def _message_dto(message) -> dict:
+    return {
+        "id": message.id,
+        "conversationId": message.conversation_id,
+        "author": message.author_email or message.author_user_id,
+        "body": message.body,
+        "attachments": json.loads(message.attachments_json or "[]"),
+        "createdAt": timestamps.utc_z(message.created_at),
+    }
+
+
+def _effective_project_ids(
+    principal: AuthenticatedPrincipal, requested: list[str] | None
+) -> list[str] | None:
+    """`visible_projects`, narrowed by an explicit `projectId` filter.
+
+    Same helper `routes/missions.py` keeps as its own local copy rather than
+    a shared one: a requested project outside the caller's visibility is
+    dropped rather than surfaced as an error, so a filter naming a project
+    the caller cannot see cannot become a way to probe which ids exist.
+    """
+    visible = visible_projects(principal)
+    if requested is None:
+        return visible
+    if visible is None:
+        return requested
+    allowed = set(visible)
+    return [project_id for project_id in requested if project_id in allowed]
+
+
+class ContextReference(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str = Field(min_length=1, max_length=32)
+    id: str = Field(min_length=1, max_length=128)
+
+
+class CreateConversationRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    title: str | None = Field(default=None, max_length=255)
+    # `min_length=1` is the acceptance criterion itself ("every conversation
+    # has at least one explicit context reference") — enforced by the request
+    # never reaching the handler, the same way `DecisionRejectRequest.reason`
+    # enforces "not empty".
+    context: list[ContextReference] = Field(min_length=1, max_length=16)
+
+
+class CreateMessageRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    # Markdown source. The server stores and returns it unrendered.
+    body: str = Field(min_length=1, max_length=50000)
+    attachments: list[str] | None = Field(default=None, max_length=20)
+
+
+@router.get("/conversations", tags=["conversations"])
+async def list_conversations(
+    response: Response,
+    project_id: list[str] | None = Query(default=None, alias="projectId"),
+    cursor: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.CONVERSATIONS_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Conversations the caller may see, newest-created first."""
+    projects = visible_projects(principal)
+    effective_projects = _effective_project_ids(principal, project_id)
+    size = pagination.parse_limit(limit)
+
+    scope = pagination.scope_digest(
+        CONVERSATIONS_ENDPOINT,
+        {
+            "projectId": sorted(project_id) if project_id else None,
+            "actor": principal.user_id,
+            "projects": sorted(projects) if projects is not None else "*",
+        },
+    )
+    after = None
+    if cursor:
+        position = pagination.decode_cursor(scope, cursor, expect={"createdAt": str, "id": str})
+        after = (position["createdAt"], position["id"])
+
+    rows = await store.list_conversations_page(
+        session, project_ids=effective_projects, after=after, limit=size
+    )
+    page, info = pagination.paginate(
+        rows,
+        limit=size,
+        scope=scope,
+        position_of=lambda c: {"createdAt": timestamps.cursor_z(c.created_at), "id": c.id},
+    )
+    read_states = await store.conversation_read_states(
+        session, user_id=principal.user_id, conversation_ids=[c.id for c in page]
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return {
+        "items": [
+            _conversation_dto(
+                c,
+                unread=store.conversation_unread(
+                    last_activity_at=c.last_activity_at, last_read_at=read_states.get(c.id)
+                ),
+            )
+            for c in page
+        ],
+        "page": info,
+    }
+
+
+@router.get("/conversations/{conversation_id}", tags=["conversations"])
+async def get_conversation(
+    conversation_id: str,
+    response: Response,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.CONVERSATIONS_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    conversation = await store.get_conversation_for_projects(
+        session, conversation_id, visible_projects(principal)
+    )
+    if conversation is None:
+        raise _conversation_not_found()
+    read_states = await store.conversation_read_states(
+        session, user_id=principal.user_id, conversation_ids=[conversation.id]
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return _conversation_dto(
+        conversation,
+        unread=store.conversation_unread(
+            last_activity_at=conversation.last_activity_at,
+            last_read_at=read_states.get(conversation.id),
+        ),
+    )
+
+
+@router.get("/conversations/{conversation_id}/messages", tags=["conversations"])
+async def list_messages(
+    conversation_id: str,
+    response: Response,
+    cursor: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.CONVERSATIONS_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """A conversation's messages, oldest first."""
+    conversation = await store.get_conversation_for_projects(
+        session, conversation_id, visible_projects(principal)
+    )
+    if conversation is None:
+        raise _conversation_not_found()
+
+    size = pagination.parse_limit(limit)
+    scope = pagination.scope_digest(
+        f"{CONVERSATIONS_ENDPOINT}/{conversation_id}/messages",
+        {"conversationId": conversation_id, "actor": principal.user_id},
+    )
+    after = None
+    if cursor:
+        position = pagination.decode_cursor(scope, cursor, expect={"createdAt": str, "id": str})
+        after = (position["createdAt"], position["id"])
+
+    rows = await store.list_conversation_messages_page(
+        session, conversation_id=conversation_id, after=after, limit=size
+    )
+    page, info = pagination.paginate(
+        rows,
+        limit=size,
+        scope=scope,
+        position_of=lambda m: {"createdAt": timestamps.cursor_z(m.created_at), "id": m.id},
+    )
+
+    # Advance the caller's read cursor to the newest message *in this page*,
+    # not to "now" — see the module docstring's "Unread and last-activity"
+    # section for why marking further than what was actually fetched is wrong.
+    newest_fetched = max((m.created_at for m in page), default=None)
+    if newest_fetched is not None:
+        await store.mark_conversation_read(
+            session, conversation_id=conversation_id, user_id=principal.user_id, at=newest_fetched
+        )
+        await session.commit()
+
+    response.headers["Cache-Control"] = "no-store"
+    return {"items": [_message_dto(m) for m in page], "page": info}
+
+
+@router.post("/conversations", tags=["conversations"], status_code=201)
+async def create_conversation(
+    payload: CreateConversationRequest,
+    response: Response,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.CONVERSATIONS_CREATE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Start a conversation. Every context reference is resolved and checked here.
+
+    `projectId` is not a request field: the conversation's project is derived
+    from its context references, and every reference must agree on the same
+    one (`400 mixed_project` otherwise) — see the module docstring.
+    """
+    projects = visible_projects(principal)
+
+    ordered_context: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    resolved_project_ids: set[str] = set()
+    for ref in payload.context:
+        key = (ref.type, ref.id)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        if ref.type not in CONTEXT_TYPES:
+            raise _invalid_context_type(ref.type)
+        if ref.type == "project":
+            entity = await store.get_project_for_caller(session, ref.id, projects)
+        elif ref.type == "issue":
+            entity = await store.get_issue_for_projects(session, ref.id, projects)
+        else:
+            # "session" and "decision" and "mission" are the same TaskModel
+            # under three vocabularies — see the module docstring.
+            entity = await store.get_task_for_projects(session, ref.id, projects)
+        if entity is None:
+            raise _context_not_found(ref.type)
+
+        resolved_project_ids.add(entity.id if ref.type == "project" else entity.project_id)
+        ordered_context.append({"type": ref.type, "id": ref.id})
+
+    if len(resolved_project_ids) > 1:
+        raise _mixed_project_context()
+    project_id = next(iter(resolved_project_ids))
+
+    fingerprint = idempotency.fingerprint(
+        json.dumps(
+            {"projectId": project_id, "title": payload.title, "context": ordered_context},
+            sort_keys=True,
+        ).encode()
+    )
+    claim = None
+    if idempotency_key:
+        outcome = await idempotency.reserve(
+            session,
+            key=idempotency_key,
+            endpoint=CONVERSATIONS_ENDPOINT,
+            actor_id=principal.user_id,
+            request_fingerprint=fingerprint,
+        )
+        if isinstance(outcome, idempotency.ReplayedResponse):
+            response.status_code = outcome.status_code
+            response.headers["Idempotent-Replay"] = "true"
+            return outcome.body
+        claim = outcome
+
+    try:
+        conversation = await store.create_conversation(
+            session,
+            project_id=project_id,
+            title=payload.title,
+            context=ordered_context,
+            actor_user_id=principal.user_id,
+            actor_email=principal.email,
+        )
+    except ConversationPlanningError as exc:
+        if claim is not None:
+            await idempotency.release(
+                session, key=idempotency_key, endpoint=CONVERSATIONS_ENDPOINT,
+                actor_id=principal.user_id, claim=claim,
+            )
+        raise _planning_error(exc) from exc
+    except Exception:
+        if claim is not None:
+            await idempotency.release(
+                session, key=idempotency_key, endpoint=CONVERSATIONS_ENDPOINT,
+                actor_id=principal.user_id, claim=claim,
+            )
+        raise
+
+    # The creator is caught up by construction (store.create_conversation
+    # records their read state at creation time).
+    body = _conversation_dto(conversation, unread=False)
+    if claim is not None:
+        await idempotency.complete(
+            session,
+            key=idempotency_key,
+            endpoint=CONVERSATIONS_ENDPOINT,
+            actor_id=principal.user_id,
+            status_code=201,
+            body=body,
+            claim=claim,
+            request_fingerprint=fingerprint,
+        )
+    return body
+
+
+@router.post("/conversations/{conversation_id}/messages", tags=["conversations"], status_code=201)
+async def post_message(
+    conversation_id: str,
+    payload: CreateMessageRequest,
+    response: Response,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.CONVERSATIONS_POST_MESSAGE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Post a message. `Idempotency-Key` is what makes an offline retry safe.
+
+    A mobile client that loses the network right after sending cannot know
+    whether the message landed; retrying with the same key returns the first
+    response rather than posting a second copy — the acceptance criterion
+    this endpoint exists to satisfy.
+    """
+    conversation = await store.get_conversation_for_projects(
+        session, conversation_id, visible_projects(principal)
+    )
+    if conversation is None:
+        raise _conversation_not_found()
+
+    # Literal route template, not the interpolated path — see the module
+    # docstring's "Idempotency, reused rather than reinvented" section.
+    endpoint = f"{CONVERSATIONS_ENDPOINT}/{{conversationId}}/messages"
+    fingerprint = idempotency.fingerprint(
+        json.dumps(
+            {"conversationId": conversation_id, "body": payload.body, "attachments": payload.attachments or []},
+            sort_keys=True,
+        ).encode()
+    )
+    claim = None
+    if idempotency_key:
+        outcome = await idempotency.reserve(
+            session,
+            key=idempotency_key,
+            endpoint=endpoint,
+            actor_id=principal.user_id,
+            request_fingerprint=fingerprint,
+        )
+        if isinstance(outcome, idempotency.ReplayedResponse):
+            response.status_code = outcome.status_code
+            response.headers["Idempotent-Replay"] = "true"
+            return outcome.body
+        claim = outcome
+
+    try:
+        message = await store.create_conversation_message(
+            session,
+            conversation_id=conversation_id,
+            author_user_id=principal.user_id,
+            author_email=principal.email,
+            body=payload.body,
+            attachments=payload.attachments,
+        )
+    except ConversationPlanningError as exc:
+        if claim is not None:
+            await idempotency.release(
+                session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+            )
+        raise _planning_error(exc) from exc
+    except Exception:
+        if claim is not None:
+            await idempotency.release(
+                session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+            )
+        raise
+
+    body = _message_dto(message)
+    if claim is not None:
+        await idempotency.complete(
+            session,
+            key=idempotency_key,
+            endpoint=endpoint,
+            actor_id=principal.user_id,
+            status_code=201,
+            body=body,
+            claim=claim,
+            request_fingerprint=fingerprint,
+        )
+    return body

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -58,7 +58,11 @@ version_router = APIRouter()
 # (issue #7), and `GET/POST/PATCH /api/v1/epics/**` + `/api/v1/issues/**`
 # (issue #8). See each section of `docs/api/README.md` for the field-level
 # detail; none of the four alone is what "1.4.0" means.
-API_CONTRACT_VERSION = "1.4.0"
+#
+# 1.4.0 -> 1.5.0: `GET/POST /api/v1/conversations/**` (issue #10) — contextual
+# conversations and messaging. Additive only (new endpoints, new schemas), so
+# a minor bump per docs/api/README.md's "What is not breaking".
+API_CONTRACT_VERSION = "1.5.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a

--- a/gateway/app/core/config.py
+++ b/gateway/app/core/config.py
@@ -45,7 +45,8 @@ class Settings(BaseSettings):
     oauth_allowed_client_ids: str = "chatgpt-codexbridge"
     oauth_allowed_redirect_uri_prefixes: str = "https://chatgpt.com,https://chat.openai.com,https://auth.openai.com"
     oauth_default_scopes: str = (
-        "codexbridge.read codexbridge.task.submit codexbridge.task.cancel codexbridge.issues.write"
+        "codexbridge.read codexbridge.task.submit codexbridge.task.cancel "
+        "codexbridge.issues.write codexbridge.conversations.write"
     )
     oauth_access_token_ttl_seconds: int = 3600
     oauth_authorization_code_ttl_seconds: int = 600

--- a/gateway/app/db/schema_guard.py
+++ b/gateway/app/db/schema_guard.py
@@ -42,6 +42,9 @@ REQUIRED_TABLES: dict[str, str] = {
     "oauth_refresh_tokens": "0003_mobile_auth.sql",
     "epics": "0006_epics_issues.sql",
     "issues": "0006_epics_issues.sql",
+    "conversations": "0007_conversations.sql",
+    "conversation_messages": "0007_conversations.sql",
+    "conversation_read_states": "0007_conversations.sql",
 }
 
 REQUIRED_COLUMNS: dict[str, dict[str, str]] = {

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -13,6 +13,7 @@ from gateway.app.api.idempotency import purge_expired
 from gateway.app.api.rate_limit import RateLimitDependency, client_key
 from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import decisions, missions, probes, projects, sessions
+from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
 from gateway.app.api.setup import install_api_conventions
@@ -129,6 +130,11 @@ app.include_router(auth_routes.router, dependencies=[Depends(RateLimitDependency
 # authorization plumbing as sessions and auth above.
 app.include_router(epics_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 app.include_router(issues_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# Contextual conversations and messaging (issue #10): threads linked to
+# projects, sessions/decisions/missions and issues. Same limiter, same
+# authorization plumbing as epics and issues above.
+app.include_router(conversations_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 
 
 def oauth_www_authenticate_header() -> str:

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -125,6 +125,72 @@ class IssueModel(Base):
     revision: Mapped[int] = mapped_column(Integer, default=1, server_default="1")
 
 
+class ConversationModel(Base):
+    """A contextual thread linked to at least one product entity — issue #10.
+
+    `context_json` is a JSON list of `{"type", "id"}` pairs, not a join table:
+    the scope here is "record and surface which entities this conversation is
+    about", the same reasoning `IssueModel.dependencies_json` documents, and a
+    join table with a single consumer is the architecture expansion
+    `docs/limits.md` rules out. `project_id` is denormalized from the context
+    references at creation time (every reference resolves to exactly one
+    project, checked in `store.resolve_conversation_context`) so authorization
+    and listing do not have to parse `context_json` on every query.
+    """
+
+    __tablename__ = "conversations"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    project_id: Mapped[str] = mapped_column(String(128), ForeignKey("projects.id"))
+    title: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    context_json: Mapped[str] = mapped_column(Text)
+    created_by_user_id: Mapped[str] = mapped_column(String(255))
+    created_by_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    # Null until the first message. Bumped by `store.create_conversation_message`
+    # alone — this row itself is never PATCHable, so unlike Epic/Issue there is
+    # no `revision`/`ETag` on a conversation: nothing here can go stale under a
+    # concurrent write, because nothing here can be written except by appending
+    # a message, which is its own idempotent, unconditional operation.
+    last_activity_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class ConversationMessageModel(Base):
+    """One message in a conversation. Immutable once written — no update path."""
+
+    __tablename__ = "conversation_messages"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(String(128), ForeignKey("conversations.id"))
+    author_user_id: Mapped[str] = mapped_column(String(255))
+    author_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Markdown source, stored and returned verbatim. The server never renders
+    # it; rendering is the mobile client's responsibility (docs/api/README.md).
+    body: Mapped[str] = mapped_column(Text)
+    # Opaque artifact/file identifiers, JSON-encoded. Not validated against a
+    # backing model: no `ArtifactModel` exists yet (issue #11), so these are
+    # recorded as caller-supplied references and returned unchanged, the same
+    # way `IssueModel.dependencies_json` records ids without owning a graph.
+    attachments_json: Mapped[str] = mapped_column(Text, default="[]", server_default="[]")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
+class ConversationReadStateModel(Base):
+    """How far one actor has read into one conversation.
+
+    Not exposed by any endpoint of its own: `GET .../messages` advances it as a
+    side effect of fetching the current messages, and `POST .../messages`
+    advances the sender's own past the message just sent — issue #10 names no
+    "mark as read" endpoint, so this is the only mechanism that can move it.
+    """
+
+    __tablename__ = "conversation_read_states"
+
+    conversation_id: Mapped[str] = mapped_column(String(128), ForeignKey("conversations.id"), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    last_read_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
 class TaskLogModel(Base):
     __tablename__ = "task_logs"
 

--- a/gateway/app/services/conversation_types.py
+++ b/gateway/app/services/conversation_types.py
@@ -1,0 +1,61 @@
+"""Closed vocabulary for conversation context references, and their error.
+
+Kept out of `shared/protocol.py` on purpose, same reasoning as
+`gateway/app/services/issue_types.py`: this is a gateway-only planning
+concept with no executor involvement, so it does not share a module with the
+executor protocol.
+
+## Why `artifact` is not a context type
+
+Issue #10's objective names conversations "linked to projects, decisions,
+missions, issues, sessions and artifacts". Five of those six already have a
+backing model this build can validate a reference against: `project` is
+`ProjectModel`; `session`, `decision` and `mission` are the same `TaskModel`
+under three vocabularies (`docs/api/README.md`'s "Decisions"/"Missions"
+sections); `issue` is `IssueModel` (issue #8). `artifact` has no backing model
+— issue #11 has not shipped `ArtifactModel` — so a context reference of that
+type could not be checked for existence or for project visibility, which is
+exactly the acceptance criterion this issue's context references exist to
+satisfy ("Unauthorized entity references are rejected without disclosing
+hidden resources"). Rather than accept an unverifiable reference, `artifact`
+is omitted from `CONTEXT_TYPES` until issue #11 gives it something to check
+against, the same discipline issue #8 applied to "missions, conversations and
+decisions" as issue links and issue #7 applied to `dependencies`/
+`relatedEntities`: no backing entity, no field.
+
+This does not remove artifacts from the feature. "Attachment references
+through artifact/file identifiers" (issue #10's own Scope wording) is a
+*message* concept, not a conversation *context* concept — `ConversationMessageModel.attachments_json`
+carries opaque artifact/file ids on each message, unvalidated for the same
+reason, and is unaffected by this restriction.
+"""
+
+from __future__ import annotations
+
+
+CONTEXT_TYPES = frozenset({"project", "session", "decision", "mission", "issue"})
+
+# Generous but bounded: a conversation about "this session and its parent
+# project" is two references; there is no use case in this codebase for
+# dozens, and an unbounded list is an unbounded query fan-out in
+# `store.resolve_conversation_context`.
+MAX_CONTEXT_REFERENCES = 16
+
+MAX_MESSAGE_BODY_LENGTH = 50000
+MAX_ATTACHMENTS_PER_MESSAGE = 20
+MAX_ATTACHMENT_ID_LENGTH = 255
+
+
+class ConversationPlanningError(ValueError):
+    """A create input that fails validation inside the store itself.
+
+    Same shape and same reasoning as `issue_types.IssuePlanningError`: the
+    guard belongs inside the operation, not the route, so a future second
+    caller does not get to skip it by construction.
+    """
+
+    def __init__(self, field: str, code: str, message: str) -> None:
+        super().__init__(message)
+        self.field = field
+        self.code = code
+        self.message = message

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -25,6 +25,7 @@ from gateway.app.models.entities import (
 )
 from gateway.app.services.audit import record_event
 from gateway.app.services.conversation_types import (
+    MAX_ATTACHMENT_ID_LENGTH,
     MAX_ATTACHMENTS_PER_MESSAGE,
     MAX_MESSAGE_BODY_LENGTH,
     ConversationPlanningError,
@@ -1949,6 +1950,12 @@ async def create_conversation_message(
             "/attachments", "too_many",
             f"attachments must be at most {MAX_ATTACHMENTS_PER_MESSAGE} entries.",
         )
+    for index, attachment_id in enumerate(normalized_attachments):
+        if len(attachment_id) > MAX_ATTACHMENT_ID_LENGTH:
+            raise ConversationPlanningError(
+                f"/attachments/{index}", "too_long",
+                f"attachment id must be at most {MAX_ATTACHMENT_ID_LENGTH} characters.",
+            )
 
     now = now or datetime.now(timezone.utc)
     message = ConversationMessageModel(

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -9,6 +9,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.app.models.entities import (
     AuditEventModel,
+    ConversationMessageModel,
+    ConversationModel,
+    ConversationReadStateModel,
     EpicModel,
     ExecutorModel,
     IssueModel,
@@ -21,6 +24,11 @@ from gateway.app.models.entities import (
     TaskModel,
 )
 from gateway.app.services.audit import record_event
+from gateway.app.services.conversation_types import (
+    MAX_ATTACHMENTS_PER_MESSAGE,
+    MAX_MESSAGE_BODY_LENGTH,
+    ConversationPlanningError,
+)
 from gateway.app.services.issue_types import (
     DEFAULT_EPIC_STATUS,
     DEFAULT_ISSUE_PRIORITY,
@@ -1732,3 +1740,267 @@ async def link_issue_to_epic(
     await session.commit()
     await session.refresh(issue)
     return issue
+
+
+# --------------------------------------------------------------------------
+# Conversations (issue #10) — contextual threads linked to product entities.
+# See gateway/app/services/conversation_types.py for the closed vocabulary of
+# context reference types and why `artifact` is not among them.
+# --------------------------------------------------------------------------
+
+
+async def create_conversation(
+    session: AsyncSession,
+    *,
+    project_id: str,
+    title: str | None,
+    context: list[dict],
+    actor_user_id: str,
+    actor_email: str | None,
+) -> ConversationModel:
+    """Create a conversation from an already-resolved, already-authorized context.
+
+    Every entry in `context` has already been fetched through a
+    `*_for_projects` getter by the route (mirroring `link_issue_to_epic`'s
+    division of labour: the route resolves and authorizes, the store persists
+    and re-checks the invariant the write itself must never violate). This
+    function's own defense is that `project_id` names a real, enabled project
+    — the same check `create_epic`/`create_issue` make — because a caller
+    whose `allowed_projects` names a project the registry no longer has must
+    still fail here rather than write an orphaned row.
+    """
+    project = await session.get(ProjectModel, project_id)
+    if project is None or not project.enabled:
+        raise ConversationPlanningError("/context", "unknown_project", "No such project.")
+    if not context:
+        raise ConversationPlanningError("/context", "required", "At least one context reference is required.")
+    if title is not None:
+        title = title.strip() or None
+
+    now = datetime.now(timezone.utc)
+    conversation = ConversationModel(
+        id=str(uuid4()),
+        project_id=project_id,
+        title=title,
+        context_json=json.dumps(context, ensure_ascii=True),
+        created_by_user_id=actor_user_id,
+        created_by_email=actor_email,
+        created_at=now,
+        last_activity_at=None,
+    )
+    session.add(conversation)
+    await record_event(
+        session, "conversation", conversation.id, "conversation.created",
+        {"project_id": project_id, "actor_id": actor_user_id, "context": context},
+    )
+    # The creator starts caught up: they were just looking at what they wrote,
+    # so an empty conversation must not open already "unread" for its own author.
+    session.add(
+        ConversationReadStateModel(conversation_id=conversation.id, user_id=actor_user_id, last_read_at=now)
+    )
+    await session.commit()
+    await session.refresh(conversation)
+    return conversation
+
+
+async def get_conversation(session: AsyncSession, conversation_id: str) -> ConversationModel | None:
+    return await session.get(ConversationModel, conversation_id)
+
+
+async def get_conversation_for_projects(
+    session: AsyncSession, conversation_id: str, project_ids: list[str] | None
+) -> ConversationModel | None:
+    """A conversation the caller may see, or None. Mirrors `get_epic_for_projects`."""
+    conversation = await session.get(ConversationModel, conversation_id)
+    if conversation is None:
+        return None
+    if project_ids is not None and conversation.project_id not in project_ids:
+        return None
+    return conversation
+
+
+async def list_conversations_page(
+    session: AsyncSession,
+    *,
+    project_ids: list[str] | None,
+    after: tuple[str, str] | None = None,
+    limit: int = 50,
+) -> list[ConversationModel]:
+    """Conversations the caller may see, newest-created first, over-fetched by one.
+
+    Ordered by `created_at`/`id` — creation order, never `last_activity_at`.
+    A live-reordering feed is the opposite of the acceptance criterion
+    ("pagination preserves stable ordering"): sorting by an activity
+    timestamp would move a conversation's position in the list the moment a
+    new message lands mid-pagination, which can skip or repeat rows across
+    page fetches. `lastActivityAt` is still reported on every item; a client
+    that wants "most recently active first" sorts the page client-side.
+    """
+    statement = select(ConversationModel)
+    if project_ids is not None:
+        if not project_ids:
+            return []
+        statement = statement.where(ConversationModel.project_id.in_(project_ids))
+    if after is not None:
+        created_at, conversation_id = after
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at)
+        statement = statement.where(
+            or_(
+                ConversationModel.created_at < created_at,
+                and_(ConversationModel.created_at == created_at, ConversationModel.id < conversation_id),
+            )
+        )
+    statement = statement.order_by(ConversationModel.created_at.desc(), ConversationModel.id.desc()).limit(limit + 1)
+    result = await session.execute(statement)
+    return list(result.scalars())
+
+
+async def conversation_read_states(
+    session: AsyncSession, *, user_id: str, conversation_ids: list[str]
+) -> dict[str, datetime]:
+    """`{conversation_id: last_read_at}` for one actor, over the given ids.
+
+    One query for a whole page of conversations rather than one per row —
+    the same reasoning `executors_by_project` gives for loading its whole
+    small table at once instead of querying per project.
+    """
+    if not conversation_ids:
+        return {}
+    result = await session.execute(
+        select(ConversationReadStateModel.conversation_id, ConversationReadStateModel.last_read_at).where(
+            ConversationReadStateModel.user_id == user_id,
+            ConversationReadStateModel.conversation_id.in_(conversation_ids),
+        )
+    )
+    return {row.conversation_id: _as_utc(row.last_read_at) for row in result}
+
+
+def conversation_unread(
+    *, last_activity_at: datetime | None, last_read_at: datetime | None
+) -> bool:
+    """Whether an actor has unseen activity in a conversation.
+
+    `last_activity_at` is `None` for a conversation with no messages yet —
+    nothing to read, so never unread, regardless of who is asking. Otherwise
+    unread when the actor has no read state at all, or their read state is
+    older than the last message.
+    """
+    if last_activity_at is None:
+        return False
+    if last_read_at is None:
+        return True
+    return _as_utc(last_read_at) < _as_utc(last_activity_at)
+
+
+async def mark_conversation_read(
+    session: AsyncSession, *, conversation_id: str, user_id: str, at: datetime | None = None
+) -> None:
+    """Advance (never retreat) one actor's read cursor on one conversation.
+
+    Never retreating matters for the sender's own cursor in
+    `create_conversation_message`: two rapid sends must not let the second
+    call's `now()` — which could, on a slow clock, read earlier than the
+    first — undo the first call's own advancement.
+    """
+    # Normalized once, here: SQLite hands back a naive `created_at`/`last_read_at`
+    # while Postgres hands back an aware one (same split `timestamps.utc_z`
+    # documents), so comparing an unconverted `at` against `_as_utc(state.last_read_at)`
+    # raised on SQLite the moment a caller passed a DB-sourced timestamp
+    # (`routes/conversations.py`'s "newest message in this page").
+    at = _as_utc(at or datetime.now(timezone.utc))
+    state = await session.get(ConversationReadStateModel, (conversation_id, user_id))
+    if state is None:
+        session.add(ConversationReadStateModel(conversation_id=conversation_id, user_id=user_id, last_read_at=at))
+    elif _as_utc(state.last_read_at) < at:
+        state.last_read_at = at
+
+
+async def create_conversation_message(
+    session: AsyncSession,
+    *,
+    conversation_id: str,
+    author_user_id: str,
+    author_email: str | None,
+    body: str,
+    attachments: list[str] | None,
+    now: datetime | None = None,
+) -> ConversationMessageModel:
+    """Append a message. Immutable once written — there is no update path.
+
+    Bumps the conversation's `last_activity_at` and the sender's own read
+    cursor in the same transaction: a client that just posted a message must
+    not immediately see its own conversation reported as unread.
+    """
+    conversation = await session.get(ConversationModel, conversation_id)
+    if conversation is None:
+        raise ValueError("unknown_conversation")
+
+    body = body.strip()
+    if not body:
+        raise ConversationPlanningError("/body", "required", "body must not be empty.")
+    if len(body) > MAX_MESSAGE_BODY_LENGTH:
+        raise ConversationPlanningError(
+            "/body", "too_long", f"body must be at most {MAX_MESSAGE_BODY_LENGTH} characters."
+        )
+    normalized_attachments = list(dict.fromkeys(attachments or []))
+    if len(normalized_attachments) > MAX_ATTACHMENTS_PER_MESSAGE:
+        raise ConversationPlanningError(
+            "/attachments", "too_many",
+            f"attachments must be at most {MAX_ATTACHMENTS_PER_MESSAGE} entries.",
+        )
+
+    now = now or datetime.now(timezone.utc)
+    message = ConversationMessageModel(
+        id=str(uuid4()),
+        conversation_id=conversation_id,
+        author_user_id=author_user_id,
+        author_email=author_email,
+        body=body,
+        attachments_json=json.dumps(normalized_attachments, ensure_ascii=True),
+        created_at=now,
+    )
+    session.add(message)
+    conversation.last_activity_at = now
+    await record_event(
+        session, "conversation", conversation_id, "conversation.message_created",
+        {"message_id": message.id, "actor_id": author_user_id, "attachments": len(normalized_attachments)},
+    )
+    await mark_conversation_read(session, conversation_id=conversation_id, user_id=author_user_id, at=now)
+    await session.commit()
+    await session.refresh(message)
+    return message
+
+
+async def list_conversation_messages_page(
+    session: AsyncSession,
+    *,
+    conversation_id: str,
+    after: tuple[str, str] | None = None,
+    limit: int = 50,
+) -> list[ConversationMessageModel]:
+    """A conversation's messages, oldest first — the order a thread reads in.
+
+    Same convention and same reasoning as `list_task_events_page`'s mission
+    timeline: unlike the newest-first collection endpoints, a message thread
+    is read forward from its start. Over-fetches by one, same as every other
+    collection here.
+    """
+    statement = select(ConversationMessageModel).where(
+        ConversationMessageModel.conversation_id == conversation_id
+    )
+    if after is not None:
+        created_at, message_id = after
+        if isinstance(created_at, str):
+            created_at = datetime.fromisoformat(created_at)
+        statement = statement.where(
+            or_(
+                ConversationMessageModel.created_at > created_at,
+                and_(ConversationMessageModel.created_at == created_at, ConversationMessageModel.id > message_id),
+            )
+        )
+    statement = statement.order_by(
+        ConversationMessageModel.created_at.asc(), ConversationMessageModel.id.asc()
+    ).limit(limit + 1)
+    result = await session.execute(statement)
+    return list(result.scalars())

--- a/migrations/0007_conversations.sql
+++ b/migrations/0007_conversations.sql
@@ -1,0 +1,53 @@
+-- WK-20260821-gh-10-conversations / issue #10
+--
+-- Contextual conversations and messaging: threads linked to at least one
+-- product entity (project, session/decision/mission, or issue — see
+-- gateway/app/services/conversation_types.py for the closed vocabulary and
+-- why `artifact` is not among them yet). `context_json` on `conversations`
+-- is a JSON list, not a join table, for the same reason
+-- `issues.dependencies_json` is: the scope here is "record and surface",
+-- not a full graph API.
+--
+-- Apply with `python3 scripts/apply_migrations.py`. Each file runs exactly
+-- once, tracked in `schema_migrations`; no `IF NOT EXISTS` guard is needed
+-- on anything but table/index creation, since this file only creates tables.
+
+create table if not exists conversations (
+  id varchar(128) primary key,
+  project_id varchar(128) not null references projects(id),
+  title varchar(255) null,
+  context_json text not null,
+  created_by_user_id varchar(255) not null,
+  created_by_email varchar(255) null,
+  created_at timestamptz not null,
+  -- Null until the first message. See ConversationModel's docstring for why
+  -- there is no `revision`/`ETag` on this table: nothing here is ever
+  -- PATCHed, so nothing here can go stale under a concurrent write.
+  last_activity_at timestamptz null
+);
+
+-- The list endpoint filters by project and orders by creation, never by
+-- last_activity_at — see routes/conversations.py's module docstring.
+create index if not exists conversations_project_id_created_at_idx
+  on conversations (project_id, created_at desc);
+
+create table if not exists conversation_messages (
+  id varchar(128) primary key,
+  conversation_id varchar(128) not null references conversations(id),
+  author_user_id varchar(255) not null,
+  author_email varchar(255) null,
+  body text not null,
+  attachments_json text not null default '[]',
+  created_at timestamptz not null
+);
+
+-- GET .../messages reads oldest-first, scoped to one conversation.
+create index if not exists conversation_messages_conversation_id_created_at_idx
+  on conversation_messages (conversation_id, created_at asc);
+
+create table if not exists conversation_read_states (
+  conversation_id varchar(128) not null references conversations(id),
+  user_id varchar(255) not null,
+  last_read_at timestamptz not null,
+  primary key (conversation_id, user_id)
+);

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from gateway.app.api import permissions
 from gateway.app.api.routes import auth as auth_routes
+from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import decisions as decisions_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
@@ -162,6 +163,7 @@ async def api(users_file, monkeypatch):
     app.include_router(missions_routes.router)
     app.include_router(epics_routes.router)
     app.include_router(issues_routes.router)
+    app.include_router(conversations_routes.router)
 
     async def override():
         async with factory() as s:
@@ -1033,6 +1035,9 @@ ENDPOINT_FOR_ACTION = {
     "issues.update": ("PATCH", "/api/v1/issues/{id}"),
     "epics.create": ("POST", "/api/v1/epics"),
     "epics.linkIssue": ("POST", "/api/v1/epics/e1/issues/{id}"),
+    "conversations.read": ("GET", "/api/v1/conversations"),
+    "conversations.create": ("POST", "/api/v1/conversations"),
+    "conversations.postMessage": ("POST", "/api/v1/conversations/{id}/messages"),
 }
 
 # Actions with no endpoint of their own, each naming the test that covers it

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -1,0 +1,578 @@
+"""Conversations and contextual messaging — issue #10.
+
+Weighted toward the acceptance criteria named explicitly: at least one context
+reference, idempotent offline message replay and duplicate prevention, stable
+pagination, and unauthorized entity references answering `404` rather than
+disclosing what the caller cannot see — plus the authorization and
+idempotency conventions every other write endpoint in this API already
+carries.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import conversations as conversations_routes
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.services import store
+from shared.protocol import (
+    ExecutorRegistration,
+    ProjectRegistration,
+    SubmitTaskRequest,
+    TaskMode,
+    TaskPriority,
+)
+
+
+ALICE_TOKEN = "token-alice"    # p1 only, has conversations.write
+READER_TOKEN = "token-reader"  # p1 only, read-only
+ADMIN_TOKEN = "token-admin"    # everything
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "alice", "email": "alice@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read", "codexbridge.conversations.write"], "enabled": True,
+                    },
+                    {
+                        "user_id": "reader", "email": "reader@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read"], "enabled": True,
+                    },
+                    {
+                        "user_id": "admin", "email": "admin@example.com", "password_hash": "x",
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def api(users_file, monkeypatch):
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="E1", display_name="E1", machine_token="t",
+                    allowed_projects=["p1", "p2"], enabled=True,
+                )
+            ],
+            projects=[
+                ProjectRegistration(
+                    project_id=pid, name=pid, path=f"/srv/{pid}",
+                    allowed_modes=[TaskMode.ANALYZE], max_timeout_seconds=600,
+                    sensitive_patterns=[], enabled=True,
+                )
+                for pid in ("p1", "p2")
+            ],
+        )
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        for token, user_id, scopes in (
+            (ALICE_TOKEN, "alice", ["codexbridge.read", "codexbridge.conversations.write"]),
+            (READER_TOKEN, "reader", ["codexbridge.read"]),
+            (ADMIN_TOKEN, "admin", ["codexbridge.admin"]),
+        ):
+            await store.create_oauth_access_token(
+                seed, token=token, client_id="c", user_id=user_id, scopes=scopes, expires_at=future
+            )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(conversations_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.factory = factory  # type: ignore[attr-defined]
+    yield client
+    await engine.dispose()
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def make_task(factory, project_id: str = "p1"):
+    async with factory() as s:
+        return await store.create_task(
+            s,
+            SubmitTaskRequest(
+                executor_id="E1", project_id=project_id, instruction="analyze it",
+                mode=TaskMode.ANALYZE, priority=TaskPriority.NORMAL, timeout_seconds=60,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            ),
+            executor_online=True,
+        )
+
+
+async def make_issue(factory, project_id: str = "p1", **kwargs):
+    async with factory() as s:
+        return await store.create_issue(
+            s,
+            project_id=project_id,
+            epic_id=kwargs.pop("epic_id", None),
+            title=kwargs.pop("title", "Issue one"),
+            description=kwargs.pop("description", None),
+            status=kwargs.pop("status", None),
+            priority=kwargs.pop("priority", None),
+            labels=kwargs.pop("labels", None),
+            assignee_user_id=kwargs.pop("assignee_user_id", None),
+            assignee_email=kwargs.pop("assignee_email", None),
+            dependencies=kwargs.pop("dependencies", None),
+            blocked_reason=kwargs.pop("blocked_reason", None),
+            actor_user_id="alice",
+            actor_email="alice@example.com",
+        )
+
+
+async def make_conversation(factory, *, project_id: str = "p1", context: list[dict] | None = None):
+    async with factory() as s:
+        return await store.create_conversation(
+            s,
+            project_id=project_id,
+            title="Existing",
+            context=context or [{"type": "project", "id": project_id}],
+            actor_user_id="alice",
+            actor_email="alice@example.com",
+        )
+
+
+def create_payload(context: list[dict], title: str | None = None) -> dict:
+    body: dict = {"context": context}
+    if title is not None:
+        body["title"] = title
+    return body
+
+
+# --------------------------------------------------------------------------
+# Authentication, authorization and project visibility
+# --------------------------------------------------------------------------
+
+
+async def test_conversations_require_a_token(api) -> None:
+    assert api.get("/api/v1/conversations").status_code == 401
+    assert api.post(
+        "/api/v1/conversations", json=create_payload([{"type": "project", "id": "p1"}])
+    ).status_code == 401
+
+
+async def test_reader_cannot_create_a_conversation_or_post_a_message(api) -> None:
+    conversation = await make_conversation(api.factory)
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload([{"type": "project", "id": "p1"}]),
+        headers=auth(READER_TOKEN),
+    )
+    assert response.status_code == 403
+    assert response.json()["code"] == "permission_denied"
+
+    response = api.post(
+        f"/api/v1/conversations/{conversation.id}/messages",
+        json={"body": "hello"},
+        headers=auth(READER_TOKEN),
+    )
+    assert response.status_code == 403
+
+
+async def test_reader_can_still_list_get_and_read_messages(api) -> None:
+    conversation = await make_conversation(api.factory)
+    assert api.get("/api/v1/conversations", headers=auth(READER_TOKEN)).status_code == 200
+    assert api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).status_code == 200
+    assert (
+        api.get(f"/api/v1/conversations/{conversation.id}/messages", headers=auth(READER_TOKEN)).status_code
+        == 200
+    )
+
+
+async def test_a_conversation_in_an_invisible_project_is_not_found(api) -> None:
+    """404, never 403 — confirming existence is what probing is for."""
+    theirs = await make_conversation(api.factory, project_id="p2")
+    for response in (
+        api.get(f"/api/v1/conversations/{theirs.id}", headers=auth(ALICE_TOKEN)),
+        api.get(f"/api/v1/conversations/{theirs.id}/messages", headers=auth(ALICE_TOKEN)),
+        api.post(f"/api/v1/conversations/{theirs.id}/messages", json={"body": "x"}, headers=auth(ALICE_TOKEN)),
+    ):
+        assert response.status_code == 404
+        assert response.json()["code"] == "not_found"
+
+
+# --------------------------------------------------------------------------
+# Context references — the acceptance criterion
+# --------------------------------------------------------------------------
+
+
+async def test_create_requires_at_least_one_context_reference(api) -> None:
+    response = api.post("/api/v1/conversations", json={"context": []}, headers=auth(ALICE_TOKEN))
+    assert response.status_code == 422
+
+
+async def test_create_rejects_an_unknown_context_type(api) -> None:
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload([{"type": "artifact", "id": "p1"}]),
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 400
+    assert response.json()["details"][0]["code"] == "invalid_context_type"
+
+
+async def test_create_with_a_context_reference_in_a_hidden_project_is_not_found(api) -> None:
+    """Unauthorized entity references are rejected without disclosing hidden resources."""
+    hidden_task = await make_task(api.factory, "p2")
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload([{"type": "session", "id": hidden_task.id}]),
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 404
+    assert response.json()["code"] == "not_found"
+
+
+async def test_create_with_an_unknown_context_id_is_not_found(api) -> None:
+    """A reference to something that does not exist answers exactly like a hidden one."""
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload([{"type": "issue", "id": "does-not-exist"}]),
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 404
+
+
+async def test_create_rejects_context_references_spanning_two_projects(api) -> None:
+    task_p1 = await make_task(api.factory, "p1")
+    task_p2 = await make_task(api.factory, "p2")
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload(
+            [{"type": "session", "id": task_p1.id}, {"type": "session", "id": task_p2.id}]
+        ),
+        headers=auth(ADMIN_TOKEN),
+    )
+    assert response.status_code == 400
+    assert response.json()["details"][0]["code"] == "mixed_project"
+
+
+async def test_create_accepts_a_session_decision_or_mission_reference_to_the_same_task(api) -> None:
+    """session/decision/mission all name the same TaskModel row."""
+    task = await make_task(api.factory, "p1")
+    for context_type in ("session", "decision", "mission"):
+        response = api.post(
+            "/api/v1/conversations",
+            json=create_payload([{"type": context_type, "id": task.id}]),
+            headers=auth(ALICE_TOKEN),
+        )
+        assert response.status_code == 201, response.text
+        assert response.json()["projectId"] == "p1"
+
+
+async def test_create_derives_project_id_from_the_context_and_deduplicates(api) -> None:
+    issue = await make_issue(api.factory, "p1")
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload(
+            [
+                {"type": "issue", "id": issue.id},
+                {"type": "issue", "id": issue.id},
+                {"type": "project", "id": "p1"},
+            ],
+            title="About this issue",
+        ),
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["projectId"] == "p1"
+    assert body["title"] == "About this issue"
+    assert len(body["context"]) == 2
+    assert {"type": "issue", "id": issue.id} in body["context"]
+    assert {"type": "project", "id": "p1"} in body["context"]
+    # The creator is caught up on what they just wrote.
+    assert body["unread"] is False
+    assert body["lastActivityAt"] is None
+
+
+async def test_a_project_outside_the_caller_visibility_is_not_found_when_used_as_context(api) -> None:
+    response = api.post(
+        "/api/v1/conversations",
+        json=create_payload([{"type": "project", "id": "p2"}]),
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Idempotent creation, and duplicate prevention
+# --------------------------------------------------------------------------
+
+
+async def test_a_retried_conversation_create_does_not_create_a_second_conversation(api) -> None:
+    headers = {**auth(ALICE_TOKEN), "Idempotency-Key": "conv-1"}
+    payload = create_payload([{"type": "project", "id": "p1"}])
+
+    first = api.post("/api/v1/conversations", json=payload, headers=headers)
+    second = api.post("/api/v1/conversations", json=payload, headers=headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.headers.get("Idempotent-Replay") == "true"
+    assert second.json() == first.json()
+
+    listed = api.get("/api/v1/conversations", headers=auth(ALICE_TOKEN)).json()
+    assert len(listed["items"]) == 1
+
+
+# --------------------------------------------------------------------------
+# Messages: markdown bodies, attachments, idempotent offline replay
+# --------------------------------------------------------------------------
+
+
+async def test_post_message_stores_markdown_and_attachments_verbatim(api) -> None:
+    conversation = await make_conversation(api.factory)
+    response = api.post(
+        f"/api/v1/conversations/{conversation.id}/messages",
+        json={"body": "**bold** and a [link](https://example.com)", "attachments": ["artifact-1", "file-2"]},
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["body"] == "**bold** and a [link](https://example.com)"
+    assert body["attachments"] == ["artifact-1", "file-2"]
+    assert body["author"] == "alice@example.com"
+    assert body["conversationId"] == conversation.id
+
+
+async def test_post_message_rejects_an_empty_body(api) -> None:
+    conversation = await make_conversation(api.factory)
+    response = api.post(
+        f"/api/v1/conversations/{conversation.id}/messages",
+        json={"body": "   "},
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 400
+    assert response.json()["details"][0]["field"] == "/body"
+
+
+async def test_a_retried_message_post_does_not_create_a_second_message(api) -> None:
+    """Message creation is idempotent for offline retries — the acceptance criterion."""
+    conversation = await make_conversation(api.factory)
+    headers = {**auth(ALICE_TOKEN), "Idempotency-Key": "msg-1"}
+    payload = {"body": "sent once"}
+
+    first = api.post(f"/api/v1/conversations/{conversation.id}/messages", json=payload, headers=headers)
+    second = api.post(f"/api/v1/conversations/{conversation.id}/messages", json=payload, headers=headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    assert second.headers.get("Idempotent-Replay") == "true"
+    assert second.json() == first.json()
+
+    listed = api.get(
+        f"/api/v1/conversations/{conversation.id}/messages", headers=auth(ALICE_TOKEN)
+    ).json()
+    assert len(listed["items"]) == 1
+
+
+async def test_the_same_key_with_a_different_body_is_a_conflict(api) -> None:
+    """Reusing a key for a different payload is a client bug, not a silent replay."""
+    conversation = await make_conversation(api.factory)
+    headers = {**auth(ALICE_TOKEN), "Idempotency-Key": "msg-2"}
+    first = api.post(
+        f"/api/v1/conversations/{conversation.id}/messages", json={"body": "first"}, headers=headers
+    )
+    assert first.status_code == 201
+
+    second = api.post(
+        f"/api/v1/conversations/{conversation.id}/messages", json={"body": "different"}, headers=headers
+    )
+    assert second.status_code == 409
+
+    listed = api.get(
+        f"/api/v1/conversations/{conversation.id}/messages", headers=auth(ALICE_TOKEN)
+    ).json()
+    assert len(listed["items"]) == 1
+
+
+async def test_a_message_without_an_idempotency_key_is_never_deduplicated(api) -> None:
+    """No key means no replay protection — each call is a genuinely new message."""
+    conversation = await make_conversation(api.factory)
+    payload = {"body": "sent twice on purpose"}
+    api.post(f"/api/v1/conversations/{conversation.id}/messages", json=payload, headers=auth(ALICE_TOKEN))
+    api.post(f"/api/v1/conversations/{conversation.id}/messages", json=payload, headers=auth(ALICE_TOKEN))
+
+    listed = api.get(
+        f"/api/v1/conversations/{conversation.id}/messages", headers=auth(ALICE_TOKEN)
+    ).json()
+    assert len(listed["items"]) == 2
+
+
+# --------------------------------------------------------------------------
+# Unread and last-activity
+# --------------------------------------------------------------------------
+
+
+async def test_a_new_message_makes_the_conversation_unread_for_others(api) -> None:
+    conversation = await make_conversation(api.factory)
+    assert api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()["unread"] is False
+
+    api.post(
+        f"/api/v1/conversations/{conversation.id}/messages", json={"body": "hi"}, headers=auth(ALICE_TOKEN)
+    )
+
+    reader_view = api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()
+    assert reader_view["unread"] is True
+    assert reader_view["lastActivityAt"] is not None
+
+    # The sender is never shown their own conversation as unread.
+    alice_view = api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(ALICE_TOKEN)).json()
+    assert alice_view["unread"] is False
+
+
+async def test_fetching_messages_marks_the_conversation_read(api) -> None:
+    conversation = await make_conversation(api.factory)
+    api.post(f"/api/v1/conversations/{conversation.id}/messages", json={"body": "hi"}, headers=auth(ALICE_TOKEN))
+
+    assert api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()["unread"] is True
+
+    api.get(f"/api/v1/conversations/{conversation.id}/messages", headers=auth(READER_TOKEN))
+
+    assert api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()["unread"] is False
+
+
+async def test_an_early_page_of_messages_does_not_mark_later_ones_read(api) -> None:
+    """Fetching the oldest page must not silently mark newer, unfetched messages seen."""
+    conversation = await make_conversation(api.factory)
+    for index in range(3):
+        api.post(
+            f"/api/v1/conversations/{conversation.id}/messages",
+            json={"body": f"message {index}"},
+            headers=auth(ALICE_TOKEN),
+        )
+
+    first_page = api.get(
+        f"/api/v1/conversations/{conversation.id}/messages",
+        params={"limit": 1},
+        headers=auth(READER_TOKEN),
+    ).json()
+    assert first_page["page"]["hasMore"] is True
+    assert first_page["items"][0]["body"] == "message 0"
+
+    # Only the oldest message was fetched, so the conversation must still read
+    # unread: two newer messages have not been seen yet.
+    assert (
+        api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()["unread"] is True
+    )
+
+
+async def test_an_empty_conversation_is_never_unread(api) -> None:
+    conversation = await make_conversation(api.factory)
+    assert api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()["unread"] is False
+    assert api.get(f"/api/v1/conversations/{conversation.id}", headers=auth(READER_TOKEN)).json()["lastActivityAt"] is None
+
+
+# --------------------------------------------------------------------------
+# Pagination — stable ordering
+# --------------------------------------------------------------------------
+
+
+async def test_the_conversation_list_cursor_walks_every_conversation_once(api) -> None:
+    for index in range(6):
+        await make_conversation(api.factory)
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(10):
+        params = {"limit": 2}
+        if cursor:
+            params["cursor"] = cursor
+        body = api.get("/api/v1/conversations", headers=auth(ALICE_TOKEN), params=params).json()
+        seen.extend(item["id"] for item in body["items"])
+        cursor = body["page"]["nextCursor"]
+        if not body["page"]["hasMore"]:
+            break
+
+    assert len(seen) == 6
+    assert len(set(seen)) == 6
+
+
+async def test_the_message_list_cursor_walks_every_message_once_oldest_first(api) -> None:
+    conversation = await make_conversation(api.factory)
+    for index in range(6):
+        api.post(
+            f"/api/v1/conversations/{conversation.id}/messages",
+            json={"body": f"message {index}"},
+            headers=auth(ALICE_TOKEN),
+        )
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(10):
+        params = {"limit": 2}
+        if cursor:
+            params["cursor"] = cursor
+        body = api.get(
+            f"/api/v1/conversations/{conversation.id}/messages",
+            headers=auth(ALICE_TOKEN),
+            params=params,
+        ).json()
+        seen.extend(item["body"] for item in body["items"])
+        cursor = body["page"]["nextCursor"]
+        if not body["page"]["hasMore"]:
+            break
+
+    assert seen == [f"message {index}" for index in range(6)], "must read oldest first, in order"
+
+
+async def test_a_conversation_cursor_from_a_different_project_is_rejected(api) -> None:
+    await make_conversation(api.factory, project_id="p1")
+    await make_conversation(api.factory, project_id="p2")
+    first = api.get(
+        "/api/v1/conversations", headers=auth(ADMIN_TOKEN), params={"projectId": "p1", "limit": 1}
+    ).json()
+    cursor = first["page"]["nextCursor"] or "x"
+    response = api.get(
+        "/api/v1/conversations", headers=auth(ADMIN_TOKEN), params={"projectId": "p2", "cursor": cursor}
+    )
+    assert response.status_code == 400
+
+
+async def test_list_conversations_filters_by_project(api) -> None:
+    p1 = await make_conversation(api.factory, project_id="p1")
+    await make_conversation(api.factory, project_id="p2")
+    body = api.get(
+        "/api/v1/conversations", params={"projectId": "p1"}, headers=auth(ADMIN_TOKEN)
+    ).json()
+    assert [item["id"] for item in body["items"]] == [p1.id]

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -386,6 +386,20 @@ async def test_post_message_rejects_an_empty_body(api) -> None:
     assert response.json()["details"][0]["field"] == "/body"
 
 
+async def test_post_message_rejects_an_oversized_attachment_id(api) -> None:
+    """`MAX_ATTACHMENT_ID_LENGTH` (255) must be enforced, same as its three
+    siblings in `conversation_types.py` — council round-1 finding, PR #22."""
+    conversation = await make_conversation(api.factory)
+    response = api.post(
+        f"/api/v1/conversations/{conversation.id}/messages",
+        json={"body": "hello", "attachments": ["a" * 256]},
+        headers=auth(ALICE_TOKEN),
+    )
+    assert response.status_code == 400
+    assert response.json()["details"][0]["field"] == "/attachments/0"
+    assert response.json()["details"][0]["code"] == "too_long"
+
+
 async def test_a_retried_message_post_does_not_create_a_second_message(api) -> None:
     """Message creation is idempotent for offline retries — the acceptance criterion."""
     conversation = await make_conversation(api.factory)


### PR DESCRIPTION
## Summary
- Implements issue #10 (parent epic #1): `GET /api/v1/conversations`, `GET .../{id}`, `GET .../{id}/messages`, `POST .../{id}/messages`, `POST /api/v1/conversations`.
- Conversations link to at least one product entity (project, session/decision/mission, or issue), resolved and authorization-checked through the existing `*_for_projects` getters — a hidden reference answers `404`, indistinguishable from a nonexistent one.
- Markdown-capable message bodies, opaque artifact/file attachment references, per-actor unread/last-activity state, and `Idempotency-Key`-based offline replay/duplicate prevention on both create endpoints — all reusing existing pagination/idempotency/error-envelope helpers.
- `artifact` is deliberately **not** a context reference type: no `ArtifactModel` exists yet (issue #11), so it would be unvalidatable, which would break the "no hidden-resource disclosure" acceptance criterion for that one type. Message attachments (opaque artifact/file ids) are unaffected and fully implemented.
- Recovery session: a prior cloud-container attempt finished this work but lost it to a `git push` 403/404 before the container was recycled. Redone from scratch off current `development`, not resumed from anything.

See `docs/api/README.md`'s new "Conversations (issue #10)" section and `docs/napkin-lessons.md`'s 2026-08-21 entry for the full reasoning behind every judgment call (read-cursor semantics, list ordering vs. `lastActivityAt`, why there is no `revision`/`ETag`/`If-Match` on this feature).

## Test plan
- [x] `python3 -m pytest -q` → 521 passed (495 pre-existing + 26 new in `tests/integration/test_conversations.py`), run multiple times for stability.
- [x] `python3 -m pytest tests/contract -q` → all green, including the OpenAPI route-inventory drift gate and the nginx-vhost coverage gate.
- [x] Pre-existing, order/CWD-sensitive flake in `tests/integration/test_agent_ws_handshake.py` (4 tests) independently reproduced on a fresh clone of `origin/development` itself — not caused by this diff, already documented in `docs/napkin-lessons.md`'s 2026-08-19 entry, left alone.
- [x] `docs/codemap.md` regenerated via `governancekit --root . map`.