### PR TITLE
fix(gh-34): read-only sandbox default for codex exec

### DIFF
--- a/agent/codex_bridge_agent/codex_runner.py
+++ b/agent/codex_bridge_agent/codex_runner.py
@@ -18,6 +18,16 @@ from shared.security import filtered_environment, sanitize_log_line
 
 LogSender = Callable[[str, str], Awaitable[None]]
 
+# codex-cli 0.147.0's `codex exec -s/--sandbox <MODE>` (confirmed via
+# `codex exec --help`, issue #34): `read-only`, `workspace-write`,
+# `danger-full-access`. This runner only ever emits the first two — the third
+# is a real, accepted value that this codebase must never pass regardless of
+# caller input, so it is deliberately left out of the allowed set rather than
+# merely undocumented.
+SANDBOX_READ_ONLY = "read-only"
+SANDBOX_WORKSPACE_WRITE = "workspace-write"
+_ALLOWED_SANDBOX_MODES = frozenset({SANDBOX_READ_ONLY, SANDBOX_WORKSPACE_WRITE})
+
 
 @dataclass
 class RunningTask:
@@ -123,7 +133,33 @@ class CodexRunner:
         timeout_seconds: int,
         continue_session_id: str | None,
         send_log: LogSender,
+        sandbox: str = SANDBOX_READ_ONLY,
     ) -> dict:
+        """Issue #34: `sandbox` is now always explicit, never implicit.
+
+        Before this, `_build_command` passed no `-s`/`--sandbox` at all, so
+        whether a task could actually write depended on whether the executor
+        host's `~/.codex/config.toml` already marked `project_root`
+        `trust_level = "trusted"` — invisible here, and untouched by anything
+        `codex_runner.py` itself does. A freshly-registered project ran fully
+        read-only: exit 0, `TaskState.COMPLETED`, `no_changes: true`, no error
+        anywhere (confirmed live against codex-cli 0.147.0,
+        `docs/napkin-lessons.md` 2026-08-21).
+
+        The default here (`read-only`) is deliberately the *safe* one — a
+        caller that does not think about sandboxing at all gets the
+        restrictive behavior, not the permissive one. `AgentService._handle_dispatch`
+        is the only caller in this codebase and always passes an explicit
+        value derived from the task's policy level
+        (`shared.policy.policy_level_for_mode`), so this default is what a
+        test or a future caller gets for saying nothing — never what a real
+        dispatched task gets by omission.
+        """
+        if sandbox not in _ALLOWED_SANDBOX_MODES:
+            raise ValueError(
+                f"sandbox must be one of {sorted(_ALLOWED_SANDBOX_MODES)}, got {sandbox!r} "
+                "(danger-full-access is a real codex-cli value this runner refuses to pass)"
+            )
         pre = await collect_git_snapshot(project_root, self.settings.max_diff_chars)
         start = time.monotonic()
         deadline = start + timeout_seconds
@@ -157,7 +193,7 @@ class CodexRunner:
                 remaining = max(1, int(deadline - time.monotonic()))
                 with NamedTemporaryFile(prefix="codex-last-message-", suffix=".txt", delete=False) as handle:
                     output_path = Path(handle.name)
-                cmd = self._build_command(project_root, instruction, output_path, continue_session_id)
+                cmd = self._build_command(project_root, instruction, output_path, continue_session_id, sandbox)
                 process = await asyncio.create_subprocess_exec(
                     *cmd,
                     cwd=str(project_root),
@@ -249,6 +285,7 @@ class CodexRunner:
         instruction: str,
         output_path: Path,
         continue_session_id: str | None,
+        sandbox: str,
     ) -> list[str]:
         if continue_session_id:
             # `codex exec resume` (unlike `codex exec`) has no `-C`/`--cd` flag at
@@ -259,6 +296,15 @@ class CodexRunner:
             # (disables cwd filtering)"), which `run_task` already sets via
             # `create_subprocess_exec(..., cwd=str(project_root))` below — so the
             # project directory still reaches it, just not as a flag.
