### PR TITLE
fix(agent): capture real codex session id and fix resume command (#32, #33)

### DIFF
--- a/agent/codex_bridge_agent/codex_runner.py
+++ b/agent/codex_bridge_agent/codex_runner.py
@@ -251,14 +251,20 @@ class CodexRunner:
         continue_session_id: str | None,
     ) -> list[str]:
         if continue_session_id:
+            # `codex exec resume` (unlike `codex exec`) has no `-C`/`--cd` flag at
+            # all — confirmed via `codex exec resume --help` against the real CLI
+            # (issue #33); passing it makes clap reject the whole command with exit
+            # code 2 before anything runs. `resume` instead scopes/finds sessions by
+            # the process's actual cwd (see its `--all` flag: "Show all sessions
+            # (disables cwd filtering)"), which `run_task` already sets via
+            # `create_subprocess_exec(..., cwd=str(project_root))` below — so the
+            # project directory still reaches it, just not as a flag.
             return [
                 self.settings.codex_bin,
                 "exec",
                 "resume",
                 continue_session_id,
                 "--json",
-                "-C",
-                str(project_root),
                 "-o",
                 str(output_path),
                 instruction,
@@ -293,15 +299,28 @@ class CodexRunner:
         return tests[:50]
 
     def _find_session_id(self, raw_events: list[dict]) -> str | None:
+        """Looks for the resumable session id across every JSON event shape we know of.
+
+        `thread_id` is the real one: codex-cli 0.147.0's `codex exec --json` opens
+        every stream with `{"type": "thread.started", "thread_id": "<uuid>"}`
+        (issue #32, confirmed by driving the real CLI in
+        `tests/integration/test_codex_runner_real_process.py`). The other four keys
+        (`session_id`/`sessionId`/`conversation_id`/`conversationId`) were never
+        observed against a real CLI version — they predate the real-process test and
+        are kept as defensive fallbacks in case an older/newer `codex` build, or a
+        differently-configured one, emits one of those shapes instead. `thread_id` is
+        checked first since it is the one shape known to actually occur.
+        """
+        keys = ("thread_id", "session_id", "sessionId", "conversation_id", "conversationId")
         for event in raw_events:
             if isinstance(event, dict):
-                for key in ("session_id", "sessionId", "conversation_id", "conversationId"):
+                for key in keys:
                     value = event.get(key)
                     if isinstance(value, str) and value:
                         return value
                 payload = event.get("payload")
                 if isinstance(payload, dict):
-                    for key in ("session_id", "sessionId", "conversation_id", "conversationId"):
+                    for key in keys:
                         value = payload.get(key)
                         if isinstance(value, str) and value:
                             return value

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -882,3 +882,57 @@ binary; full suite otherwise unchanged (507 passed / 2 pre-existing failures in
 `tests/integration/test_probes.py`, reproduced identically on `origin/development`
 before this change — a local `fastapi==0.128.8` short of the `>=0.141.1` the repo
 now requires, unrelated to this work).
+
+## 2026-08-21 — #32, #33: fixing the two real-CLI mismatches PR #31 found, not just documenting them
+
+PR #31's real-process test found two bugs against real `codex-cli 0.147.0` but
+didn't fix them (by design — that PR's job was proving the gap existed). This
+work (`WK-20260821-fix-session-resume`) is the follow-through: fix both, then
+rewrite the two real-process tests to assert the FIXED behavior end-to-end
+against the real CLI, not just that the old bug reproduces. A test that keeps
+asserting "this is broken" after the code is fixed would fail forever and
+teach nothing — it had to become a test that the feature works.
+
+- `_find_session_id` (`agent/codex_bridge_agent/codex_runner.py`) now checks
+  `thread_id` first, alongside the original four keys (kept as defensive
+  fallbacks — never confirmed against any real CLI version, but no reason to
+  assume they're dead weight either). One-line fix once the real key was known;
+  the entire remaining cost was already paid by PR #31 pinning the exact real
+  event shape (`{"type":"thread.started","thread_id":"<uuid>"}`) in a test.
+- `_build_command`'s resume branch no longer passes `-C <project_root>`. Read
+  `codex exec resume --help` directly (not `codex exec --help`, which does list
+  `-C` — the two subcommands' flag sets are not the same, that mismatch is
+  exactly what caused the original bug): `resume` takes no `-C`/`--cd` at all.
+  The working directory still reaches the real CLI, just not as a flag —
+  `run_task` already spawns the subprocess with `cwd=str(project_root)`, and
+  `resume`'s own `--all` flag ("Show all sessions (disables cwd filtering)")
+  confirms `resume` locates/filters sessions by the process's actual cwd.
+- Rewrote `test_run_task_resume_branch_is_rejected_by_the_real_cli` into
+  `test_run_task_resume_actually_resumes_the_real_session`: a real first
+  `run_task` call captures a real `thread_id`-derived `codex_session_id`, a real
+  second call resumes it, and the real CLI accepts the command and completes —
+  exercising both fixes together, since resume was untestable end-to-end until
+  both landed (no session id to resume with, and a command the CLI would have
+  rejected outright even with one). `test_run_task_drives_a_real_codex_process_
+  end_to_end` now asserts `codex_session_id == first_event["thread_id"]` instead
+  of asserting it stays `None`.
+
+Verified against the real installed CLI, not just the fakes:
+`RUN_REAL_CODEX_TESTS=1 python3 -m pytest tests/integration/
+test_codex_runner_real_process.py -v` — both tests pass (65.5s). Full suite:
+`python3 -m pytest tests/ -q` (contract tests excluded, pre-existing environment
+gap, see below) — 510 passed, 2 skipped, same 2 pre-existing failures in
+`tests/integration/test_probes.py` (the `fastapi==0.128.8` vs `>=0.141.1` gap
+from the entry above — untouched by this work, reproduces identically before
+and after). `tests/unit/test_codex_runner.py` (the fake-based contract suite)
+still 13/13 — it never exercised `_build_command`'s resume branch or
+`_find_session_id` in the first place, so no fake-vs-real contract to
+reconcile.
+
+Action next time: when a real-process test finds and pins a bug (PR #31's
+model), fixing the bug is a separate, trackable follow-up (#32/#33 here) — but
+that follow-up must rewrite the pinning test's assertions to match the fixed
+behavior, not just patch the production code and leave a test that now asserts
+the wrong thing. A green suite with a stale "prove it's broken" assertion
+still passing is a silent trap: it means either the fix didn't really land, or
+the test stopped testing anything real.

--- a/tests/integration/test_codex_runner_real_process.py
+++ b/tests/integration/test_codex_runner_real_process.py
@@ -9,28 +9,32 @@ the real CLI does. This file closes exactly that gap by driving one real `codex 
 (codex-cli 0.147.0) subprocess end-to-end through `CodexRunner.run_task`, against a
 disposable scratch git repo (never a real project, never given a remote).
 
-Two real, reproducible mismatches between what `codex_runner.py` assumes and what the
+Two real, reproducible mismatches between what `codex_runner.py` assumed and what the
 installed `codex` 0.147.0 binary actually does came out of writing this file — both
-demonstrated live below, not inferred from reading the code:
+demonstrated live below, not inferred from reading the code. Both are now FIXED
+(issues #32 and #33); the tests below assert the fixed behavior against the real CLI,
+not just that the bugs exist.
 
-1. `CodexRunner._find_session_id` looks for `session_id`, `sessionId`,
-   `conversation_id` or `conversationId`, top-level or nested under `event["payload"]`.
-   Real `codex exec --json` opens the stream with
-   `{"type": "thread.started", "thread_id": "<uuid>"}` — the id lives under a key
-   `_find_session_id` never checks. Every real run's `codex_session_id` comes back
-   `None`; `test_run_task_drives_a_real_codex_process_end_to_end` below asserts this
-   directly against real output, not a guess.
+1. (issue #32, fixed) `CodexRunner._find_session_id` used to look only for
+   `session_id`, `sessionId`, `conversation_id` or `conversationId`, top-level or
+   nested under `event["payload"]`. Real `codex exec --json` opens the stream with
+   `{"type": "thread.started", "thread_id": "<uuid>"}` — a key `_find_session_id`
+   never checked, so `codex_session_id` always came back `None`.
+   `_find_session_id` now also checks `thread_id` (checked first, since it's the
+   shape actually observed); `test_run_task_drives_a_real_codex_process_end_to_end`
+   below asserts `codex_session_id` is populated from a real run.
 
-2. The resume branch of `_build_command` builds
+2. (issue #33, fixed) The resume branch of `_build_command` used to build
    `[codex, exec, resume, <id>, --json, -C, <dir>, -o, <file>, instruction]`. The real
    `codex exec resume` subcommand does not accept `-C`/`--cd` at all (confirmed via
-   `codex exec resume --help`); it rejects the flag with exit code 2 before running
-   anything: `error: unexpected argument '-C' found`.
-   `test_run_task_resume_branch_is_rejected_by_the_real_cli` below reproduces that
-   exit code through `run_task` itself, unmodified. Combined with (1) — no session id
-   is ever captured to resume with in the first place — session continuation
-   (`continue_codex_session` on the gateway side) cannot work against this CLI version
-   today, in two independent ways.
+   `codex exec resume --help`); it used to reject the flag with exit code 2 before
+   running anything: `error: unexpected argument '-C' found`. `_build_command` no
+   longer passes `-C` in the resume branch — the project directory still reaches the
+   subprocess via `cwd=` on `create_subprocess_exec`, which is how `resume` itself
+   scopes sessions (see its `--all` flag: "disables cwd filtering").
+   `test_run_task_resume_actually_resumes_the_real_session` below drives a real
+   resume, end to end, using the session id captured from a real first run — both
+   bugs had to be fixed together for that to be possible at all.
 
 A third finding, not asserted as a hard regression here because it depends on the
 executor host's local trust registry rather than on `codex_runner.py` itself:
@@ -141,12 +145,12 @@ async def test_run_task_drives_a_real_codex_process_end_to_end(tmp_path: Path) -
         "the thread.started event"
     )
 
-    # Finding (1): _find_session_id never looks for 'thread_id', so it can never
-    # find the id codex-cli actually emits. If this assertion ever starts
-    # failing, _find_session_id has been fixed to read 'thread_id' (or codex
-    # changed its event shape again) — update this test and the docstring above
-    # together, don't just delete the assertion.
-    assert result["codex_session_id"] is None
+    # Finding (1), fixed: _find_session_id now reads 'thread_id' off the real
+    # thread.started event, so a real run's session id is actually captured. If
+    # this assertion ever starts failing, either _find_session_id regressed or
+    # codex changed its event shape again — update this test and the docstring
+    # above together, don't just delete the assertion.
+    assert result["codex_session_id"] == first_event["thread_id"]
 
     # Finding (3, structural half): the scratch repo is not pre-registered as
     # trusted anywhere, `_build_command` passes no sandbox override, and
@@ -162,27 +166,48 @@ async def test_run_task_drives_a_real_codex_process_end_to_end(tmp_path: Path) -
 
 @requires_real_codex
 @pytest.mark.asyncio
-async def test_run_task_resume_branch_is_rejected_by_the_real_cli(tmp_path: Path) -> None:
-    """Finding (2), reproduced through `run_task` itself rather than by shelling
-    out separately: the resume branch of `_build_command` includes `-C
-    <project_root>`, and the real `codex exec resume` subcommand does not accept
-    that flag. clap rejects it before any model call happens, so this is fast
-    and needs no real session id — any string reaches the same failure, because
-    the argument parser never gets far enough to look at it.
+async def test_run_task_resume_actually_resumes_the_real_session(tmp_path: Path) -> None:
+    """Finding (2), now fixed, driven through `run_task` itself end to end:
+    `_build_command`'s resume branch no longer passes `-C <project_root>`, so
+    `codex exec resume <id> --json -o <file> <instruction>` is what actually
+    reaches the real CLI, and the real CLI accepts it.
+
+    This needs a real session id to resume with, which needs finding (1) fixed
+    too (`_find_session_id` reading `thread_id`) — so this test exercises both
+    fixes together: a first real run captures a resumable `codex_session_id`,
+    then a second real run resumes it and the real CLI actually accepts the
+    command instead of rejecting it with exit code 2 before doing anything.
     """
     _init_scratch_repo(tmp_path)
-
     runner = CodexRunner(AgentSettings())
-    result = await runner.run_task(
-        task_id="real-codex-resume-smoke-1",
+
+    first = await runner.run_task(
+        task_id="real-codex-resume-smoke-first",
+        project_root=tmp_path,
+        instruction="Say the word PING and do nothing else.",
+        timeout_seconds=60,
+        continue_session_id=None,
+        send_log=_collect_logs,
+    )
+    assert first["return_code"] == 0
+    session_id = first["codex_session_id"]
+    assert session_id, "first run must capture a resumable session id before resume can be tested"
+
+    second = await runner.run_task(
+        task_id="real-codex-resume-smoke-second",
         project_root=tmp_path,
         instruction="Say the word PONG and do nothing else.",
-        timeout_seconds=30,
-        continue_session_id="00000000-0000-0000-0000-000000000000",
+        timeout_seconds=60,
+        continue_session_id=session_id,
         send_log=_collect_logs,
     )
 
-    assert result["return_code"] == 2
-    assert result["final_state"] == "failed"
-    assert "-C" in result["command"]
-    assert result["command"][2] == "resume"
+    # The real CLI no longer rejects the command outright (it used to, exit code
+    # 2, before this fix — see the docstring above and issue #33).
+    assert second["return_code"] == 0
+    assert second["final_state"] == "completed"
+    assert second["command"][2] == "resume"
+    assert second["command"][3] == session_id
+    assert "-C" not in second["command"], (
+        "codex exec resume does not accept -C/--cd; _build_command must not pass it"
+    )


### PR DESCRIPTION
## Summary

Fixes both bugs found by PR #31's real-`codex exec` integration test (driving the actual installed `codex-cli 0.147.0`, not a fake) — both block real session continuation.

- **#32** — `_find_session_id` in `agent/codex_bridge_agent/codex_runner.py` never checked for the real event shape. `codex exec --json` opens the stream with `{"type":"thread.started","thread_id":"<uuid>"}`, a key none of the original four checks (`session_id`/`sessionId`/`conversation_id`/`conversationId`) matched, so `codex_session_id` was always `None` after a real run. Now checks `thread_id` first; the original four keys are kept as defensive fallbacks since they were never confirmed against any real CLI version but there's no evidence they're dead either.
- **#33** — `_build_command`'s resume branch included `-C <project_root>`, but `codex exec resume` does not accept `-C`/`--cd` at all — confirmed directly via `codex exec resume --help` against the real CLI (`codex exec --help` *does* list `-C`; the two subcommands' flag sets differ, which is exactly what caused this bug). The real CLI rejected the command outright, exit code 2, before doing anything. Dropped `-C` from the resume branch — the working directory still reaches the CLI via the subprocess `cwd=` that `run_task` already sets, which is how `resume` itself scopes/finds sessions (its `--all` flag: "Show all sessions (disables cwd filtering)").

Both bugs had to be fixed together for resume to be testable end-to-end at all — no session id was ever captured, and even a valid one would have hit a command the CLI rejects.

## Real CLI evidence

Read directly, not assumed:

```
$ codex exec --help        # lists -C, --cd <DIR>
$ codex exec resume --help # no -C/--cd anywhere in its options
```

## Tests

Rewrote the two real-process tests added in PR #31 (`tests/integration/test_codex_runner_real_process.py`) to assert the FIXED behavior against the real CLI, not just reproduce the old bugs:

- `test_run_task_drives_a_real_codex_process_end_to_end` now asserts `codex_session_id == first_event["thread_id"]` (was asserting it stays `None`).
- `test_run_task_resume_branch_is_rejected_by_the_real_cli` → renamed/rewritten to `test_run_task_resume_actually_resumes_the_real_session`: drives a real first run to capture a session id, then a real resume of it, asserting `return_code == 0`, `final_state == "completed"`, and no `-C` in the built resume command.

Confirmed against the real installed `codex-cli 0.147.0`:

```
RUN_REAL_CODEX_TESTS=1 python3 -m pytest tests/integration/test_codex_runner_real_process.py -v
# 2 passed in 65.51s
```

Full suite (fakes-based unit tests included, unaffected — `tests/unit/test_codex_runner.py` never exercised `_build_command`'s resume branch or `_find_session_id`, so no contract to reconcile):

```
python3 -m pytest tests/ -q   # (contract tests excluded, see below)
# 510 passed, 2 skipped
```

Two pre-existing failures in `tests/integration/test_probes.py` and the two `tests/contract/*` collection errors are a local environment gap (`fastapi==0.128.8` vs the repo's required `>=0.141.1`, missing `iter_route_contexts`) — already documented in `docs/napkin-lessons.md`, reproduces identically on `origin/development` before this change, unrelated to this work.

Updated `docs/napkin-lessons.md` with a new entry for this fix.

## Test plan

- [x] `RUN_REAL_CODEX_TESTS=1 python3 -m pytest tests/integration/test_codex_runner_real_process.py -v` — 2 passed, against the real installed CLI
- [x] `python3 -m pytest tests/unit/test_codex_runner.py -v` — 13 passed (fake-based contract suite unaffected)
- [x] `python3 -m pytest tests/ -q` (contract dir excluded) — 510 passed, 2 skipped, 2 pre-existing unrelated failures