### PR TITLE
fix(gh-25): teach the contract gate to see through FastAPI's lazy include_router

### DIFF
--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -722,3 +722,80 @@ transient 4-failure blip in `test_agent_ws_handshake.py` matching the
 2026-08-20 entry's own root cause (that file imports the real `gateway.app.
 main.app` instead of an isolated in-memory one); gone on rerun. With this
 session's changes: 508 passed, 0 failed (504 baseline + 4 new).
+
+## 2026-08-21 — #25: the `contract` CI gate was blind, not the app
+
+Root cause found by refusing the trap every prior agent (and the issue itself)
+fell into: building a *fresh* venv the CI way (`pip install -e '.[test]'`,
+no cached `.venv`) instead of trusting a stale local one. `pyproject.toml`
+pins `fastapi>=0.116.0` with no upper bound — a floor, not a pin — and a
+fresh resolve on 2026-08-21 pulled `fastapi==0.141.1` (`starlette` along for
+the ride at `1.6.0`). Every stale local `.venv` any agent had been testing
+against still had a pre-0.141 FastAPI, so "passes locally, fails in CI" was
+never environment noise — CI was right, and local was stale.
+
+FastAPI 0.141 made `include_router()` lazy: `app.include_router(router)` used
+to eagerly copy `router`'s routes into `app.routes`, flattened, with the
+prefix baked in. Now it appends one `fastapi.routing._IncludedRouter` wrapper
+per `include_router()` call instead, and defers resolving the real
+`APIRoute`/`Route` objects — and their effective, prefixed `path` — until
+something asks. This project has ten `include_router()` calls in
+`gateway/app/main.py`, so `app.routes` went from ~40 real routes to ten
+opaque wrappers overnight. Every place in this repo that walked `app.routes`
+by hand and did `isinstance(route, StarletteRoute)` or `getattr(route,
+"path", ...)` — `tests/contract/test_openapi_document.py`'s `_route_entries`
+(feeding both `test_gate_sees_every_route_the_app_exposes` and
+`test_no_contract_path_is_unimplemented`), `tests/contract/
+test_docs_match_the_runtime.py`'s `_rate_limited_api_routes`, and two spots in
+`tests/integration/test_probes.py` (`_api_route_signals` and
+`test_every_served_api_route_carries_the_rate_limiter`) — silently stopped
+seeing routes. The two `test_openapi_document.py` tests failed loudly
+(exactly per the issue). `_rate_limited_api_routes` also failed loudly only
+because its own precondition assertion (`assert limited`) exists precisely to
+catch a query that stopped finding anything — the same "gate reports green
+over an unexamined surface" failure mode this file's own docstrings warn
+about elsewhere turned up in two more places (`_api_route_signals` and
+`test_every_served_api_route_carries_the_rate_limiter`) that had no such
+precondition and were quietly passing vacuously, `assert not []`, the whole
+time — a live blind spot with nothing reporting it.
+
+Fixed with (b), not (a): pinning FastAPI back below 0.141 would have hidden
+the same break again at the next unconstrained bump, and FastAPI's own
+`fastapi.openapi.utils.get_openapi` — the code that generates the very
+`/openapi.json` this project deliberately serves 404 for — already walks
+`_IncludedRouter` via a module-level (not underscore-prefixed)
+`fastapi.routing.iter_route_contexts()`, which recurses through
+`_IncludedRouter` and yields a `RouteContext` per real leaf route, exposing
+`.original_route` (the true `Route`/`WebSocketRoute`, for `isinstance`), the
+*effective* `.path` (prefix resolved), and — confirmed by reading
+`_EffectiveRouteContext.from_api_route` — the *effective*, merged
+`.dependant`/`.dependencies` (router-level `include_router(dependencies=
+[Depends(RateLimitDependency(...))])` folded in). That merge is why the raw
+`original_route.dependant` was never a valid substitute: the rate limiter is
+attached at `include_router()` time, invisible on the sub-router's own
+unresolved route. All four call sites now iterate `iter_route_contexts(app.
+routes)` instead of `app.routes` directly; `Mount`/`Host` blindness — the
+gate's other, deliberate blind spot — is unaffected, since `iter_route_contexts`
+does not recurse into either.
+
+Verified by reproducing red first: fresh venv, CI's exact `pip install -e
+'.[test]'`, `pytest tests/contract -q` → the two `test_openapi_document.py`
+failures plus all four `test_the_api_readme_does_not_deny_the_limiter_that_
+ships` parametrizations, byte-for-byte the CI log's own failure list,
+including the `_IncludedRouter <no path>` x10. Green after the fix, same
+fresh venv: `tests/contract` 26/26, `tests/unit tests/integration` 509/509
+(also confirmed `test_every_served_api_route_carries_the_rate_limiter` and
+`_api_route_signals`'s consumer, `test_capability_flags_match_what_the_
+served_routes_accept`, still pass for the right reason post-fix, not
+vacuously).
+
+Action next time: a floating dependency floor (`>=`, no ceiling) is a promise
+that "whatever the resolver picks, this code still works" — nobody was
+checking that promise against a fresh resolve, so it silently broke and
+stayed broken for 11+ days across every branch. Any test helper that walks
+`app.routes`/`router.routes` by hand for FastAPI ≥0.141 must go through
+`fastapi.routing.iter_route_contexts()`, not `isinstance`/`getattr` on the
+raw list — and per the 2026-08-20 entry above, this working tree still
+accumulates a stray gitignored `codex_bridge.db` from ad hoc runs that causes
+an unrelated `test_agent_ws_handshake.py` blip; unrelated to this fix, still
+unowned.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,13 @@ requires-python = ">=3.10"
 dependencies = [
   "aiomysql>=0.2.0",
   "aiosqlite>=0.20.0",
-  "fastapi>=0.116.0",
+  # >=0.141.1: tests/contract and tests/integration route-inventory helpers
+  # import fastapi.routing.iter_route_contexts() to see through
+  # _IncludedRouter (lazy include_router(), shipped in this release) — on an
+  # older FastAPI that name does not exist, and app.routes is still the
+  # pre-0.141 flattened list. See docs/napkin-lessons.md, "#25: the
+  # `contract` CI gate was blind, not the app".
+  "fastapi>=0.141.1",
   "greenlet>=3.1.1",
   "httpx>=0.28.0",
   "prometheus-client>=0.22.0",

--- a/tests/contract/test_docs_match_the_runtime.py
+++ b/tests/contract/test_docs_match_the_runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from fastapi.routing import iter_route_contexts
 from starlette.routing import Route as StarletteRoute
 
 from gateway.app.api.rate_limit import RateLimitDependency
@@ -110,15 +111,26 @@ def _rate_limited_api_routes() -> list[str]:
     stale if the thing it denies is actually there.
     """
     limited: list[str] = []
-    for route in app.routes:
-        if not isinstance(route, StarletteRoute) or not route.path.startswith("/api"):
+    # `app.routes` holds one `_IncludedRouter` per `include_router()` call
+    # rather than that router's flattened routes (FastAPI's lazy router
+    # include), and the router-level `dependencies=[Depends(RateLimitDependency(...))]`
+    # that actually guards these routes is only folded into the *effective*
+    # dependant, not the sub-router's own unresolved one. `iter_route_contexts`
+    # is the same recursion FastAPI's own `get_openapi` uses to see through
+    # `_IncludedRouter`, and its `dependant` is the merged one.
+    for route_context in iter_route_contexts(app.routes):
+        path = route_context.path
+        if not isinstance(route_context.original_route, StarletteRoute) or not path or not path.startswith("/api"):
+            continue
+        dependant = getattr(route_context, "dependant", None)
+        if dependant is None:
             continue
         if any(
             isinstance(dependency.call, RateLimitDependency)
-            for dependency in route.dependant.dependencies
+            for dependency in dependant.dependencies
             if dependency.call is not None
         ):
-            limited.append(route.path)
+            limited.append(path)
     return limited
 
 

--- a/tests/contract/test_openapi_document.py
+++ b/tests/contract/test_openapi_document.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from fastapi.routing import iter_route_contexts
 from fastapi.testclient import TestClient
 from openapi_spec_validator import validate
 from openapi_spec_validator.readers import read_from_filename
@@ -138,7 +139,7 @@ def _brace_error(path: str) -> str | None:
     return "unterminated '{'" if depth else None
 
 
-def _route_entries(route: object) -> set[tuple[str, str]]:
+def _route_entries(route_context: object) -> set[tuple[str, str]]:
     """Every (path, METHOD) pair one route object exposes.
 
     Deliberately typed against Starlette's base classes rather than FastAPI's
@@ -150,16 +151,29 @@ def _route_entries(route: object) -> set[tuple[str, str]]:
     this gate while it reported green. Those four are switched off now
     (`test_generated_openapi_is_not_served`), but the blind spot was in the
     filter, not in them.
+
+    `route_context` is a `fastapi.routing.RouteContext` as yielded by
+    `iter_route_contexts`, not a raw route. Since FastAPI's lazy router
+    include (`_IncludedRouter`), `app.routes` holds one `_IncludedRouter` per
+    `include_router()` call rather than that router's flattened routes, and
+    the mounted path prefix is only resolved lazily. `original_route` still
+    carries the true leaf type — the same `Route`/`WebSocketRoute` classes as
+    before — so the Mount/Host blind spot this docstring describes stays
+    intact: `iter_route_contexts` recurses through `_IncludedRouter` but not
+    through `Mount`/`Host`, so those still surface here as unrecognised and
+    still fail `test_gate_sees_every_route_the_app_exposes` on purpose.
     """
-    path = getattr(route, "path", None)
+    original_route = getattr(route_context, "original_route", route_context)
+    path = getattr(route_context, "path", None)
     if path is None:
         return set()
-    if isinstance(route, StarletteWebSocketRoute):
+    if isinstance(original_route, StarletteWebSocketRoute):
         return {(_normalize(path), WEBSOCKET_METHOD)}
-    if isinstance(route, StarletteRoute):
+    if isinstance(original_route, StarletteRoute):
+        methods = getattr(route_context, "methods", None)
         return {
             (_normalize(path), method)
-            for method in (route.methods or set())
+            for method in (methods or set())
             if method not in IMPLICIT_METHODS
         }
     return set()
@@ -168,8 +182,8 @@ def _route_entries(route: object) -> set[tuple[str, str]]:
 def _app_routes() -> set[tuple[str, str]]:
     """Every (path, METHOD) pair the application exposes, HTTP and WebSocket."""
     pairs: set[tuple[str, str]] = set()
-    for route in app.routes:
-        pairs |= _route_entries(route)
+    for route_context in iter_route_contexts(app.routes):
+        pairs |= _route_entries(route_context)
     return pairs
 
 
@@ -233,9 +247,10 @@ def test_gate_sees_every_route_the_app_exposes() -> None:
     escaped the first cut of this file.
     """
     invisible = [
-        f"{type(route).__name__} {getattr(route, 'path', '<no path>')}"
-        for route in app.routes
-        if not _route_entries(route)
+        f"{type(route_context.original_route).__name__} "
+        f"{route_context.path or '<no path>'}"
+        for route_context in iter_route_contexts(app.routes)
+        if not _route_entries(route_context)
     ]
     assert not invisible, (
         f"routes the gate cannot see, so cannot check: {invisible}. Mounting a "
@@ -366,8 +381,8 @@ def test_route_paths_are_well_formed(spec: dict) -> None:
     this file would report it as a mysterious path mismatch.
     """
     malformed = []
-    for route in app.routes:
-        path = getattr(route, "path", None)
+    for route_context in iter_route_contexts(app.routes):
+        path = route_context.path
         if isinstance(path, str) and (problem := _brace_error(path)):
             malformed.append(f"served {path!r}: {problem}")
     for path in (spec.get("paths") or {}):

--- a/tests/integration/test_probes.py
+++ b/tests/integration/test_probes.py
@@ -240,17 +240,23 @@ def _api_route_signals() -> dict[str, bool]:
     list: a capability flag is a promise about request handling, so the evidence
     has to come from the handlers.
     """
+    from fastapi.routing import iter_route_contexts
+
     from gateway.app.main import app
 
     query_names: set[str] = set()
     header_names: set[str] = set()
     paths: set[str] = set()
-    for route in app.routes:
-        path = str(getattr(route, "path", ""))
+    # `app.routes` holds one `_IncludedRouter` per `include_router()` call
+    # rather than that router's flattened routes (FastAPI's lazy router
+    # include); `iter_route_contexts` is the same recursion FastAPI's own
+    # `get_openapi` uses to see through it to the real, prefixed routes.
+    for route_context in iter_route_contexts(app.routes):
+        path = route_context.path or ""
         if not (path == "/api" or path.startswith("/api/")):
             continue
         paths.add(path)
-        dependant = getattr(route, "dependant", None)
+        dependant = getattr(route_context, "dependant", None)
         if dependant is not None:
             _collect_params(dependant, query_names, header_names)
 
@@ -645,15 +651,21 @@ def test_every_served_api_route_carries_the_rate_limiter() -> None:
     route added with `@app.get("/api/v1/...")` further down the module would be
     unlimited. This asserts the claim instead of trusting the comment.
     """
+    from fastapi.routing import iter_route_contexts
+
     from gateway.app.api.rate_limit import RateLimitDependency
     from gateway.app.main import app
 
     unlimited = []
-    for route in app.routes:
-        path = str(getattr(route, "path", ""))
+    # See `_api_route_signals` above: `app.routes` no longer holds flattened
+    # routes, and the limiter is attached via `include_router(dependencies=…)`,
+    # which is only folded into the *effective* route's `dependencies` — not
+    # into the sub-router's own unresolved `APIRoute.dependencies`.
+    for route_context in iter_route_contexts(app.routes):
+        path = route_context.path or ""
         if not (path == "/api" or path.startswith("/api/")):
             continue
-        dependencies = getattr(route, "dependencies", []) or []
+        dependencies = getattr(route_context, "dependencies", []) or []
         calls = [getattr(dep, "dependency", None) for dep in dependencies]
         if not any(isinstance(call, RateLimitDependency) for call in calls):
             unlimited.append(path)


### PR DESCRIPTION
Re-opening against `development` — the original PR #27 was accidentally opened and merged against `main` (this repo's GitHub default branch) instead of `development`, due to a missing --base flag. That accidental merge into main has been reverted (main is back to its pre-incident state). This PR carries the same, already-verified fix for #25 onto the branch it always should have targeted.