+            #
+            # Same check for `-s`/`--sandbox` (issue #34): `codex exec resume
+            # --help` lists no such option either — confirmed against codex-cli
+            # 0.147.0, the same version issue #33 was confirmed against. `sandbox`
+            # is accepted here (not ignored) so a caller does not have to special-
+            # case resume, but it deliberately does not reach the command; a
+            # resumed session's sandbox is whatever the original `codex exec`
+            # call that created it established, which this codebase does not
+            # currently have a verified way to override after the fact.
             return [
                 self.settings.codex_bin,
                 "exec",
@@ -273,6 +319,8 @@ class CodexRunner:
             self.settings.codex_bin,
             "exec",
             "--json",
+            "-s",
+            sandbox,
             "-C",
             str(project_root),
             "-o",

--- a/agent/codex_bridge_agent/config.py
+++ b/agent/codex_bridge_agent/config.py
@@ -22,6 +22,15 @@ class AgentSettings(BaseSettings):
     max_prompt_chars: int = 12000
     max_diff_chars: int = 120000
     max_result_chars: int = 200000
+    # Issue #34: a write-intending task's mode (edit/implement) is the normal
+    # way to opt into `-s workspace-write` (see `service.py:_handle_dispatch`).
+    # This is the machine-level kill switch beneath that: an operator who wants
+    # one specific executor to never write, regardless of what any task asks
+    # for, sets `CODEX_BRIDGE_AGENT_ALLOW_WORKSPACE_WRITE=false` and every
+    # dispatch on that host runs `-s read-only` no matter its policy level —
+    # the same "last barrier on this machine" role `allowed_projects_file`
+    # already plays for project scope (`docs/software-overview.md`).
+    allow_workspace_write: bool = True
 
     model_config = SettingsConfigDict(env_prefix="CODEX_BRIDGE_AGENT_", env_file=".env")
 

--- a/agent/codex_bridge_agent/service.py
+++ b/agent/codex_bridge_agent/service.py
@@ -9,13 +9,14 @@ from uuid import uuid4
 
 import websockets
 
-from agent.codex_bridge_agent.codex_runner import CodexRunner
+from agent.codex_bridge_agent.codex_runner import SANDBOX_READ_ONLY, SANDBOX_WORKSPACE_WRITE, CodexRunner
 from agent.codex_bridge_agent.config import AgentSettings, load_agent_projects
 from shared.policy import evaluate_task_policy
 from shared.protocol import (
     EXECUTOR_TOKEN_HEADER,
     AgentEnvelope,
     AgentMessageType,
+    PolicyLevel,
     SubmitTaskRequest,
     TaskMode,
     TaskPriority,
@@ -29,6 +30,25 @@ BASE_PROMPT = (
     "Do not access parent directories, secrets, deployment targets, or other hosts. "
     "Do not push, deploy, migrate production, or modify infrastructure unless explicitly approved."
 )
+
+
+def _sandbox_for(policy_level: PolicyLevel, *, allow_workspace_write: bool) -> str:
+    """Issue #34: the sandbox `codex exec` runs a dispatched task under.
+
+    Read-only unless the task's own mode already opted into writing
+    (`PolicyLevel.CONTROLLED_WRITE`/`SENSITIVE` — see
+    `shared/policy.py:policy_level_for_mode`; a `SENSITIVE` task only reaches
+    here at all once `_handle_dispatch`'s approval gate above has let it
+    through, so by the time this runs it is exactly as write-intending as a
+    `CONTROLLED_WRITE` one). `allow_workspace_write=False` is the executor's
+    own machine-level override (`AgentSettings.allow_workspace_write`) and
+    wins regardless of what the task asked for — the same "last barrier on
+    this machine" shape `allowed_projects_file` already has for project
+    scope.
+    """
+    if policy_level == PolicyLevel.READ:
+        return SANDBOX_READ_ONLY
+    return SANDBOX_WORKSPACE_WRITE if allow_workspace_write else SANDBOX_READ_ONLY
 
 
 class AgentService:
@@ -199,6 +219,7 @@ class AgentService:
                     ).model_dump_json()
                 )
 
