### PR TITLE
feat(gh-36): add an optional reason to mission cancellation

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -737,6 +737,19 @@ reads, same as sessions' `stop`. This is issue #7's acceptance criterion
 ("destructive commands require authenticated actor context and are
 audited").
 
+### An optional cancel reason (issue #36)
+
+`POST .../{id}/cancel`'s body may carry an optional `reason` (free text, up
+to 4000 chars) — the operator-typed explanation CodexBridgeMobile's cancel
+dialog already collects and, before this, had nowhere to send. It is not a
+new column on `TaskModel`: there is no `Mission.cancelReason` field, only the
+`reason` this endpoint's own `task.stopped_by_actor` audit event now carries,
+the same way `task.decision_resolved_by_actor` already carries a decision's
+resolution reason. The mission's timeline (`GET .../{id}/timeline`) surfaces
+it in the cancellation entry's summary when present. Omitting `reason`, or
+the body entirely, behaves exactly as before — this is purely additive
+(contract `1.5.0` → `1.6.0`).
+
 ### State-transition validation
 
 `cancel` refuses with `409 conflict` outside `CANCELLABLE`, which is

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -728,6 +728,17 @@ independent implementations (concurrency, idempotency and audit each written
 once per router) rather than one sharing a helper, so that this issue does
 not touch `gateway/app/api/routes/sessions.py`'s already-tested code path.
 
