### PR TITLE
fix: continue_codex_session datetime crash and missing dispatch (#23, #24)

### DIFF
--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -655,3 +655,70 @@ fix restored.
 `python3 -m pytest -q` → 500 passed, 4 failed (same
 `tests/integration/test_agent_ws_handshake.py` four, unchanged from the
 2026-08-20 baseline — the extra passing test is this round's own).
+
+## 2026-08-21 — #23/#24: `continue_codex_session` datetime crash and missing dispatch
+
+Two more pre-existing (not #21/#22-introduced) findings from the same
+council-style second-caller pass, this time on the MCP transport's
+`continue_codex_session` — the one tool of the five in `gateway/app/mcp/
+server.py` with zero test coverage before this (`pytest -k
+continue_codex_session` selected 0 of 503 tests).
+
+**#23**: `continue_codex_session` forwards `parent.expires_at` — fetched via
+`store.get_task`, naive under SQLite despite `DateTime(timezone=True)` — into
+a freshly built `SubmitTaskRequest`, which `store.create_task` then compares
+directly against `datetime.now(timezone.utc)`
+(`if request.expires_at <= datetime.now(timezone.utc)`). Every real call
+raised `TypeError: can't compare offset-naive and offset-aware datetimes`
+before any dispatch logic ran — `submit_codex_task`'s request never hits
+this because its `expires_at` comes straight from validated MCP input, aware
+by construction; `continue_codex_session`'s is the one path that round-trips
+a `DateTime(timezone=True)` column back through Python first. Fixed by
+reusing this file's own established pattern for the exact same hazard —
+`store.py`'s `_as_utc` helper, already applied to this same `TaskModel.
+expires_at` field four other places in the file (`is_task_expired`,
+`decide_task_approval`, the two credential-purge spots) — rather than
+inventing a new normalization at the MCP call site. Normalized once in
+`create_task` and reused for both the comparison and the stored value, so a
+row this function writes is never itself the naive one a later caller has to
+defend against.
+
+**#24**: even past that crash, `continue_codex_session` never dispatched the
+continuation to a connected, idle executor — it landed `QUEUED` and waited for
+an unrelated event, exactly the starvation shape #17/#18/#20 already found at
+two other call sites. Its sibling `submit_codex_task` (same file) dispatches
+via a hand-rolled `is_connected`/`dispatch_next`/`send` sequence that
+predates PR #21; `approve_codex_task` was already routed onto the shared
+`AgentHub.dispatch_available` PR #21 introduced. `continue_codex_session` had
+neither — no dispatch attempt at all. Fixed by routing it through the same
+`dispatch_available`, mirroring the REST approve path's own
+`session.refresh(task)` afterward (`decisions.py`'s `_resolve`, the
+2026-08-21 council-round-2 entry above): `dispatch_available` runs in
+`AgentHub`'s own session and, when it dispatches, bumps the task's state and
+revision through that other session — without the refresh, the response
+would report the pre-dispatch `queued` state even after a same-request
+dispatch actually ran.
+
+New tests, all in `tests/integration/test_store_and_mcp.py` (a real `AgentHub`
+over its own database, same convention as the #18/#20 MCP-path tests just
+above them, not the always-`None`-`dispatch_next` `DummyHub` used elsewhere in
+this file):
+`test_mcp_continue_codex_session_succeeds_without_datetime_crash`,
+`test_mcp_continue_codex_session_dispatches_to_a_connected_idle_executor`,
+`test_mcp_continue_codex_session_leaves_task_queued_when_the_executor_is_offline`,
+`test_mcp_continue_codex_session_at_capacity_does_not_dispatch`. The dispatch
+test's own fixture (`_make_parent_task`) has to leave the parent task
+`COMPLETED`, not `QUEUED`: left `QUEUED`, it would still be the oldest
+QUEUED row for the executor by `next_dispatchable_task`'s own `created_at`
+ordering, and `dispatch_next` would hand *it* back out instead of the
+continuation the test means to observe — caught by the dispatch test
+initially failing with the parent's own task id coming back dispatched
+instead of the child's.
+
+`python3 -m pytest -q` on a clean `development` checkout (`git stash`,
+repeated twice) → 504 passed, 0 failed — a stray, gitignored
+`codex_bridge.db` left over from an earlier ad hoc debug run had caused one
+transient 4-failure blip in `test_agent_ws_handshake.py` matching the
+2026-08-20 entry's own root cause (that file imports the real `gateway.app.
+main.app` instead of an isolated in-memory one); gone on rerun. With this
+session's changes: 508 passed, 0 failed (504 baseline + 4 new).

--- a/gateway/app/mcp/server.py
+++ b/gateway/app/mcp/server.py
@@ -204,6 +204,26 @@ async def handle_mcp_call(
             requested_by_user_id=parent.requested_by_user_id,
             requested_by_email=parent.requested_by_email,
         )
+        if task.state == TaskState.QUEUED.value:
+            # Issue #24: unlike `submit_codex_task` (hand-rolled dispatch just
+            # above), this branch had no dispatch at all — a continuation to a
+            # connected, idle executor landed QUEUED and sat until an
+            # unrelated event nudged the queue. `dispatch_available` is the
+            # shared mechanism PR #21 introduced for the REST approve path
+            # (`gateway/app/api/routes/decisions.py`'s `_resolve`); it already
+            # no-ops for an offline/at-capacity executor, so this mirrors
+            # `submit_codex_task`'s outcome without hand-rolling another inline
+            # is_connected/dispatch_next/send sequence.
+            await hub.dispatch_available(task.executor_id)
+            # `dispatch_available` runs in its own session (`AgentHub`'s
+            # `session_factory`) and, when it dispatches, bumps the task's
+            # state (and revision) via `store.update_task_state` on that other
+            # session. `task` is still the pre-dispatch row in this session's
+            # identity map; `_resolve`'s same-shaped fix (`decisions.py`,
+            # issue #20) refreshes for exactly this reason, so this does too —
+            # otherwise the payload below would report `queued` even after a
+            # successful dispatch.
+            await session.refresh(task)
         payload = {"task_id": task.id, "state": task.state, "continued_from_task_id": parent.id}
         result = _text_result(f"Continuation task {task.id} created.", payload)
     elif tool_name == "cancel_codex_task":

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -330,7 +330,19 @@ async def create_task(
     state = TaskState.QUEUED if executor_online else TaskState.WAITING_EXECUTOR
     if not executor_online and not request.run_when_available:
         raise ValueError("executor_offline")
-    if request.expires_at <= datetime.now(timezone.utc):
+    # `request.expires_at` is aware when it comes from validated API/MCP
+    # input, but `continue_codex_session` (gateway/app/mcp/server.py) forwards
+    # `parent.expires_at` straight from a DB row — naive under SQLite despite
+    # the column being `DateTime(timezone=True)` (issue #23). `_as_utc` is the
+    # same normalization already applied to this exact field a few lines down
+    # (`is_task_expired`, `decide_task_approval`, and the two credential-purge
+    # spots below), so `create_task` defends itself the same way instead of
+    # trusting every caller to pre-normalize. Normalized once and reused for
+    # the stored value too, not just this comparison, so a row this function
+    # writes is never itself the naive one a later caller has to defend
+    # against.
+    expires_at = _as_utc(request.expires_at)
+    if expires_at <= datetime.now(timezone.utc):
         raise ValueError("task_already_expired")
     if not policy.approved:
         state = TaskState.AWAITING_APPROVAL
@@ -343,7 +355,7 @@ async def create_task(
         state=state.value,
         priority=request.priority.value,
         run_when_available=request.run_when_available,
-        expires_at=request.expires_at,
+        expires_at=expires_at,
         timeout_seconds=request.timeout_seconds,
         created_at=datetime.now(timezone.utc),
         requested_by_user_id=requested_by_user_id,

--- a/tests/integration/test_store_and_mcp.py
+++ b/tests/integration/test_store_and_mcp.py
@@ -604,4 +604,211 @@ async def test_mcp_reject_and_request_revision_do_not_dispatch(mcp_hub_factory):
     async with mcp_hub_factory() as session:
         reloaded = await store.get_task(session, task.id)
     assert reloaded.state == TaskState.CANCELLED.value
+
+
+# --------------------------------------------------------------------------
+# continue_codex_session via MCP — issues #23/#24
+#
+# Zero coverage existed for this tool before (`pytest -k
+# continue_codex_session` selected 0 tests). `_make_parent_task` creates its
+# task in its own session and every test below reopens a *fresh* session from
+# `mcp_hub_factory` for the actual `continue_codex_session` call — deliberately,
+# so `store.get_task`'s `session.get()` cannot serve the parent row out of an
+# identity-map cache and must round-trip it through SQLite, which is exactly
+# what turns `expires_at` tzinfo-naive (issue #23) and is what a real second
+# MCP call would do too.
+# --------------------------------------------------------------------------
+
+
+async def _make_parent_task(factory):
+    """A finished task with a session to continue from.
+
+    Left QUEUED (`executor_online=True`, its natural state on creation) it
+    would still be the oldest QUEUED row for T610 by `created_at` —
+    `next_dispatchable_task`'s own ordering — and `dispatch_next` would hand
+    *it* back out instead of the continuation this fixture exists to set up
+    for. Marking it COMPLETED, as a real finished session would be by the time
+    anything continues it, takes it out of the QUEUED/WAITING_EXECUTOR pool
+    `next_dispatchable_task` selects from.
+    """
+    async with factory() as session:
+        task = await store.create_task(
+            session,
+            SubmitTaskRequest(
+                executor_id="T610",
+                project_id="p1",
+                instruction="explore the repository",
+                mode=TaskMode.ANALYZE,
+                timeout_seconds=300,
+                priority=TaskPriority.NORMAL,
+                run_when_available=True,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            ),
+            executor_online=True,
+        )
+        task = await store.update_task_state(session, task.id, TaskState.COMPLETED)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_mcp_continue_codex_session_succeeds_without_datetime_crash(mcp_hub_factory):
+    """Issue #23: `continue_codex_session` forwards `parent.expires_at` —
+    tzinfo-naive once it has round-tripped through SQLite, despite the column
+    being `DateTime(timezone=True)` — into `store.create_task`'s
+    `request.expires_at <= datetime.now(timezone.utc)` comparison, which used
+    to raise `TypeError: can't compare offset-naive and offset-aware
+    datetimes` before any dispatch logic ran. This is the plain success path:
+    no executor connected, nothing to dispatch, just proving the call itself
+    no longer raises.
+    """
+    parent = await _make_parent_task(mcp_hub_factory)
+    hub = AgentHub(mcp_hub_factory)  # T610 left offline; this test is only about the crash
+
+    async with mcp_hub_factory() as session:
+        response = await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "continue_codex_session",
+                    "arguments": {
+                        "task_id": parent.id,
+                        "instruction": "now add tests",
+                        "timeout_seconds": 300,
+                    },
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+
+    structured = response["result"]["structuredContent"]
+    assert structured["continued_from_task_id"] == parent.id
+    assert structured["task_id"] != parent.id
+    assert structured["state"] == TaskState.WAITING_EXECUTOR.value
+
+
+@pytest.mark.asyncio
+async def test_mcp_continue_codex_session_dispatches_to_a_connected_idle_executor(mcp_hub_factory):
+    """Issue #24: unlike its sibling `submit_codex_task` (same file), this
+    branch used to have no dispatch call at all — a continuation to a
+    connected, idle executor landed QUEUED and waited for an unrelated event.
+    Now routed through the shared `AgentHub.dispatch_available` (PR #21), same
+    as the REST approve path and `approve_codex_task`.
+    """
+    parent = await _make_parent_task(mcp_hub_factory)
+    hub = AgentHub(mcp_hub_factory)
+    await hub.register("T610", _DummyWebSocket())
+
+    async with mcp_hub_factory() as session:
+        response = await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "continue_codex_session",
+                    "arguments": {
+                        "task_id": parent.id,
+                        "instruction": "now add tests",
+                        "timeout_seconds": 300,
+                    },
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+
+    structured = response["result"]["structuredContent"]
+    # RUNNING, not just QUEUED: `dispatch_next` moves a dispatched task
+    # straight to RUNNING, and the response reflects the post-dispatch row
+    # (`session.refresh(task)` after `dispatch_available`), not the
+    # pre-dispatch one.
+    assert structured["state"] == TaskState.RUNNING.value
+
+    async with mcp_hub_factory() as session:
+        reloaded = await store.get_task(session, structured["task_id"])
+    assert reloaded.state == TaskState.RUNNING.value
+
+    connection = hub.connections["T610"]
+    sent_types = [msg["type"] for msg in connection.websocket.sent]
+    assert "task.dispatch" in sent_types
+
+
+@pytest.mark.asyncio
+async def test_mcp_continue_codex_session_leaves_task_queued_when_the_executor_is_offline(mcp_hub_factory):
+    """No regression on the pre-existing (disconnected) case: an offline
+    executor gets no dispatch attempt at all, matching #18/#20's own coverage
+    of the REST approve path."""
+    parent = await _make_parent_task(mcp_hub_factory)
+    hub = AgentHub(mcp_hub_factory)  # nothing registered — T610 stays offline
+
+    async with mcp_hub_factory() as session:
+        response = await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "continue_codex_session",
+                    "arguments": {
+                        "task_id": parent.id,
+                        "instruction": "now add tests",
+                        "timeout_seconds": 300,
+                    },
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+
+    structured = response["result"]["structuredContent"]
+    assert structured["state"] == TaskState.WAITING_EXECUTOR.value
+    assert hub.connections == {}
+
+
+@pytest.mark.asyncio
+async def test_mcp_continue_codex_session_at_capacity_does_not_dispatch(mcp_hub_factory):
+    """A connected executor already at its concurrency limit must not be sent
+    a second `task.dispatch` — `dispatch_available`'s existing capacity gate
+    (`AgentHub.dispatch_next`) must still apply through this call site,
+    matching #18/#20's own at-capacity coverage of the REST approve path."""
+    parent = await _make_parent_task(mcp_hub_factory)
+    hub = AgentHub(mcp_hub_factory)
+    await hub.register("T610", _DummyWebSocket())
+    # T610's `max_concurrent_tasks` is 1 (mcp_hub_factory's registration) —
+    # occupy that one slot with an unrelated task before continuing.
+    hub.running_tasks["T610"] = {"some-other-task-already-running"}
+
+    async with mcp_hub_factory() as session:
+        response = await handle_mcp_call(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/call",
+                "params": {
+                    "name": "continue_codex_session",
+                    "arguments": {
+                        "task_id": parent.id,
+                        "instruction": "now add tests",
+                        "timeout_seconds": 300,
+                    },
+                },
+            },
+            session,
+            hub,
+            ADMIN,
+        )
+
+    structured = response["result"]["structuredContent"]
+    # The executor is connected, so `create_task` starts this continuation at
+    # QUEUED (not WAITING_EXECUTOR — that state is only for an offline
+    # executor). `dispatch_available`'s capacity gate must leave it there
+    # rather than forcing a dispatch past the concurrency limit.
+    assert structured["state"] == TaskState.QUEUED.value, "the fix must not bypass the concurrency gate"
+    assert hub.connections["T610"].websocket.sent == []
     assert hub.connections["T610"].websocket.sent == []


### PR DESCRIPTION
## Summary
- Fixes #23: `continue_codex_session` crashed on every real call with `TypeError: can't compare offset-naive and offset-aware datetimes` because `parent.expires_at` (naive after a SQLite round-trip, despite `DateTime(timezone=True)`) was compared directly to an aware `datetime.now(timezone.utc)` in `store.create_task`. Normalized with the codebase's existing `_as_utc` helper (`gateway/app/services/store.py`), the same pattern already applied to this exact field elsewhere in the file, and reused for the stored value too.
- Fixes #24: even past that crash, the continuation never dispatched to a connected, idle executor — it landed `QUEUED` and waited for an unrelated event. Now routed through the shared `AgentHub.dispatch_available()` PR #21 introduced (same mechanism the REST approve path and `approve_codex_task` already use), including the matching `session.refresh(task)` afterward so the response reflects the post-dispatch state.
- Adds MCP-path test coverage for `continue_codex_session` (previously zero — `pytest -k continue_codex_session` selected 0 tests): normal continuation succeeds without the crash, a connected idle executor receives `task.dispatch` in the same call, and an offline/at-capacity executor gets no dispatch attempt.

## Test plan
- [x] `pytest -k continue_codex_session -v` — 4/4 new tests pass
- [x] Full suite on clean `development` (baseline, `git stash`, run twice): 504 passed, 0 failed
- [x] Full suite with this branch's changes: 508 passed, 0 failed (504 baseline + 4 new) — no regressions
- [x] `docs/napkin-lessons.md` updated with root-cause detail for both issues

Not merged, not deployed — per project policy this stops here for operator review.