+            sandbox = _sandbox_for(decision.level, allow_workspace_write=self.settings.allow_workspace_write)
             try:
                 result = await self.runner.run_task(
                     task_id=task_id,
@@ -207,6 +228,7 @@ class AgentService:
                     timeout_seconds=int(envelope.payload["timeout_seconds"]),
                     continue_session_id=envelope.payload.get("continue_session_id"),
                     send_log=send_log,
+                    sandbox=sandbox,
                 )
             except Exception as exc:
                 await send_log("stderr", f"Codex execution failed before completion: {exc}")

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- 95 file(s) · 865 symbol(s) indexed
+- 95 file(s) · 876 symbol(s) indexed
 - Languages: config (2), python (91), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -159,7 +159,7 @@ tests/
   - `pause(self, task_id)` *(async method)*
   - `resume(self, task_id)` *(async method)*
   - `restart(self, task_id)` *(async method)*
-  - `run_task(self, task_id, project_root, instruction, timeout_seconds, continue_session_id, send_log)` *(async method)*
+  - `run_task(self, task_id, project_root, instruction, timeout_seconds, continue_session_id, send_log, sandbox)` *(async method)* — "Issue #34: `sandbox` is now always explicit, never implicit."
 
 ### `agent/codex_bridge_agent/config.py`
 
@@ -854,6 +854,7 @@ tests/
 > CodexRunner against a REAL `codex` subprocess — not the fake used everywhere else.
 
 - `test_run_task_drives_a_real_codex_process_end_to_end(tmp_path)` *(async function)* — "A real `codex exec --json -C <dir> -o <file> <instruction>` subprocess,"
+- `test_run_task_actually_writes_when_dispatched_with_workspace_write_sandbox(tmp_path)` *(async function)* — "The override side of finding (3): the same scratch repo, still not"
 - `test_run_task_resume_actually_resumes_the_real_session(tmp_path)` *(async function)* — "Finding (2), now fixed, driven through `run_task` itself end to end:"
 
 ### `tests/integration/test_conversations.py`
@@ -1252,6 +1253,12 @@ tests/
 - `test_cancel_of_an_unknown_task_still_acks_over_the_socket(monkeypatch)` *(async function)* — "issue #17 council round 1, "the claim auditor" / "the second caller":"
 - `test_pause_of_an_unknown_task_reports_known_false(monkeypatch)` *(async function)* — "The control-message sibling of the cancel case above (issue #17"
 - `test_handle_dispatch_forgets_the_task_only_after_the_result_is_sent(tmp_path)` *(async function)* — "finding 14 (council round 2, "the second caller"): before this fix,"
+- `test_sandbox_for_is_read_only_for_the_read_policy_level()`
+- `test_sandbox_for_is_workspace_write_for_controlled_write_and_sensitive()`
+- `test_sandbox_for_machine_override_forces_read_only_even_for_write_levels()` — "`AgentSettings.allow_workspace_write=False` is the executor's own kill"
+- `test_handle_dispatch_sends_read_only_for_a_read_mode_task(tmp_path)` *(async function)*
+- `test_handle_dispatch_sends_workspace_write_for_a_write_mode_task(tmp_path)` *(async function)*
+- `test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_path)` *(async function)* — "A write-mode task still only gets `read-only` when this executor's own"
 
 ### `tests/unit/test_apply_migrations.py`
 
@@ -1289,6 +1296,10 @@ tests/
 - `test_terminate_gracefully_resumes_a_paused_process_before_terminating()` *(async function)*
 - `test_terminate_gracefully_does_not_signal_cont_when_not_paused()` *(async function)*
 - `test_terminate_gracefully_falls_back_to_kill_if_still_stuck()` *(async function)* — "The safety net behind the SIGCONT fix: a process that does not end"
+- `test_build_command_passes_the_sandbox_flag_on_a_fresh_run()`
+- `test_build_command_workspace_write_is_also_passed_through()`
+- `test_build_command_resume_branch_never_gets_a_sandbox_flag()` — "`codex exec resume --help` lists no `-s`/`--sandbox` option (confirmed"
+- `test_run_task_refuses_a_sandbox_value_this_codebase_never_passes()` *(async function)* — "`danger-full-access` is a real, accepted `codex exec -s` value — exactly"
 
 ### `tests/unit/test_config_settings.py`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -99,18 +99,31 @@ Para um ciclo completo local, aponte o projeto de exemplo para um repositório g
 descartável criado no scratchpad da sessão. **Nunca aponte a allowlist de teste
 para um repositório real.**
 
