### PR TITLE
fix(gh-28): isolate test_agent_ws_handshake.py's database

### DIFF
--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -722,3 +722,58 @@ transient 4-failure blip in `test_agent_ws_handshake.py` matching the
 2026-08-20 entry's own root cause (that file imports the real `gateway.app.
 main.app` instead of an isolated in-memory one); gone on rerun. With this
 session's changes: 508 passed, 0 failed (504 baseline + 4 new).
+
+## 2026-08-21 — #28: `test_agent_ws_handshake.py`'s isolated-DB fix, closing the chronic 4-failure flake
+
+The root cause the 2026-08-20 entry above named but didn't fix, finally owned
+as its own issue (#28) because #25's contract-drift fix removed the noise that
+had been masking it: after #25, this file's four failures were the *only* red
+left in CI, not one line among several.
+
+Confirmed the diagnosis exactly, plus one detail the earlier entry didn't
+have: it isn't only that `client`'s fixture builds `TestClient` around the
+real `gateway.app.main.app` — every other integration test file avoids that
+by building its own `FastAPI()` instance and overriding
+`app.dependency_overrides[get_session]`. This file could not use that same
+trick even if it built its own app, because `/agent/ws` (`gateway/app/
+main.py`'s `agent_ws`) never goes through `Depends(get_session)` at all — it
+opens sessions from the module-level `SessionLocal` directly, the same seam
+`test_refusing_an_anonymous_handshake_touches_no_executor_record` already
+monkeypatches to a database-touch-detector for one test. And the real
+`gateway.app.main.app`'s schema only ever gets created by its `startup` event
+(`Base.metadata.create_all` against the *production* `engine`, default
+`sqlite+aiosqlite:///./codex_bridge.db`) — an event that never fires here in
+the first place, because none of the six tests enters `TestClient` as `with
+client:` (the only thing that runs ASGI lifespan). So every test's outcome
+always depended entirely on whatever schema a stray `codex_bridge.db` already
+had on disk from some unrelated earlier run — CWD- and order-sensitive by
+construction, not a flake in any test's own logic.
+
+Fix: rebuilt the `client` fixture around an isolated `sqlite+aiosqlite:///
+:memory:` engine, `Base.metadata.create_all` run explicitly (no dependence on
+the `startup` event), and `monkeypatch.setattr(main, "SessionLocal", factory)`
+pointed at it — the one seam that actually reaches `/agent/ws`, since there is
+no `Depends(get_session)` to override. `main.app` itself is still the real
+app (needed for the real route and the real `gateway.app.main` logger the
+`caplog` assertions target); only its database is swapped. The fixture had to
+become `async` to build the engine, which pytest's `asyncio_mode = "auto"`
+handles transparently even though all six test functions stayed synchronous
+(`TestClient` calls are blocking regardless) — no need to convert them.
+
+Verified not just "passes once": the isolated file 10/10 in a row, in three
+interleavings with other integration files (before, after, and sandwiched
+between `test_agent_ack_handling.py` / `test_sessions.py` /
+`test_store_and_mcp.py` / `test_probes.py`), and the full suite 4 times in a
+row including once with a stray pre-existing `codex_bridge.db` deliberately
+left in place — the exact condition that used to flip these four tests red.
+Every run: `535 passed, 0 failed`. No `codex_bridge.db` file is created as a
+side effect of running this file anymore either (confirmed by `ls` between
+runs) — the earlier code always created one lazily on first connection even
+though it left it schemaless.
+
+Action next time: an integration test file that imports `gateway.app.main.
+app` directly (rather than building its own minimal `FastAPI()`) is a signal
+to check *how* its routes acquire sessions before reusing the
+`dependency_overrides[get_session]` pattern — a route that reads a
+module-level `SessionLocal` (or `engine`) directly needs that name monkeypatched
+instead, `app.dependency_overrides` never reaches it.

--- a/tests/integration/test_agent_ws_handshake.py
+++ b/tests/integration/test_agent_ws_handshake.py
@@ -10,19 +10,47 @@ the credential it was called with.
 from __future__ import annotations
 
 import logging
+from typing import AsyncIterator
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from starlette.websockets import WebSocketDisconnect
 