+**Issue #36's `reason` is a missions-door-only addition, not shared by this
+lock.** `/sessions/{id}/stop` still writes `task.stopped_by_actor` with no
+`reason` key at all — the two doors are no longer identical, only
+"same event type, same row." A client that only ever cancels through
+`/sessions` has nowhere to send an operator-typed reason today; issue #36's
+own scope (`gh issue view 36`) names only the missions endpoint and
+CodexBridgeMobile's mission-control cancel dialog, so extending `/stop` to
+match was left out rather than folded in here. If a session-vocabulary
+cancel flow ever needs the same field, that is a new issue against
+`routes/sessions.py`, not an assumption this section should still make.
+
 ### Destructive commands are authenticated and audited
 
 `cancel` requires `require_action(permissions.MISSIONS_CANCEL)` — an

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.5.0
+  version: 1.6.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -1412,6 +1412,11 @@ paths:
         carries `executorNotified: false` — nothing replays `task.cancel` on
         reconnect (issue #17), so the run may continue while the mission
         reads as cancelled.
+
+        `reason` (issue #36) is optional free text — an operator-typed
+        explanation for the cancellation. It has no dedicated field on
+        `Mission`; it is recorded on the mission's timeline the same way
+        a decision's resolution reason already is.
       security:
         - bearerAuth: []
       parameters:
@@ -1422,6 +1427,17 @@ paths:
             $ref: '#/components/schemas/Id'
         - $ref: '#/components/parameters/IfMatch'
         - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  maxLength: 4000
+                  description: Optional. Recorded on the mission's timeline.
       responses:
         '200':
           description: The mission after cancellation.

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -11,7 +11,6 @@
 
 ## Governance
 
-- `AGENTS.md`
 - `docs/required-reading.md`
 - `docs/project-rules.md`
 - `docs/software-overview.md`

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,16 +1,17 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-08-21 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge/.claude/worktrees/agent-a0b0474577bded53e`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge/.claude/worktrees/agent-a0b0474577bded53e map`
+> Generated: 2026-08-22 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge map`
 
 ## Summary
 
-- 94 file(s) · 841 symbol(s) indexed
-- Languages: config (2), python (90), shell (2)
+- 95 file(s) · 865 symbol(s) indexed
+- Languages: config (2), python (91), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
 
+- `AGENTS.md`
 - `docs/required-reading.md`
 - `docs/project-rules.md`
 - `docs/software-overview.md`
@@ -119,6 +120,7 @@ tests/
     test_agent_ws_handshake.py  — "The `/agent/ws` handshake stops carrying the token in the URL — issue #15."
     test_api_conventions.py  — "Representative-endpoint compliance for the cross-cutting API rules (issue #12)."
     test_auth.py  — "The mobile credential lifecycle — issue #4."
+    test_codex_runner_real_process.py  — "CodexRunner against a REAL `codex` subprocess — not the fake used everywhere else."
     test_conversations.py  — "Conversations and contextual messaging — issue #10."
     test_decisions.py  — "Operational decisions — issue #6."
     test_epics_issues.py  — "Epics and issues — issue #8."
@@ -329,10 +331,11 @@ tests/
 
 > Missions: the mission-control view of the same run Sessions exposes — issue #7.
 
+- **`MissionCancelRequest`** *(class)* — "Issue #36: an operator-typed reason has nowhere to go without this."
 - `list_missions(response, project_id, stage, state, risk, blocked, cursor, limit, principal, session)` *(async function)* — "Missions the caller may see, newest first."
 - `get_mission(mission_id, response, principal, session)` *(async function)*
 - `get_mission_timeline(mission_id, response, cursor, limit, principal, session)` *(async function)* — "The mission's recorded events, oldest first — the order a narrative reads in."
-- `cancel_mission(mission_id, response, if_match, idempotency_key, principal, session)` *(async function)* — "Cancel a mission that is queued, waiting, running or awaiting approval."
+- `cancel_mission(mission_id, response, if_match, idempotency_key, body, principal, session)` *(async function)* — "Cancel a mission that is queued, waiting, running or awaiting approval."
 - `explain_mission(mission_id, principal, session)` *(async function)* — "A structured account of a mission's current state, assembled server-side."
 
 ### `gateway/app/api/routes/probes.py`
@@ -523,6 +526,7 @@ tests/
   - `unregister(self, executor_id)` *(async method)*
   - `send(self, executor_id, envelope)` *(async method)*
   - `dispatch_next(self, executor_id)` *(async method)*
+  - `dispatch_available(self, executor_id)` *(async method)* — "Dispatches the next queued/waiting task to `executor_id`, if one is"
   - `mark_task_finished(self, executor_id, task_id)` *(async method)* — "Releases the slot `task_id` held and, if the executor is still"
 - `hub_envelope(executor_id, message_type, payload)` — "Build a message for an executor."
 
@@ -723,7 +727,7 @@ tests/
 
 > The `/agent/ws` handshake stops carrying the token in the URL — issue #15.
 
-- `client()`
+- `client(monkeypatch)` *(async function)* — "A real app, but wired to its own isolated in-memory database."
 - `test_a_handshake_with_no_credential_is_refused(client)`
 - `test_refusing_an_anonymous_handshake_touches_no_executor_record(client, monkeypatch)` — "4401 must be decided before the database, not after a lookup."
 - `test_the_header_is_bound_and_reaches_the_registry_check(client)` — "An unknown executor authenticating by header gets 4404, not 4401."
@@ -846,6 +850,13 @@ tests/
 - `test_the_administrative_action_describes_what_the_list_endpoint_does(api)` *(async function)* — "`sessions.readAllProjects` is administrative because it crosses projects."
 - `test_the_administrative_action_describes_what_the_missions_list_endpoint_does(api)` *(async function)* — "`missions.readAllProjects` mirrors `sessions.readAllProjects` — same widening."
 
+### `tests/integration/test_codex_runner_real_process.py`
+
+> CodexRunner against a REAL `codex` subprocess — not the fake used everywhere else.
+
+- `test_run_task_drives_a_real_codex_process_end_to_end(tmp_path)` *(async function)* — "A real `codex exec --json -C <dir> -o <file> <instruction>` subprocess,"
+- `test_run_task_resume_actually_resumes_the_real_session(tmp_path)` *(async function)* — "Finding (2), now fixed, driven through `run_task` itself end to end:"
+
 ### `tests/integration/test_conversations.py`
 
 > Conversations and contextual messaging — issue #10.
@@ -872,6 +883,7 @@ tests/
 - `test_a_retried_conversation_create_does_not_create_a_second_conversation(api)` *(async function)*
 - `test_post_message_stores_markdown_and_attachments_verbatim(api)` *(async function)*
 - `test_post_message_rejects_an_empty_body(api)` *(async function)*
+- `test_post_message_rejects_an_oversized_attachment_id(api)` *(async function)* — "`MAX_ATTACHMENT_ID_LENGTH` (255) must be enforced, same as its three"
 - `test_a_retried_message_post_does_not_create_a_second_message(api)` *(async function)* — "Message creation is idempotent for offline retries — the acceptance criterion."
 - `test_the_same_key_with_a_different_body_is_a_conflict(api)` *(async function)* — "Reusing a key for a different payload is a client bug, not a silent replay."
 - `test_a_message_without_an_idempotency_key_is_never_deduplicated(api)` *(async function)* — "No key means no replay protection — each call is a genuinely new message."
@@ -917,6 +929,12 @@ tests/
 - `test_approving_an_already_resolved_decision_is_a_conflict(api)` *(async function)*
 - `test_a_retried_approve_replays_instead_of_acting_twice(api)` *(async function)*
 - `test_approve_records_the_deciding_actor(api)` *(async function)*
+- `test_approving_dispatches_to_a_connected_idle_executor(api)` *(async function)*
+- `test_approve_response_revision_matches_the_post_dispatch_task_after_same_request_dispatch(api)` *(async function)* — "Council round-1 finding on this issue: `_resolve` fetches `updated`"
+- `test_approving_leaves_the_task_waiting_when_the_executor_is_offline(api)` *(async function)* — "No regression on the pre-existing (disconnected) case: `api.hub` has"
+- `test_approving_when_the_executor_is_at_capacity_does_not_bypass_the_concurrency_gate(api)` *(async function)*
+- `test_reject_never_dispatches(api)` *(async function)*
+- `test_request_revision_never_dispatches(api)` *(async function)*
 - `test_reject_requires_a_non_empty_reason(api)` *(async function)*
 - `test_reject_with_no_body_is_refused(api)` *(async function)*
 - `test_rejecting_cancels_the_underlying_session(api)` *(async function)*
@@ -1010,6 +1028,11 @@ tests/
 - `test_a_disconnected_executor_does_not_block_cancel(api)` *(async function)*
 - `test_a_retried_cancel_replays_instead_of_acting_twice(api)` *(async function)*
 - `test_cancel_is_audited_with_the_actor(api)` *(async function)* — "Destructive commands require authenticated actor context and are audited."
+- `test_cancel_accepts_no_body_exactly_as_before(api)` *(async function)* — "Issue #36 is additive: a client that sends no body at all must still work."
+- `test_cancel_records_an_operator_typed_reason(api)` *(async function)* — "Issue #36: the reason has somewhere to go, on the same audit event."
+- `test_cancel_with_no_reason_records_none(api)` *(async function)* — "No `reason` is sent — the field must not silently default to something else."
+- `test_the_cancel_reason_appears_on_the_timeline(api)` *(async function)*
+- `test_a_reused_idempotency_key_with_a_different_reason_is_a_conflict(api)` *(async function)* — "Same shape as `routes/decisions.py`'s reason-in-fingerprint: a reused key"
 - `test_cancel_releases_the_executor_slot(api)` *(async function)*
 - `test_explain_reports_mission_control_fields_alongside_evidence(api)` *(async function)*
 - `test_explain_on_a_blocked_mission_reports_it(api)` *(async function)*
@@ -1189,6 +1212,14 @@ tests/
 - `test_mcp_cancel_records_who_cancelled_it(db_session, initial_state, connect_executor, slot_was_held)` *(async function)* — "issue #17 council round 1, "the second caller": HTTP `/stop` records"
 - `test_startup_recovery_marks_running_as_lost(db_session)` *(async function)*
 - `test_startup_recovery_marks_pending_control_states_as_lost(db_session, pending_state)` *(async function)* — "council 2026-08-18, round 2, "the second caller": issue #16 added these"
+- `mcp_hub_factory()` *(async function)* — "A session factory over a fresh database, seeded like `db_session` but"
+- `test_mcp_approve_dispatches_to_a_connected_idle_executor(mcp_hub_factory)` *(async function)* — "Issue #20 asks this of the REST path specifically because the MCP"
+- `test_mcp_approve_records_the_deciding_actor(mcp_hub_factory)` *(async function)* — "Issue #19: only the generic `task.approval_decision` (written inside"
+- `test_mcp_reject_and_request_revision_do_not_dispatch(mcp_hub_factory)` *(async function)*
+- `test_mcp_continue_codex_session_succeeds_without_datetime_crash(mcp_hub_factory)` *(async function)* — "Issue #23: `continue_codex_session` forwards `parent.expires_at` —"
+- `test_mcp_continue_codex_session_dispatches_to_a_connected_idle_executor(mcp_hub_factory)` *(async function)* — "Issue #24: unlike its sibling `submit_codex_task` (same file), this"
+- `test_mcp_continue_codex_session_leaves_task_queued_when_the_executor_is_offline(mcp_hub_factory)` *(async function)* — "No regression on the pre-existing (disconnected) case: an offline"
+- `test_mcp_continue_codex_session_at_capacity_does_not_dispatch(mcp_hub_factory)` *(async function)* — "A connected executor already at its concurrency limit must not be sent"
 
 ### `tests/unit/test_agent_auth.py`
 

--- a/gateway/app/api/routes/missions.py
+++ b/gateway/app/api/routes/missions.py
@@ -38,7 +38,8 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Header, Query, Response
+from fastapi import APIRouter, Body, Depends, Header, Query, Response
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.app.api import concurrency, idempotency, pagination, permissions, timestamps
@@ -67,6 +68,18 @@ MISSIONS_ENDPOINT = "/api/v1/missions"
 CANCELLABLE = STOPPABLE_TASK_STATES
 
 BLOCKED_REASON_AWAITING_APPROVAL = "awaiting_approval"
+
+
+class MissionCancelRequest(BaseModel):
+    """Issue #36: an operator-typed reason has nowhere to go without this.
+
+    Optional and defaults to no body at all (`Body(default=None)` on the
+    handler), the same shape `routes/auth.py:revoke`'s `RevokeRequest` uses —
+    an existing client that cancels with no body must keep working exactly as
+    before.
+    """
+
+    reason: str | None = Field(default=None, max_length=4000)
 
 
 def _iso(value: datetime | None) -> str | None:
@@ -273,7 +286,8 @@ def _timeline_summary(event_type: str, payload: dict) -> str:
     if event_type == "task.result":
         return "Execution finished."
     if event_type == "task.stopped_by_actor":
-        return "Cancelled by an operator."
+        reason = redact(payload.get("reason")) if payload.get("reason") else None
+        return "Cancelled by an operator." + (f" {reason}" if reason else "")
     if event_type == "task.recovered":
         state = payload.get("state") or "unknown"
         return f"Recovered after a gateway restart; marked {state}."
@@ -347,6 +361,7 @@ async def cancel_mission(
     response: Response,
     if_match: str | None = Header(default=None, alias="If-Match"),
     idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    body: MissionCancelRequest | None = Body(default=None),
     principal: AuthenticatedPrincipal = Depends(require_action(permissions.MISSIONS_CANCEL)),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
@@ -356,15 +371,28 @@ async def cancel_mission(
     protocol reason Sessions' `stop` is the only one there: see the module
     docstring. Requires `If-Match`. With `Idempotency-Key`, a retry replays
     the first response and cancels nothing twice.
+
+    `reason` (issue #36) is optional and free text, recorded on the mission's
+    timeline the same way `task.decision_resolved_by_actor` already records
+    why a decision was resolved — there is no dedicated column for it, only
+    the audit event, which is enough for an operator to see why on the
+    timeline without inventing a new piece of mission state.
     """
     from gateway.app.main import hub  # imported late: main includes this router
+
+    reason = body.reason if body else None
 
     projects = visible_projects(principal)
     task = await store.get_task_for_projects(session, mission_id, projects)
     if task is None:
         raise _not_found()
 
-    fingerprint = idempotency.fingerprint(f"cancel:{mission_id}".encode())
+    # `reason` folds into the fingerprint, same as `routes/decisions.py`'s
+    # `_resolve`: a retry with the *same* key and the *same* reason is the
+    # replay this mechanism exists for, but a caller that reuses a key with a
+    # different reason gets the `409` `idempotency.reserve` already gives a
+    # body mismatch, rather than the first reason silently winning.
+    fingerprint = idempotency.fingerprint(f"cancel:{mission_id}:{reason or ''}".encode())
     claim = None
     if idempotency_key:
         outcome = await idempotency.reserve(
@@ -410,6 +438,7 @@ async def cancel_mission(
                 "actor_email": principal.email,
                 "via": "missions_api",
                 "executor_notified": notified,
+                "reason": reason,
             },
         )
         await session.commit()

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -62,7 +62,12 @@ version_router = APIRouter()
 # 1.4.0 -> 1.5.0: `GET/POST /api/v1/conversations/**` (issue #10) — contextual
 # conversations and messaging. Additive only (new endpoints, new schemas), so
 # a minor bump per docs/api/README.md's "What is not breaking".
-API_CONTRACT_VERSION = "1.5.0"
+#
+# 1.5.0 -> 1.6.0: `POST /api/v1/missions/{missionId}/cancel` (issue #36) gains
+# an optional `reason` field on its request body, recorded on the mission's
+# timeline. Additive only (new optional field; an existing client sending no
+# body is unaffected), so another minor bump.
+API_CONTRACT_VERSION = "1.6.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a

--- a/tests/integration/test_missions.py
+++ b/tests/integration/test_missions.py
@@ -599,6 +599,101 @@ async def test_cancel_is_audited_with_the_actor(api) -> None:
     assert payload["via"] == "missions_api"
 
 
+async def test_cancel_accepts_no_body_exactly_as_before(api) -> None:
+    """Issue #36 is additive: a client that sends no body at all must still work."""
+    task = await make_task(api.factory, "p1", state="running")
+    detail = api.get(f"/api/v1/missions/{task.id}", headers=auth(ALICE_TOKEN))
+    response = api.post(
+        f"/api/v1/missions/{task.id}/cancel",
+        headers={**auth(ALICE_TOKEN), "If-Match": detail.headers["ETag"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == TaskState.CANCELLED.value
+
+
+async def test_cancel_records_an_operator_typed_reason(api) -> None:
+    """Issue #36: the reason has somewhere to go, on the same audit event."""
+    from sqlalchemy import select
+
+    from gateway.app.models.entities import AuditEventModel
+
+    task = await make_task(api.factory, "p1", state="running")
+    detail = api.get(f"/api/v1/missions/{task.id}", headers=auth(ALICE_TOKEN))
+    response = api.post(
+        f"/api/v1/missions/{task.id}/cancel",
+        headers={**auth(ALICE_TOKEN), "If-Match": detail.headers["ETag"]},
+        json={"reason": "Duplicate of another running mission."},
+    )
+    assert response.status_code == 200
+
+    async with api.factory() as s:
+        rows = (
+            await s.execute(
+                select(AuditEventModel).where(
+                    AuditEventModel.entity_id == task.id,
+                    AuditEventModel.event_type == "task.stopped_by_actor",
+                )
+            )
+        ).scalars().all()
+    assert len(rows) == 1
+    payload = json.loads(rows[0].payload_json)
+    assert payload["reason"] == "Duplicate of another running mission."
+
+
+async def test_cancel_with_no_reason_records_none(api) -> None:
+    """No `reason` is sent — the field must not silently default to something else."""
+    from sqlalchemy import select
+
+    from gateway.app.models.entities import AuditEventModel
+
+    task = await make_task(api.factory, "p1", state="running")
+    detail = api.get(f"/api/v1/missions/{task.id}", headers=auth(ALICE_TOKEN))
+    api.post(
+        f"/api/v1/missions/{task.id}/cancel",
+        headers={**auth(ALICE_TOKEN), "If-Match": detail.headers["ETag"]},
+    )
+
+    async with api.factory() as s:
+        rows = (
+            await s.execute(
+                select(AuditEventModel).where(
+                    AuditEventModel.entity_id == task.id,
+                    AuditEventModel.event_type == "task.stopped_by_actor",
+                )
+            )
+        ).scalars().all()
+    assert json.loads(rows[0].payload_json)["reason"] is None
+
+
+async def test_the_cancel_reason_appears_on_the_timeline(api) -> None:
+    task = await make_task(api.factory, "p1", state="running")
+    detail = api.get(f"/api/v1/missions/{task.id}", headers=auth(ALICE_TOKEN))
+    api.post(
+        f"/api/v1/missions/{task.id}/cancel",
+        headers={**auth(ALICE_TOKEN), "If-Match": detail.headers["ETag"]},
+        json={"reason": "Operator changed their mind."},
+    )
+
+    timeline = api.get(f"/api/v1/missions/{task.id}/timeline", headers=auth(ALICE_TOKEN)).json()
+    entry = next(item for item in timeline["items"] if item["type"] == "task.stopped_by_actor")
+    assert entry["summary"] == "Cancelled by an operator. Operator changed their mind."
+
+
+async def test_a_reused_idempotency_key_with_a_different_reason_is_a_conflict(api) -> None:
+    """Same shape as `routes/decisions.py`'s reason-in-fingerprint: a reused key
+    with a different payload is a client bug, reported rather than silently
+    dropping the second write's reason."""
+    task = await make_task(api.factory, "p1", state="running")
+    detail = api.get(f"/api/v1/missions/{task.id}", headers=auth(ALICE_TOKEN))
+    headers = {**auth(ALICE_TOKEN), "If-Match": detail.headers["ETag"], "Idempotency-Key": "k-reason"}
+
+    first = api.post(f"/api/v1/missions/{task.id}/cancel", headers=headers, json={"reason": "A"})
+    second = api.post(f"/api/v1/missions/{task.id}/cancel", headers=headers, json={"reason": "B"})
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+
+
 async def test_cancel_releases_the_executor_slot(api) -> None:
     task = await make_task(api.factory, "p1", state="running")
     api.hub.running_tasks["E1"] = {task.id}


### PR DESCRIPTION
Closes #36.

## Summary
- `POST /api/v1/missions/{id}/cancel` accepted no request body — an operator-typed cancel reason (CodexBridgeMobile's cancel dialog already collects one, per mobile PR #56) had nowhere to go.
- Added `MissionCancelRequest{reason: str | None}` as an optional `Body`, same shape `routes/auth.py:revoke`'s `RevokeRequest` uses — a client sending no body at all is unaffected, so this is purely additive.
- `reason` folds into the idempotency fingerprint (same pattern `routes/decisions.py`'s `_resolve` uses for its own `reason`), so a reused `Idempotency-Key` with a different reason answers `409` instead of the first reason silently winning.
- Recorded on the existing `task.stopped_by_actor` audit event (same event Sessions' `/stop` and this endpoint already write) the same way `task.decision_resolved_by_actor` already carries a decision's resolution reason — no new `TaskModel` column.
- Surfaced in the mission timeline's cancellation entry summary when present.
- `docs/api/codex-bridge.openapi.yaml` (`requestBody`) and `docs/api/README.md` ("Missions (issue #7)") updated. `API_CONTRACT_VERSION` bumped 1.5.0 → 1.6.0 (additive).
- `docs/codemap.md` regenerated — this branch was cut from `development` before #37 (the CI codemap-drift fix) landed, so it carries the same regen to pass `tests/contract` standalone; no functional overlap with #37's diff otherwise.

## Test plan
- [x] `pytest tests/contract -q` → 26 passed
- [x] `pytest tests/unit tests/integration -q` → 514 passed, 2 skipped (unchanged — real-`codex`-subprocess integration tests)
- [x] New tests: no-body backward compat, reason recorded on the audit event, no-reason records `None`, reason appears on the timeline summary, reused idempotency key with a different reason is a `409`