-## Política de sandbox do `codex exec` — decisão em aberto
+## Política de sandbox do `codex exec` (issue #34, decidido em 2026-08-22)
 
-`CodexRunner.run_task` monta o comando com `--json`, `-C` e `-o` apenas. Nenhuma
-flag de sandbox ou de aprovação é passada, então o nível de escrita que o Codex
-tem dentro do projeto alvo é **o default do CLI**, herdado e não declarado.
+Decisão tomada pelo operador: `CodexRunner.run_task` agora sempre passa `-s`
+explicitamente — nunca herda o default silencioso do CLI. `read-only` é o
+padrão para uma tarefa que não pede escrita (`sandbox` não informado, ou
+`PolicyLevel.READ` — modos `analyze`/`review`/`test`); `workspace-write` é
+emitido quando `AgentService._handle_dispatch` calcula, a partir do
+`policy_level` da própria tarefa (`edit`/`implement` → `CONTROLLED_WRITE`,
+ou `SENSITIVE` já aprovado), que a tarefa pretende escrever — ver
+`shared/policy.py:policy_level_for_mode` e
+`agent/codex_bridge_agent/service.py:_sandbox_for`. `AgentSettings.
+allow_workspace_write=False` é o trava adicional no nível da máquina: um
+operador pode travar um executor específico em somente-leitura
+independentemente do que qualquer tarefa peça.
 
-O `README.md` lista `--skip-git-repo-check` e `--ephemeral` entre as capacidades
-verificadas do Codex CLI 0.145.0, e nenhuma das duas é usada.
-
-Num produto cuja função é modificar repositórios de terceiros, isso precisa ser
-escolha explícita. A decisão está pendente com o operador; até que seja tomada,
-não altere as flags do runner por conta própria.
+Antes disso, o nível de escrita do Codex dentro do projeto alvo era **o
+default do CLI**, herdado e não declarado — na prática dependia de
+`trust_level = "trusted"` já estar gravado em `~/.codex/config.toml` no host
+do executor, um estado externo, silencioso e não relacionado a nada que o
+CodexBridge decide. Uma tarefa de escrita apontada a um projeto recém
+registrado terminava com sucesso (`exit 0`, `TaskState.COMPLETED`) sem
+alterar nada — ver `docs/napkin-lessons.md`, entrada de 2026-08-21, e
+`tests/integration/test_codex_runner_real_process.py`, que agora prova as
+duas pontas (leitura bloqueia escrita; `workspace-write` explícito escreve de
+verdade) contra o CLI real.
 
 ## Antes de entregar
 

--- a/docs/software-overview.md
+++ b/docs/software-overview.md
@@ -91,6 +91,18 @@ A implementação usa apenas capacidades verificadas em `2026-07-28`:
 `codex exec [PROMPT]`, `--json`, `-C <DIR>`, `-o <FILE>`, `--skip-git-repo-check`,
 `--ephemeral`, `codex exec resume`. Nenhuma flag fora dessa lista é presumida.
 