+from gateway.app.db.base import Base
 from shared.protocol import EXECUTOR_TOKEN_HEADER
 
 
 @pytest.fixture
-def client() -> TestClient:
-    from gateway.app.main import app
+async def client(monkeypatch) -> AsyncIterator[TestClient]:
+    """A real app, but wired to its own isolated in-memory database.
 
-    return TestClient(app, raise_server_exceptions=False)
+    `gateway.app.main.app` normally gets its schema from the `startup` event
+    (`Base.metadata.create_all` against the module-level production `engine`,
+    which defaults to the file `./codex_bridge.db`). That event never fires
+    here — `TestClient` only runs ASGI lifespan when entered as `with client:`,
+    and nothing below does that — so, left alone, every test in this file
+    depended on whatever schema happened to already be sitting in that stray
+    file from a previous run, order- and CWD-sensitive (issue #28).
+
+    `/agent/ws` also reads its sessions from the module-level `SessionLocal`
+    directly rather than through `Depends(get_session)` (see
+    `gateway.app.main.agent_ws`), so an `app.dependency_overrides` swap — the
+    trick the rest of `tests/integration` uses — would never reach it either.
+    Patching `main.SessionLocal` itself, the same seam
+    `test_refusing_an_anonymous_handshake_touches_no_executor_record` already
+    exploited below, is what actually redirects it.
+    """
+    from gateway.app import main
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(main, "SessionLocal", factory)
+
+    yield TestClient(main.app, raise_server_exceptions=False)
+    await engine.dispose()
 
 
 def test_a_handshake_with_no_credential_is_refused(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Closes #28: `tests/integration/test_agent_ws_handshake.py`'s 4 tests failed intermittently with `sqlalchemy.exc.OperationalError: no such table: executors`, confirmed both locally and on real CI (PR #21's Actions run).
- Root cause: the `client` fixture built `TestClient` around the real `gateway.app.main.app`. That app's schema is only created by its FastAPI `startup` event (`Base.metadata.create_all` against the *production* engine, default `sqlite+aiosqlite:///./codex_bridge.db`) — an event that never fires here, since none of the six tests enters `TestClient` as `with client:` (the only thing that runs ASGI lifespan). So every test's outcome depended entirely on whatever schema a stray `codex_bridge.db` happened to already have on disk from an unrelated earlier run — CWD- and order-sensitive by construction, not a flake in the tests' own logic.
- A second wrinkle the earlier investigation (see `docs/napkin-lessons.md`, 2026-08-20 entry) hadn't fully resolved: `/agent/ws` reads its sessions from the module-level `SessionLocal` directly rather than through `Depends(get_session)`, so the `app.dependency_overrides[get_session]` trick every other integration test file uses would not have reached it even after switching to a self-built app.
- Fix: rebuilt the `client` fixture around an isolated `sqlite+aiosqlite:///:memory:` engine, ran `Base.metadata.create_all` explicitly, and `monkeypatch.setattr(main, "SessionLocal", factory)` — the one seam that actually reaches `/agent/ws` (already exploited by one of this file's own tests for a different purpose).
- Updated `docs/napkin-lessons.md` with the full root cause and fix, following the existing entry conventions.

## Verification
- `test_agent_ws_handshake.py` alone: 10/10 consecutive runs green.
- Interleaved with other integration files in three different orders (before, after, and sandwiched between other files): all green.
- Full suite run 4x in a row, including once with a stray pre-existing `codex_bridge.db` deliberately left on disk (the exact condition that used to trigger the flake): `535 passed, 0 failed` every time — same baseline as prior sessions, no new failures.
- No `codex_bridge.db` file is created as a side effect of running this file anymore (previously it lazily created one, just schemaless).

## Test plan
- [x] `python3 -m pytest tests/integration/test_agent_ws_handshake.py -q` — repeated 10x
- [x] Interleaved runs with `test_agent_ack_handling.py`, `test_sessions.py`, `test_store_and_mcp.py`, `test_probes.py` in varying order
- [x] `python3 -m pytest -q` (full suite) — repeated 4x, with and without a stray `codex_bridge.db`

Not merging or deploying — stopping here per project policy for explicit human approval.