+Verificado adicionalmente em `2026-08-22` contra `codex-cli 0.147.0` (issue #34):
+`codex exec -s/--sandbox <read-only|workspace-write|danger-full-access>`.
+`codex exec resume` **não** aceita `-s`/`--sandbox` (mesma lacuna já confirmada
+para `-C`, issue #33) — `_build_command` nunca emite a flag nesse ramo.
+`codex_runner.py` agora sempre passa `-s` explicitamente no dispatch inicial
+(nunca em branco): `read-only` por padrão, `workspace-write` apenas quando o
+`policy_level` da tarefa já indicava escrita (`edit`/`implement`) — ver
+`shared/policy.py:policy_level_for_mode`. Antes disso a escrita dependia de
+`trust_level = "trusted"` já estar gravado em `~/.codex/config.toml` no host
+do executor, um estado externo e silencioso que fazia tarefas de escrita
+"terminarem com sucesso" sem alterar nada.
+
 ## Distinção crítica para agentes
 
 O CodexBridge **é uma ferramenta cujo propósito é despachar execução para outros

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -91,8 +91,10 @@ por alcance de sistema de arquivos, `~/.gitconfig`, credential helpers do Git,
   sem chaves SSH pessoais e sem credenciais Git de escrita em repositório de
   produção — assim o que o subprocesso alcança é o mínimo que o `codex` exige
 
-A política de sandbox do `codex exec` (que hoje é o default do CLI, sem flag
-explícita) está em aberto e será decidida à parte. Ver `docs/development.md`.
+A política de sandbox do `codex exec` é explícita, não mais o default herdado
+do CLI (issue #34): `read-only` a menos que o `policy_level` da tarefa já
+indicasse escrita, com trava adicional por executor
+(`AgentSettings.allow_workspace_write`). Ver `docs/development.md`.
 
 ### Escalada local no executor
 

--- a/tests/integration/test_codex_runner_real_process.py
+++ b/tests/integration/test_codex_runner_real_process.py
@@ -9,11 +9,11 @@ the real CLI does. This file closes exactly that gap by driving one real `codex 
 (codex-cli 0.147.0) subprocess end-to-end through `CodexRunner.run_task`, against a
 disposable scratch git repo (never a real project, never given a remote).
 
-Two real, reproducible mismatches between what `codex_runner.py` assumed and what the
-installed `codex` 0.147.0 binary actually does came out of writing this file — both
-demonstrated live below, not inferred from reading the code. Both are now FIXED
-(issues #32 and #33); the tests below assert the fixed behavior against the real CLI,
-not just that the bugs exist.
+Three real, reproducible mismatches between what `codex_runner.py` assumed and what
+the installed `codex` 0.147.0 binary actually does came out of this file — all three
+demonstrated live below, not inferred from reading the code. All three are now FIXED
+(issues #32, #33 and #34); the tests below assert the fixed behavior against the real
+CLI, not just that the bugs exist.
 
 1. (issue #32, fixed) `CodexRunner._find_session_id` used to look only for
    `session_id`, `sessionId`, `conversation_id` or `conversationId`, top-level or
@@ -36,20 +36,20 @@ not just that the bugs exist.
    resume, end to end, using the session id captured from a real first run — both
    bugs had to be fixed together for that to be possible at all.
 
-A third finding, not asserted as a hard regression here because it depends on the
-executor host's local trust registry rather than on `codex_runner.py` itself:
-`_build_command` never passes `-s`/`--sandbox` (or any approval override), and
-`codex exec`'s default sandbox is read-only with approvals disabled in non-interactive
-mode. Writes only succeed for a project directory codex has *already* marked
-`trust_level = "trusted"` in `~/.codex/config.toml` on the machine running the agent.
-A freshly-registered project — exactly the scratch repo this test creates — runs
-fully read-only: exit 0, `TaskState.COMPLETED`, `no_changes: True`, and the model's
-own last-message explaining it could not write. `test_run_task_drives_a_real_codex_process_end_to_end`
-asserts the structural half of that (`no_changes is True`, the file is byte-identical
-before/after) without asserting on the model's prose, which is not stable across
-runs. See `docs/napkin-lessons.md` for the full writeup, including the direct
-`codex exec -s workspace-write ...` run that confirms this diagnosis (a pre-trusted
-or explicitly sandboxed directory does receive the edit).
+3. (issue #34, fixed) `_build_command` used to pass no `-s`/`--sandbox` at all, so
+   whether a task could write depended entirely on whether the executor host's
+   `~/.codex/config.toml` already marked the project directory
+   `trust_level = "trusted"` — invisible to `codex_runner.py`, and untouched by
+   anything it does. A freshly-registered project ran fully read-only: exit 0,
+   `TaskState.COMPLETED`, `no_changes: True`, no error anywhere. `run_task` now
+   takes an explicit `sandbox` argument (default `"read-only"`, the safe one for
+   a caller that says nothing) and always passes `-s <sandbox>` itself, so this
+   no longer depends on the host's local trust registry at all.
+   `test_run_task_drives_a_real_codex_process_end_to_end` below still exercises
+   the (now deliberate, not accidental) read-only default;
+   `test_run_task_actually_writes_when_dispatched_with_workspace_write_sandbox`
+   is new and proves the override side: the same scratch repo, explicitly
+   sandboxed `workspace-write`, really does receive the edit.
 
 Gated behind `RUN_REAL_CODEX_TESTS=1` (and the `codex` binary being on PATH) so the
 default `pytest` run — and CI, which has neither the binary nor a logged-in
@@ -152,16 +152,63 @@ async def test_run_task_drives_a_real_codex_process_end_to_end(tmp_path: Path) -
     # above together, don't just delete the assertion.
     assert result["codex_session_id"] == first_event["thread_id"]
 
-    # Finding (3, structural half): the scratch repo is not pre-registered as
-    # trusted anywhere, `_build_command` passes no sandbox override, and
-    # codex exec's non-interactive default is read-only with approvals
-    # disabled — so nothing was actually written, even though the process
-    # reported success. Assert on the file content and the runner's own diff,
-    # not on the model's prose (which is not byte-stable across runs).
+    # Finding (3), fixed, now exercised on purpose rather than by accident:
+    # this call passes no `sandbox=`, so `run_task`'s own default
+    # (`SANDBOX_READ_ONLY`) applies and `_build_command` sends `-s read-only`
+    # explicitly — the scratch repo's trust status in `~/.codex/config.toml`
+    # (there is none) no longer matters at all. Assert on the file content and
+    # the runner's own diff, not on the model's prose (which is not
+    # byte-stable across runs).
     after = (tmp_path / "README.md").read_text(encoding="utf-8")
     assert after == before
     assert result["no_changes"] is True
     assert result["pre_git"]["diff"] == result["post_git"]["diff"] == ""
+    assert result["command"][result["command"].index("-s") + 1] == "read-only"
+
+
+@requires_real_codex
+@pytest.mark.asyncio
+async def test_run_task_actually_writes_when_dispatched_with_workspace_write_sandbox(tmp_path: Path) -> None:
+    """The override side of finding (3): the same scratch repo, still not
+    trusted anywhere in `~/.codex/config.toml`, actually receives the edit
+    once `run_task` is told `sandbox="workspace-write"` — proving the write
+    path this codebase's whole purpose depends on works independent of the
+    executor host's local trust registry, not just that the safe default
+    blocks writes (the previous test). This is the live check
+    `docs/napkin-lessons.md`'s 2026-08-21 entry describes doing manually
+    (`codex exec -s workspace-write ...` against a scratch repo); this test
+    makes it permanent and driven through `CodexRunner.run_task` itself.
+    """
+    _init_scratch_repo(tmp_path)
+    before = (tmp_path / "README.md").read_text(encoding="utf-8")
+
+    runner = CodexRunner(AgentSettings())
+    result = await runner.run_task(
+        task_id="real-codex-workspace-write-smoke-1",
+        project_root=tmp_path,
+        instruction=(
+            "Add a one-line HTML comment at the very top of README.md that says "
+            "'reviewed by codex'. Do not change anything else in the file or "
+            "repository. Then stop."
+        ),
+        timeout_seconds=120,
+        continue_session_id=None,
+        send_log=_collect_logs,
+        sandbox="workspace-write",
+    )
+
+    assert result["return_code"] == 0
+    assert result["final_state"] == "completed"
+    assert result["command"][result["command"].index("-s") + 1] == "workspace-write"
+
+    after = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert after != before, (
+        "workspace-write must actually let codex exec write, independent of "
+        "whether this scratch directory is 'trusted' in ~/.codex/config.toml "
+        "(it never is)"
+    )
+    assert result["no_changes"] is False
+    assert result["post_git"]["diff"] != ""
 
 
 @requires_real_codex

--- a/tests/unit/test_agent_service.py
+++ b/tests/unit/test_agent_service.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pytest
 
 from agent.codex_bridge_agent.config import AgentSettings
-from agent.codex_bridge_agent.service import AgentService
-from shared.protocol import AgentEnvelope, AgentMessageType, ProjectRegistration
+from agent.codex_bridge_agent.service import AgentService, _sandbox_for
+from shared.protocol import AgentEnvelope, AgentMessageType, PolicyLevel, ProjectRegistration
 
 
 class DummyWebSocket:
@@ -371,3 +371,123 @@ async def test_handle_dispatch_forgets_the_task_only_after_the_result_is_sent(tm
         "send:task.result",
         "forget:task-1",
     ]
+
+
+# --------------------------------------------------------------------------
+# Issue #34: sandbox derived from policy level, and the machine-level override
+# --------------------------------------------------------------------------
+
+
+def test_sandbox_for_is_read_only_for_the_read_policy_level() -> None:
+    assert _sandbox_for(PolicyLevel.READ, allow_workspace_write=True) == "read-only"
+    # The machine override cannot make a read-level task write either way —
+    # there is nothing for it to override here.
+    assert _sandbox_for(PolicyLevel.READ, allow_workspace_write=False) == "read-only"
+
+
+def test_sandbox_for_is_workspace_write_for_controlled_write_and_sensitive() -> None:
+    assert _sandbox_for(PolicyLevel.CONTROLLED_WRITE, allow_workspace_write=True) == "workspace-write"
+    assert _sandbox_for(PolicyLevel.SENSITIVE, allow_workspace_write=True) == "workspace-write"
+
+
+def test_sandbox_for_machine_override_forces_read_only_even_for_write_levels() -> None:
+    """`AgentSettings.allow_workspace_write=False` is the executor's own kill
+    switch — it must win over what the task's mode asked for, not merely
+    default the same way."""
+    assert _sandbox_for(PolicyLevel.CONTROLLED_WRITE, allow_workspace_write=False) == "read-only"
+    assert _sandbox_for(PolicyLevel.SENSITIVE, allow_workspace_write=False) == "read-only"
+
+
+class _SandboxRecordingRunner:
+    """Only cares about the `sandbox=` kwarg `_handle_dispatch` passes to
+    `run_task` — everything else is `_RecordingRunner`'s minimal success stub."""
+
+    def __init__(self) -> None:
+        self.sandboxes: list[str] = []
+
+    def mark_dispatched(self, _: str) -> None:
+        pass
+
+    def forget(self, _: str) -> None:
+        pass
+
+    async def run_task(self, *, task_id: str, sandbox: str, **_: object) -> dict:
+        self.sandboxes.append(sandbox)
+        return {
+            "task_id": task_id,
+            "final_state": "completed",
+            "return_code": 0,
+            "duration_seconds": 0,
+            "command": [],
+            "command_redacted": [],
+            "codex_session_id": None,
+            "codex_version": "",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "last_message": "",
+            "pre_git": {},
+            "post_git": {},
+            "tests_ran": [],
+            "no_changes": True,
+            "raw_events": [],
+        }
+
+
+def _dispatch_envelope(*, task_id: str, mode: str, instruction: str = "do the thing") -> AgentEnvelope:
+    return AgentEnvelope(
+        message_id=f"dispatch-{task_id}",
+        executor_id="devel3",
+        sent_at=datetime.now(timezone.utc),
+        type=AgentMessageType.TASK_DISPATCH,
+        payload={
+            "task_id": task_id,
+            "project_id": "codexbridge",
+            "instruction": instruction,
+            "mode": mode,
+            "timeout_seconds": 60,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_dispatch_sends_read_only_for_a_read_mode_task(tmp_path: Path) -> None:
+    service = AgentService(AgentSettings())
+    runner = _SandboxRecordingRunner()
+    service.runner = runner
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+
+    await service._handle_dispatch(DummyWebSocket(), _dispatch_envelope(task_id="t-read", mode="analyze"))
+
+    assert runner.sandboxes == ["read-only"]
+
+
+@pytest.mark.asyncio
+async def test_handle_dispatch_sends_workspace_write_for_a_write_mode_task(tmp_path: Path) -> None:
+    service = AgentService(AgentSettings())
+    runner = _SandboxRecordingRunner()
+    service.runner = runner
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+
+    await service._handle_dispatch(DummyWebSocket(), _dispatch_envelope(task_id="t-write", mode="edit"))
+
+    assert runner.sandboxes == ["workspace-write"]
+
+
+@pytest.mark.asyncio
+async def test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_path: Path) -> None:
+    """A write-mode task still only gets `read-only` when this executor's own
+    `allow_workspace_write` is off — the override must reach `run_task`, not
+    just exist on `AgentSettings`."""
+    service = AgentService(AgentSettings(allow_workspace_write=False))
+    runner = _SandboxRecordingRunner()
+    service.runner = runner
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+
+    await service._handle_dispatch(DummyWebSocket(), _dispatch_envelope(task_id="t-locked", mode="implement"))
+
+    assert runner.sandboxes == ["read-only"]

--- a/tests/unit/test_codex_runner.py
+++ b/tests/unit/test_codex_runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import signal
+from pathlib import Path
 
 import pytest
 
@@ -217,3 +218,57 @@ async def test_terminate_gracefully_falls_back_to_kill_if_still_stuck() -> None:
 
     assert process.killed is True
     assert process.events == ["SIGCONT", "terminate", "kill", "wait_ok"]
+
+
+# --------------------------------------------------------------------------
+# Issue #34: explicit sandbox on `_build_command`/`run_task`
+# --------------------------------------------------------------------------
+
+
+def test_build_command_passes_the_sandbox_flag_on_a_fresh_run() -> None:
+    runner = CodexRunner(AgentSettings())
+    cmd = runner._build_command(  # noqa: SLF001
+        Path("/tmp/project"), "do the thing", Path("/tmp/out.txt"), None, "read-only"
+    )
+    assert cmd[cmd.index("-s") + 1] == "read-only"
+
+
+def test_build_command_workspace_write_is_also_passed_through() -> None:
+    runner = CodexRunner(AgentSettings())
+    cmd = runner._build_command(  # noqa: SLF001
+        Path("/tmp/project"), "do the thing", Path("/tmp/out.txt"), None, "workspace-write"
+    )
+    assert cmd[cmd.index("-s") + 1] == "workspace-write"
+
+
+def test_build_command_resume_branch_never_gets_a_sandbox_flag() -> None:
+    """`codex exec resume --help` lists no `-s`/`--sandbox` option (confirmed
+    against codex-cli 0.147.0, same as the `-C` omission issue #33 already
+    fixed) — passing one would either be silently ignored or, worse, rejected
+    by clap the way `-C` used to be. `_build_command` must not emit it here
+    regardless of what `sandbox` it was given."""
+    runner = CodexRunner(AgentSettings())
+    cmd = runner._build_command(  # noqa: SLF001
+        Path("/tmp/project"), "do the thing", Path("/tmp/out.txt"), "session-abc", "workspace-write"
+    )
+    assert "-s" not in cmd
+    assert "-C" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_run_task_refuses_a_sandbox_value_this_codebase_never_passes() -> None:
+    """`danger-full-access` is a real, accepted `codex exec -s` value — exactly
+    why this runner must actively refuse it rather than merely never emit it
+    on its own. Raises before touching the filesystem or spawning anything,
+    so a bogus `project_root` is fine here."""
+    runner = CodexRunner(AgentSettings())
+    with pytest.raises(ValueError, match="danger-full-access"):
+        await runner.run_task(
+            task_id="t-bad-sandbox",
+            project_root=Path("/tmp/does-not-need-to-exist"),
+            instruction="anything",
+            timeout_seconds=1,
+            continue_session_id=None,
+            send_log=lambda *_: asyncio.sleep(0),
+            sandbox="danger-full-access",
+        )


### PR DESCRIPTION
Closes #34. Sandbox flag is now always explicit on fresh dispatch (default read-only), derived from task PolicyLevel; workspace-write requires the task mode to call for it, plus AgentSettings.allow_workspace_write as an executor-level kill switch. Not a REST contract change. 524 unit/integration tests + 26 contract tests passing; real-CLI integration suite (3/3) passing against codex-cli 0.147.0.