### PR TITLE
fix(gh-4): adversarial-review fixes for auth/mobile sessions (S2/S4/S5/SC#1/SC#7/S3)

### DIFF
--- a/docs/issues/004-auth-and-mobile-sessions/RESUME.md
+++ b/docs/issues/004-auth-and-mobile-sessions/RESUME.md
@@ -6,6 +6,65 @@
 
 ## Next Step (DO THIS FIRST)
 
+~~Adversarial review of this delivery~~ — **DONE 2026-08-26** (Squad E,
+WK-20260826-gh4-adversarial-review, branch
+`feature/gh-4/adversarial-review-fixes`, PR pending). See "Adversarial review
+2026-08-26" below. What remains is the **operator's**: the escalated findings in
+`docs/security.md` ("Revisão adversarial da issue #4 — decisões pendentes do
+operador"), chiefly **S1** (a narrowed OAuth delegation still confers admin,
+ship-blocking) and the **rotation-race theft-policy** direction conflict.
+
+## Adversarial review 2026-08-26 (Squad E) — two rounds, three lenses
+
+Concentrated where the RESUME asked (rotation race, revocation counters, 401
+leakage). Lenses: security, skeptic, second-caller. Recorded per
+`.docs/agents/council.md` §4.
+
+**Round 1 — raised 22 · survived §2 22 · became tests 6 (8 tests) · left to the
+operator 6 (+3 doc-accuracy questions).** Fixed on
+`feature/gh-4/adversarial-review-fixes`, each with a test that fails without it:
+- **S2** malformed/unreadable `users.json` answered an unauthenticated
+  `500 retryable:true` → now fails closed (`{}` → uniform 401).
+- **S4** last-write-wins on a colliding registry key silently rebound a live
+  token's privileges → the loader refuses a case-folded duplicate key.
+- **S5** a non-pbkdf2 or absurd (`…$99000000$…`) round count set the derivation
+  cost for every unauthenticated attempt → `_iterations_of`/`verify_password`
+  refuse it, ceiling `_MAX_ITERATIONS`.
+- **SC#1** a last-minute rotation minted an access token (and `expiresIn`) past
+  the grant's absolute deadline → capped at the deadline.
+- **SC#7** an idempotent-retry no-op `/revoke` wrote a `0/0` audit row → recorded
+  only when something was revoked.
+- **S3** the retention sweep aged out the `refresh_token_reuse` theft record →
+  scoped to `AUTH_SWEEPABLE_EVENT_TYPES`, incident rows preserved.
+
+Left to the operator (`.docs/agents/council.md` §1 one-way door — contradict a
+rule or a fenced decision): **S1** (admin ignores the scope allowlist),
+**rotation-race theft policy** (skeptic: concurrent loser not revoked/audited;
+second-caller: benign retry punished as theft — opposite directions →
+governance-precedence), **/revoke counter oracle** (entangled with fenced
+finding 17's pinning test), **S6** (`/mcp` non-dict body 500, out of #4 scope),
+**S7** (per-request registry parse). All written up in `docs/security.md`.
+
+**Round 2 — raised 5 (4 introduced-by-r1, 1 pre-existing) · survived §2 5 ·
+became tests 1 · questions/operator 4.** Closed in the same delivery: SC#1 tests
+gained a lower bound; `_MAX_ITERATIONS` 2M→10M (no lockout for a hardening
+operator); a stale test docstring corrected. Recorded as risk-acceptance /
+operator decisions in `docs/security.md`: an over-ceiling hash is unusable and
+audits `bad_password`; routine `signed_out` records are now retained (clean fix
+needs an audit-contract change); a pre-existing "a replayed token is audited
+once" gap; the case-insensitive `user_id` side effect; per-request log volume.
+
+**Finding 17 (operator-accepted) — confirmed still true, untouched:** behaviour
+at `routes/auth.py:341-373`, acceptance at `docs/security.md`, pin at
+`test_a_consumed_refresh_token_still_ends_its_own_grant` (passes unchanged).
+
+**Checks:** `.venv/bin/python -m pytest -q` → 561 passed, 3 skipped. Each new
+test verified failing against the unfixed source (stash of `gateway/`). Not
+validated: Postgres; any deployed environment; the machine-readable council
+record (`governancekit council --record`) was not produced — see handoff.
+
+## Original delivery — Next Step (superseded)
+
 Adversarial review of this delivery — no council has looked at it. Concentrate
 on `gateway/app/api/routes/auth.py` and `store.issue_auth_grant`: the rotation
 race, the revocation counters, and whether any 401 path leaks which of the five

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1022,3 +1022,41 @@ It expects `state_version`, `values`, and `refs`; a hand-written flat JSON with
 shared-contract kit refreshes, stage the real delivery first and record the
 council round against that staged diff, because the fingerprint binding is what
 actually clears the gate.
+
+## 2026-08-26 — council on gh-4 adversarial review (auth/mobile sessions), Squad E
+
+Two rounds, three lenses (security, skeptic, second-caller), against the merged
+#4 delivery. Branch `feature/gh-4/adversarial-review-fixes`.
+
+- Round 1 — raised: 22 · survived §2: 22 · became tests: 6 (8 tests) · left to operator: 6 (+3 doc-accuracy questions)
+- Round 2 — raised: 5 · survived §2: 5 · became tests: 1 · questions/operator: 4
+
+Lessons that cost real rework this session:
+
+- A "no-op /revoke writes an audit row" test that drove the no-op through
+  unknown/already-revoked *access* tokens passed against the unfixed code too:
+  the handler guards `if item is not None`, and `get_oauth_access_token` returns
+  None for a revoked/expired token, so those paths never reach the audit write.
+  The only no-op that actually writes a `0/0` row is an already-**revoked
+  refresh** token — `inspect_refresh_token` still returns the row. A regression
+  test that cannot fail without the fix is not a test; verify the fail-first on
+  the exact path, not a plausible-looking neighbour.
+- Capping `accessTokenExpiresAt` at the grant deadline without also deriving
+  `expiresIn` from it is a half-fix: `expiresIn` is the field the contract tells
+  the client to schedule from, so the uncapped TTL there reopens the same
+  "schedule past the grant, eat the 401" the cap exists to prevent. The
+  pre-commit critique caught it; the first cut shipped the timestamp capped and
+  the seconds-counter not.
+- Detecting a duplicate registry key on the raw `user_id` while lookup resolves
+  `.lower()` first leaves the exact escalation open: `user_id "OPS@EXAMPLE.COM"`
+  never byte-matches another account's `email "ops@example.com"` yet resolves to
+  it. Detection must use the key resolution uses — fold both sides.
+- Clamping the *target* iteration count (`min(max, ceiling)`) reopens the timing
+  oracle for an account written above the ceiling: its real verify cost exceeds
+  the clamped target, so padding is negative and it answers faster. The correct
+  shape is to make the over-ceiling hash *unusable* (0 in `_iterations_of`,
+  refused in `verify_password`) so the constant-cost padding covers it — and set
+  the ceiling well above any honest cost (10M) so hardening does not self-lock.
+- The council never modifies code, so round 2's `became tests: 1` is honest: it
+  reports; the programmer closes. Do not record round-2 findings as "fixed" in
+  the same breath as raising them.

--- a/docs/security.md
+++ b/docs/security.md
@@ -238,6 +238,42 @@ ler não deve conceder nada, e a falha de deployment continua nomeada no startup
 (`main.py`) e em `/mcp` (`user_registry_unavailable`). Se a distinção I/O vs
 parse valer um `503` em `/api/v1`, é ajuste do operador.
 
+### Achados da rodada 2 do concílio (introduzidos pelos próprios fixes)
+
+A rodada 2 checou os fixes acima. Fechados na mesma entrega: o teste do cap de
+SC#1 ganhou limite inferior (`0 < expiresIn`); `_MAX_ITERATIONS` subiu para
+10.000.000 (16x o custo de produção) para não travar um operador que endurece; a
+docstring do teste de retenção foi corrigida. Ficam registrados, com risco
+aceito ou como decisão do operador:
+
+* **[risco aceito] Conta com hash acima de `_MAX_ITERATIONS` fica inutilizável e
+  o sign-in com a senha *correta* audita `bad_password`.** Acima de 10.000.000 de
+  rounds `verify_password` recusa (a conta não entra), `_iterations_of` conta 0,
+  e `unusable_registry_reason` não sinaliza a entrada específica. Aceito porque o
+  teto agora está muito acima de qualquer custo honesto; uma entrada acima dele é
+  configuração absurda. Se o operador quiser sinal explícito,
+  `unusable_registry_reason` pode passar a nomear a entrada fora do teto.
+* **[decisão do operador] Sign-out de rotina agora é retido para sempre.** A
+  varredura de retenção poupa todo `auth.credentials_revoked` para preservar a
+  prova de roubo (`refresh_token_reuse`) e a revogação forçada
+  (`account_unavailable`); como consequência, o `signed_out` de rotina — antes
+  varrido sob `entity_type == "auth"` — também deixa de envelhecer. Volume baixo
+  (um por fim de sessão, autenticado) e a varredura só roda no startup de todo
+  jeito. O fix limpo distingue por `reason`, o que hoje exigiria SQL específico
+  de banco (`json_extract`) ou um `event_type` distinto para o sign-out de
+  rotina — mudança no contrato de auditoria, direção do operador.
+* **[pré-existente, não introduzido] Replay repetido de um refresh token roubado
+  é auditado uma vez e depois nunca mais.** A primeira reapresentação grava
+  `refresh_token_reuse`; da segunda em diante `inspect_refresh_token` retorna
+  `revoked` e o handler responde 401 sem gravar evento (não existe
+  `auth.refresh_failed`). O operador não distingue um replay de dez mil. Anterior
+  a esta entrega; um tipo de evento para falha de refresh o fecharia.
+* **[nota] Sinal-de-lado de S4:** o sign-in por `user_id` ficou
+  case-insensitive (as chaves do índice são `.lower()`). Seguro — a guarda de
+  colisão proíbe a ambiguidade — mas nem `docs/installation.md` nem o OpenAPI
+  mencionam. **[nota] S2 loga por request** enquanto o registro está quebrado
+  (sem cache), até 120 linhas WARNING/min/bucket com o caminho do arquivo.
+
 ## Recomendações de produção
 
 * usar PostgreSQL real com backup e retenção;

--- a/docs/security.md
+++ b/docs/security.md
@@ -89,12 +89,14 @@
   - `audit_events` tem retenção (`CODEX_BRIDGE_AUDIT_EVENT_RETENTION_DAYS`,
     90 dias por padrão), varrida no startup como os registros de idempotência.
     Sign-in recusado é o primeiro caminho de escrita **não autenticado** nessa
-    tabela e nada removia linha nenhuma antes disso. A varredura só apaga linhas
-    de `entity_type = "auth"`: a janela existe para limitar spam de sign-in, e
-    aplicá-la à tabela inteira apagaria `task.approved` — o registro de quem
-    autorizou uma tarefa sensível — junto. Se aquele registro pode envelhecer em
-    90 dias é decisão do operador sobre a própria conformidade, não herança de
-    um controle de spam.
+    tabela e nada removia linha nenhuma antes disso. A varredura só apaga os
+    tipos de alto volume em `AUTH_SWEEPABLE_EVENT_TYPES` (`auth.sign_in_failed`,
+    `auth.token_refreshed`, `auth.signed_in`): a janela existe para limitar
+    volume, e aplicá-la a `entity_type = "auth"` inteiro apagaria
+    `auth.credentials_revoked{reason:"refresh_token_reuse"}` — o único registro
+    durável de que um refresh token roubado foi reapresentado — junto com
+    `task.approved`, que o filtro por `entity_type` já poupava. Prova de violação
+    e registro de aprovação não envelhecem por herança de um controle de spam.
 
 ### Risco aceito: refresh token gasto ainda encerra a própria concessão
 
@@ -147,7 +149,12 @@
   resultante usa o custo esperado. O engodo acompanha o registro e a verificação
   real é completada até o custo máximo dele, então um custo menor não abre
   oráculo nem no registro misto — só torna aquela senha mais barata de quebrar
-  offline, e faz toda tentativa custar o do hash mais caro do arquivo.
+  offline. O custo por tentativa é limitado a `_MAX_ITERATIONS` (2.000.000):
+  `verify_password` recusa um hash acima disso e `_iterations_of` o conta como 0,
+  então um `pbkdf2_sha256$99000000$…` (typo ou hash migrado) não vira DoS de
+  autenticação — a conta fica inutilizável, não cara, e o padding a cobre para
+  não abrir oráculo de timing. Algoritmo diferente de `pbkdf2_sha256` também vale
+  0. Uma conta legitimamente escrita acima do teto ficaria inutilizável.
 * **A varredura de `audit_events` acontece no startup**, como a de idempotência:
   não há agendador neste deployment. Um gateway que fica meses de pé não coleta
   nada nesse período. O teto continua sendo o limitador (120/min/bucket).
@@ -161,6 +168,75 @@
 * `sensitive_patterns` por projeto está no schema mas não é aplicado em lugar
   nenhum; a classificação de tarefa sensível usa apenas a lista global
   `SENSITIVE_KEYWORDS` em `shared/policy.py`. Ver `docs/project-onboarding.md`.
+
+## Revisão adversarial da issue #4 — decisões pendentes do operador
+
+O concílio de revisão adversarial da issue #4 (2026-08-26, três lentes:
+segurança, cético, segundo-chamador — `docs/napkin-lessons.md`) levantou achados
+que **contradizem uma regra estabelecida ou uma decisão de direção**, e por
+`.docs/agents/council.md` §1 saem do concílio para o operador em vez de serem
+corrigidos pelo programador. Estão aqui para não se perderem:
+
+* **[S1 — ship-blocking] Delegação OAuth estreitada ainda confere admin.** Uma
+  conta com `roles: ["admin"]` em `users.json` recebe um grant com escopos
+  interseccionados a `CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES` — possivelmente `[]` —
+  e mesmo assim `is_admin()` (lê `roles`, não o grant) libera tudo em ambos os
+  transportes. `CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES`, o único teto de um deployment,
+  não retém nada de uma conta admin; um grant de terceiro (ChatGPT) que o
+  operador estreitou no formulário de consentimento não é estreitado.
+  Reproduzido: sign-in admin → `scopes:[]`, `/auth/me` → `projects.all:true`,
+  `decisions.decide.allowed:true`. Correção aponta contra o modelo de papéis
+  fixado por `tests/integration/test_auth.py:1120-1156` (`is_admin` derivar de
+  `codexbridge.admin` no grant, mintado no sign-in) — **direção do operador**,
+  não mudança silenciosa. `gateway/app/core/users.py:64-68`.
+* **[Política da corrida de rotação — conflito de direção] Duas lentes apontam
+  em sentidos opostos.** O cético: o **perdedor da corrida concorrente** de
+  `/refresh` recebe 401 mas o grant **não** é revogado nem auditado
+  (`auth.py:286-290`), então roubo sobrevive à corrida que o UPDATE condicional
+  existe para arbitrar. O segundo-chamador: um **retry após resposta perdida**
+  (o cliente móvel normal) reapresenta o mesmo refresh, cai em `REFRESH_REUSED`
+  e revoga o grant inteiro — inclusive os tokens novos que o vencedor acabou de
+  emitir — e grava um registro de *roubo* contra um retry benigno. Consertar num
+  sentido (revogar na corrida perdida) piora o outro (retry benigno mata a
+  sessão). É um conflito de papéis → `.docs/agents/council.md` §1 → **operador
+  decide a direção** (uma opção citada: aceitar `Idempotency-Key` em `/refresh`,
+  como `epics.py`/`issues.py` já fazem, e reservir o par do vencedor).
+* **[Oráculo dos contadores do /revoke — entrelaçado com o achado 17]** Os
+  contadores `accessTokensRevoked`/`refreshTokensRevoked` na resposta de
+  `/revoke`, sem autenticação, distinguem token vivo (`1/1`) de desconhecido
+  (`0/0`) e vazam quantas rotações a sessão teve — contradizendo o próprio
+  contrato ("says nothing about which one"). **Não corrigido** porque o corpo de
+  contadores está fixado pelo teste do achado 17
+  (`test_a_consumed_refresh_token_still_ends_its_own_grant`, que afirma
+  `accessTokensRevoked >= 1` no caminho refresh-token-only), que é fenced. Mudar
+  os contadores exige mexer no achado 17 → **operador**. Opção: emitir contadores
+  só a chamador autenticado, ou remover os campos (RFC 7009 não define corpo).
+* **[S6 — fora do escopo da #4] `/mcp` com corpo JSON não-objeto explode antes de
+  autenticar.** `POST /mcp` com corpo `[]` sem `Authorization` em modo `oauth`
+  → `AttributeError` → 500 nu, antes do bearer check (`main.py:211`). É a função
+  de auth, mas do transporte `/mcp`, adjacente à #4. Correção de 1 linha
+  (`isinstance(body, dict)`), deixada para o operador decidir se entra aqui ou
+  numa issue de `/mcp`.
+* **[S7 — escalabilidade] `users.json` é relido e reparseado por request no event
+  loop.** 0,159 ms com 10 contas, 46,4 ms com 5.000 / 1,1 MB. Inofensivo hoje;
+  registrar. Cache por mtime ou `to_thread` fecharia.
+
+Achados corrigidos nesta entrega (branch `feature/gh-4/adversarial-review-fixes`,
+com teste que falha sem a correção): S2 (registro malformado falha fechado, não
+500), S4 (colisão de chave case-insensitive recusa o registro), S5 (custo de
+derivação limitado por algoritmo e teto), SC#1 (`accessTokenExpiresAt` e
+`expiresIn` limitados ao prazo do grant), SC#7 (revogação no-op não grava linha
+de auditoria), S3 (varredura de retenção poupa registros de incidente).
+
+### Risco aceito (issue #4, review): registro ilegível derruba sessões
+
+`load_user_registry` falha **fechado** para qualquer exceção, inclusive `OSError`
+(volume desmontado, permissão trocada) — o mesmo que para JSON malformado. Uma
+falha de I/O transitória vira sign-out forçado da frota inteira em `/api/v1` em
+vez de um `500 retryable:true`. Aceito: um registro que o processo não consegue
+ler não deve conceder nada, e a falha de deployment continua nomeada no startup
+(`main.py`) e em `/mcp` (`user_registry_unavailable`). Se a distinção I/O vs
+parse valer um `503` em `/api/v1`, é ajuste do operador.
 
 ## Recomendações de produção
 

--- a/gateway/app/api/routes/auth.py
+++ b/gateway/app/api/routes/auth.py
@@ -54,7 +54,7 @@ allowlist exists to withhold. One token table, one ceiling.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Body, Depends, Request, Response
 from pydantic import BaseModel, ConfigDict, Field
@@ -128,12 +128,20 @@ def _tokens_body(
     contract tells clients not to do elapsed-time arithmetic against the device
     clock, and a seconds-from-now value is the only form that survives a device
     whose clock is wrong.
+
+    It is **derived from `access_expires_at`**, not from the configured TTL. A
+    rotation near the grant deadline caps the access token below a full TTL
+    (see `refresh`), and `expiresIn` is the field the contract tells the client
+    to schedule its refresh from — reporting the uncapped TTL here would make a
+    conforming client schedule past the grant's end and meet the 401 the
+    contract promises it will not.
     """
+    remaining = int((access_expires_at - datetime.now(timezone.utc)).total_seconds())
     return {
         "tokenType": "Bearer",
         "accessToken": access_token,
         "accessTokenExpiresAt": timestamps.utc_z(access_expires_at),
-        "expiresIn": settings.oauth_access_token_ttl_seconds,
+        "expiresIn": max(0, remaining),
         "refreshToken": refresh_token,
         "refreshTokenExpiresAt": timestamps.utc_z(refresh_expires_at),
         "scopes": scopes,
@@ -265,10 +273,21 @@ async def refresh(
 
     access_token = generate_access_token()
     refresh_token = generate_refresh_token()
-    access_expires_at = expires_in(settings.oauth_access_token_ttl_seconds)
     # Carried forward, not extended: the grant has an absolute lifetime, so a
     # stolen refresh token cannot be rotated into a session that never ends.
     refresh_expires_at = item.expires_at
+    # Capped at the grant deadline, never beyond it. A rotation performed in the
+    # last minutes of a grant would otherwise mint an access token good for a
+    # full TTL *past* `refreshTokenExpiresAt` — the token's `accessTokenExpiresAt`
+    # landing after the grant's own absolute end, and `GET /auth/me` answering
+    # 200 with it after the deadline the grant is documented to enforce
+    # (`docs/api/README.md`, `docs/security.md`: "a concessão tem vida absoluta").
+    # `get_oauth_access_token` only checks the token's own `expires_at`, so the
+    # cap has to be applied here, at issue.
+    grant_deadline = item.expires_at
+    if grant_deadline.tzinfo is None:
+        grant_deadline = grant_deadline.replace(tzinfo=timezone.utc)
+    access_expires_at = min(expires_in(settings.oauth_access_token_ttl_seconds), grant_deadline)
 
     rotated = await store.issue_auth_grant(
         session,

--- a/gateway/app/core/users.py
+++ b/gateway/app/core/users.py
@@ -437,11 +437,14 @@ def _decoy_hash(iterations: int) -> str:
 _FALLBACK_ITERATIONS = 600000
 
 # The most PBKDF2 rounds any single registry entry may impose on every
-# unauthenticated sign-in attempt. Roughly three times the production cost:
-# high enough that no honestly-generated registry meets it, low enough that a
-# typo'd or migrated round count cannot turn one line of `users.json` into an
-# authentication DoS. See `_registry_iterations`.
-_MAX_ITERATIONS = 2_000_000
+# unauthenticated sign-in attempt. Well above any honestly-generated cost —
+# ~16x the production 600 000 in `docs/installation.md`, so an operator who
+# hardens has ample headroom and does not lock themselves out — while still
+# refusing an absurd typo or a mis-unit migrated count (`…$99000000$…`) that
+# would turn one line of `users.json` into an authentication DoS. A hash above
+# this is unusable (`verify_password` refuses it, `_iterations_of` is 0); see the
+# accepted risk in `docs/security.md`. See `_registry_iterations`.
+_MAX_ITERATIONS = 10_000_000
 
 
 def verify_password(password: str, encoded_hash: str) -> bool:

--- a/gateway/app/core/users.py
+++ b/gateway/app/core/users.py
@@ -28,6 +28,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import secrets
 from dataclasses import dataclass
 from functools import lru_cache
@@ -35,6 +36,9 @@ from pathlib import Path
 
 import anyio.to_thread
 from pydantic import BaseModel, Field
+
+
+logger = logging.getLogger(__name__)
 
 
 class GatewayUser(BaseModel):
@@ -71,16 +75,80 @@ class AuthenticatedPrincipal(BaseModel):
         return self.is_admin() or project_id in self.allowed_projects
 
 
-def load_user_registry(path: str) -> dict[str, GatewayUser]:
+def _read_user_registry(path: str) -> dict[str, GatewayUser]:
+    """Parse the registry, or raise. The strict form behind `load_user_registry`.
+
+    Raises on malformed JSON, a shape pydantic refuses, or a **key collision**:
+    two different accounts that resolve to the same lookup key — a duplicate
+    `user_id`, a duplicate e-mail, or a `user_id` that equals another account's
+    e-mail. Last-write-wins there silently rebinds an already-issued token to
+    whichever entry loaded last, because `current_principal` re-resolves the
+    token's `user_id` against this registry on every request; a copy-pasted
+    entry with the e-mail changed and the `user_id` left alone is enough to hand
+    one account another's roles. Refusing the whole registry is the fail-closed
+    reading (`design-standards.md` §6): a registry the loader cannot make
+    unambiguous grants nobody anything until the operator disambiguates it, and
+    `unusable_registry_reason` names the collision.
+    """
     file_path = Path(path)
     if not file_path.exists():
         return {}
     payload = UserRegistry.model_validate(json.loads(file_path.read_text(encoding="utf-8")))
     users: dict[str, GatewayUser] = {}
     for user in payload.users:
-        users[user.user_id] = user
-        users[user.email.lower()] = user
+        # Keys are case-folded, and the collision check is on the folded key.
+        # `lookup_user` and `authenticate` resolve `.lower()` first, so a
+        # collision detected on the raw `user_id` would miss the case that
+        # actually escalates: a `user_id` of `"OPS@EXAMPLE.COM"` never byte-
+        # matches another account's `email` of `"ops@example.com"`, yet resolves
+        # to it at lookup. Folding both sides makes detection and resolution use
+        # the same key. The `GatewayUser` keeps its original-case fields — only
+        # the index is folded.
+        for key in (user.user_id.lower(), user.email.lower()):
+            existing = users.get(key)
+            if existing is not None and existing is not user:
+                raise ValueError(
+                    f"duplicate registry key {key!r}: it resolves both "
+                    f"{existing.user_id!r} and {user.user_id!r}. A user_id and an "
+                    "e-mail must each identify exactly one account, case-insensitively."
+                )
+            users[key] = user
     return users
+
+
+def load_user_registry(path: str) -> dict[str, GatewayUser]:
+    """The registry as a lookup dict, failing **closed** on any problem.
+
+    A registry that cannot be read — malformed mid-edit, a shape pydantic
+    refuses, a key collision — returns `{}` here, so every credential path
+    answers the uniform `401` rather than raising out of the request handler.
+    An earlier cut let the parse raise straight through `authenticate` and
+    `lookup_user`: a hand-edited `users.json` then turned `POST /auth/sign-in`
+    and `GET /auth/me` into an unauthenticated `500 internal_error` with
+    `retryable: true`, a new distinguishing channel that also told a conforming
+    client to keep hammering a gateway that could not recover. The diagnostic
+    survives in the log (a WARNING here) and in `unusable_registry_reason`, which
+    `main.py` reports at startup and the MCP path surfaces as
+    `user_registry_unavailable`.
+
+    Failing closed covers an I/O fault (`OSError`: a volume unmounted, a
+    permission flipped) the same as a parse error — a transient one becomes a
+    fleet-wide forced sign-out rather than a `500`. That is the fail-closed
+    trade, accepted deliberately: a registry the process cannot read grants
+    nobody anything, and the deployment-level fault is still named at startup and
+    on `/mcp`. Recorded as an accepted risk in the issue-#4 review.
+    """
+    try:
+        return _read_user_registry(path)
+    except Exception as error:  # malformed JSON, a shape pydantic refuses, a collision
+        logger.warning(
+            "user registry %r is unusable (%s: %s); failing closed — no account can "
+            "sign in until it is fixed.",
+            path,
+            error.__class__.__name__,
+            error,
+        )
+        return {}
 
 
 def lookup_user(path: str, username_or_email: str) -> GatewayUser | None:
@@ -120,8 +188,8 @@ def unusable_registry_reason(path: str) -> str | None:
             "(docs/installation.md)."
         )
     try:
-        registry = load_user_registry(path)
-    except Exception as error:  # malformed JSON, or a shape pydantic refuses
+        registry = _read_user_registry(path)
+    except Exception as error:  # malformed JSON, a shape pydantic refuses, a key collision
         return (
             f"the user registry {path!r} cannot be read ({error.__class__.__name__}: "
             f"{error}). No account can sign in until it parses."
@@ -267,12 +335,36 @@ def _iterations_of(encoded_hash: str) -> int:
     Zero on an unparseable hash is deliberate: `verify_password` rejects it
     immediately, having spent nothing, so the padding below has to cover the
     whole target rather than the remainder of it.
+
+    The algorithm field is checked, not just skipped over. `verify_password`
+    only ever derives `pbkdf2_sha256`, so an `argon2id$...` or `scrypt$...`
+    string is never actually verified — reading its second field as a PBKDF2
+    round count is meaningless, and an `argon2id$99000000$...` line (a plausible
+    artefact of a hash migration) would otherwise set the padding target for
+    *every* unauthenticated attempt in the deployment to 99 million rounds. A
+    hash this function cannot honestly cost is worth 0, exactly like one it
+    cannot parse.
+
+    A round count above `_MAX_ITERATIONS` is also worth 0: `verify_password`
+    refuses such a hash (the account is unusable), so it must not set the
+    derivation target either. Returning 0 keeps the two consistent — the decoy
+    and the padding both cost the registry's real ceiling, not the absurd one —
+    and `_verify_at_constant_cost` then pads the unusable account up to that same
+    target, so it is not identifiable by timing.
     """
     try:
-        _, iterations, _, _ = encoded_hash.split("$", 3)
-        return int(iterations)
+        algorithm, iterations, _, _ = encoded_hash.split("$", 3)
     except (ValueError, AttributeError):
         return 0
+    if algorithm != "pbkdf2_sha256":
+        return 0
+    try:
+        count = int(iterations)
+    except ValueError:
+        return 0
+    if count <= 0 or count > _MAX_ITERATIONS:
+        return 0
+    return count
 
 
 def _pad_derivation(iterations: int) -> None:
@@ -303,6 +395,13 @@ def _registry_iterations(registry: dict[str, GatewayUser]) -> int:
     A registry that is empty or whose hashes are unparseable falls back to the
     production cost — the file being absent must not make sign-in fast enough to
     probe.
+
+    The ceiling is enforced in `_iterations_of`, which returns 0 for a count
+    above `_MAX_ITERATIONS` (the same hash `verify_password` refuses). So one
+    account written at an absurd round count — a typo, or a migrated hash whose
+    count is in different units — contributes 0 here rather than dictating
+    seconds of CPU per sign-in across the deployment, and every value this `max`
+    sees is already within the ceiling.
     """
     counts = set()
     for user in registry.values():
@@ -337,6 +436,13 @@ def _decoy_hash(iterations: int) -> str:
 # so the fallback is expensive rather than cheap.
 _FALLBACK_ITERATIONS = 600000
 
+# The most PBKDF2 rounds any single registry entry may impose on every
+# unauthenticated sign-in attempt. Roughly three times the production cost:
+# high enough that no honestly-generated registry meets it, low enough that a
+# typo'd or migrated round count cannot turn one line of `users.json` into an
+# authentication DoS. See `_registry_iterations`.
+_MAX_ITERATIONS = 2_000_000
+
 
 def verify_password(password: str, encoded_hash: str) -> bool:
     try:
@@ -345,9 +451,21 @@ def verify_password(password: str, encoded_hash: str) -> bool:
         return False
     if algorithm != "pbkdf2_sha256":
         return False
+    try:
+        rounds = int(iterations)
+    except ValueError:
+        return False
+    # A round count above the ceiling makes the account unusable rather than
+    # letting an attempt that names it spend that many rounds. `_registry_iterations`
+    # caps the decoy/padding target, but the derivation here is what an attacker
+    # who knows the account would actually trigger; refusing it closes the other
+    # half of that authentication-DoS. `_iterations_of` returns 0 for the same
+    # hash, so the constant-cost padding still covers it.
+    if rounds <= 0 or rounds > _MAX_ITERATIONS:
+        return False
     salt = _b64decode(salt_b64)
     expected = _b64decode(digest_b64)
-    derived = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, int(iterations))
+    derived = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, rounds)
     return hmac.compare_digest(derived, expected)
 
 

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -55,10 +55,22 @@ from shared.protocol import (
 from shared.security import hash_token
 
 
-# `entity_type` of every row the credential lifecycle writes, and the only rows
-# `purge_expired_audit_events` is allowed to remove. A literal at each call site
-# would have made the retention window's scope a coincidence of spelling.
+# `entity_type` of every row the credential lifecycle writes. A literal at each
+# call site would have made the retention window's scope a coincidence of
+# spelling.
 AUTH_ENTITY_TYPE = "auth"
+
+# The auth event types `purge_expired_audit_events` may age out: the high-volume
+# ones, driven by an unauthenticated caller (`auth.sign_in_failed`) or by a
+# client rotating on a schedule (`auth.token_refreshed`, `auth.signed_in`).
+# `auth.credentials_revoked` is deliberately absent — it carries the theft record
+# (`reason: "refresh_token_reuse"`) and the forced-revocation record
+# (`account_unavailable`), breach evidence a spam-retention window must not
+# delete — and so is any future incident type. Named here rather than inline so
+# adding an event type is a deliberate decision about whether it is spam.
+AUTH_SWEEPABLE_EVENT_TYPES = frozenset(
+    {"auth.sign_in_failed", "auth.token_refreshed", "auth.signed_in"}
+)
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -855,13 +867,20 @@ async def revoke_auth_grant(
         .values(revoked_at=now)
     )
     revoked = {"access_tokens": max(access.rowcount, 0), "refresh_tokens": max(refresh.rowcount, 0)}
-    await record_event(
-        session,
-        AUTH_ENTITY_TYPE,
-        user_id,
-        "auth.credentials_revoked",
-        {"grant_id": grant_id, "reason": reason, **revoked},
-    )
+    # Only record when something was actually revoked. `/revoke` is idempotent
+    # and its own contract blesses the retry, so a client (or an unauthenticated
+    # caller with one recovered token) can drive this repeatedly; writing an
+    # `auth.credentials_revoked` row on every no-op call floods the audit trail
+    # with `0/0` rows that bury the real revocations — the more so now that the
+    # retention sweep no longer ages `auth.credentials_revoked` out.
+    if revoked["access_tokens"] or revoked["refresh_tokens"]:
+        await record_event(
+            session,
+            AUTH_ENTITY_TYPE,
+            user_id,
+            "auth.credentials_revoked",
+            {"grant_id": grant_id, "reason": reason, **revoked},
+        )
     await session.commit()
     return revoked
 
@@ -879,13 +898,17 @@ async def revoke_access_token(
     if item is not None and item.revoked_at is None:
         item.revoked_at = datetime.now(timezone.utc)
         revoked["access_tokens"] = 1
-    await record_event(
-        session,
-        AUTH_ENTITY_TYPE,
-        user_id,
-        "auth.credentials_revoked",
-        {"grant_id": None, "reason": reason, **revoked},
-    )
+    # Only record a real revocation — see `revoke_auth_grant`. A retry against an
+    # already-revoked or unknown access token revokes nothing and must not add a
+    # `0/0` audit row.
+    if revoked["access_tokens"] or revoked["refresh_tokens"]:
+        await record_event(
+            session,
+            AUTH_ENTITY_TYPE,
+            user_id,
+            "auth.credentials_revoked",
+            {"grant_id": None, "reason": reason, **revoked},
+        )
     await session.commit()
     return revoked
 
@@ -915,15 +938,18 @@ async def purge_expired_audit_events(
     all — the startup sweep collected `idempotency_records` only — so a caller
     that never authenticated could grow the operator's database indefinitely.
 
-    Scoped to `entity_type == "auth"`, and that scope is the point. The window
-    is chosen to bound sign-in spam; applying it to the whole table would delete
-    `task.approved` — the record of who authorized a sensitive task — plus
-    `task.stopped_by_actor`, `task.state_changed` and `task.result`, on a table
-    that had kept everything forever. Whether an approval record may be aged out
-    at 90 days is an operator's decision about their own compliance, and it is
-    not one to make by inheritance from a spam control. Eleven `record_event`
-    call sites write here; two of them are auth, and those two are the ones an
-    unauthenticated caller can drive.
+    Scoped to `AUTH_SWEEPABLE_EVENT_TYPES`, and that scope is the point. The
+    window bounds high-volume rows — a rejected sign-in an unauthenticated caller
+    drives, and the `auth.token_refreshed`/`auth.signed_in` rows a client on a
+    schedule produces — so it ages out *only* those. An earlier cut scoped it to
+    `entity_type == "auth"`, which also deleted `auth.credentials_revoked`
+    — including `{reason:"refresh_token_reuse"}`, the single durable record that a
+    stolen refresh token was replayed on a grant, and `{reason:"account_unavailable"}`,
+    a forced revocation. A knob documented as a *spam* control must not age out
+    breach evidence, exactly as it must not age out `task.approved` (which the
+    `entity_type` filter already spared). The successful `/revoke` no-op rows that
+    used to share this scope no longer exist — `revoke_auth_grant` stopped writing
+    them (see above).
 
     A non-positive window means "keep everything", for a deployment that exports
     the table elsewhere. It is an explicit opt-in to unbounded growth.
@@ -938,6 +964,7 @@ async def purge_expired_audit_events(
     result = await session.execute(
         delete(AuditEventModel)
         .where(AuditEventModel.entity_type == AUTH_ENTITY_TYPE)
+        .where(AuditEventModel.event_type.in_(AUTH_SWEEPABLE_EVENT_TYPES))
         .where(AuditEventModel.created_at < cutoff),
         # The delete happens in the database, not by evaluating the predicate
         # against whatever this session happens to have loaded. Letting

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -934,8 +934,10 @@ async def test_a_last_minute_rotation_does_not_outlive_the_grant_deadline(api) -
         f"the rotated access token expires at {access_exp}, past the grant deadline {refresh_exp}"
     )
     # expiresIn is capped too, not left at the full TTL — it is the field the
-    # contract tells the client to schedule its refresh from.
-    assert body["expiresIn"] <= 30, f"expiresIn stayed at the full TTL: {body['expiresIn']}"
+    # contract tells the client to schedule its refresh from. Lower bound as well
+    # as upper: an over-truncation that returned an already-expired access token
+    # (the tz-misread the normalization guards against) would satisfy `<= 30` too.
+    assert 0 < body["expiresIn"] <= 30, f"expiresIn out of range: {body['expiresIn']}"
 
 
 async def test_a_rotation_far_from_the_deadline_still_gets_the_full_access_ttl(api) -> None:
@@ -980,9 +982,10 @@ async def test_the_retention_sweep_keeps_a_refresh_reuse_record(api) -> None:
     `auth.credentials_revoked{reason:"refresh_token_reuse"}` is the one durable
     artefact saying a stolen refresh token was replayed on a grant. Scoping the
     retention window to `entity_type == "auth"` deleted it along with rejected
-    sign-ins; it is scoped to `event_type == "auth.sign_in_failed"` so only the
-    unauthenticated spam ages out, while a rejected sign-in of the same age is
-    still swept.
+    sign-ins; it is scoped to `AUTH_SWEEPABLE_EVENT_TYPES` (the high-volume
+    `auth.sign_in_failed`, `auth.token_refreshed`, `auth.signed_in`), which
+    excludes `auth.credentials_revoked`, so the theft record survives while a
+    rejected sign-in of the same age is still swept.
     """
     async with api.factory() as s:
         old = datetime.now(timezone.utc) - timedelta(days=120)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -875,6 +875,148 @@ async def test_revocation_is_recorded_against_the_actor(api) -> None:
     assert json.loads(events[0].payload_json)["reason"] == "signed_out"
 
 
+async def test_a_no_op_revoke_writes_no_audit_row(api) -> None:
+    """A retry the endpoint blesses must not add a `0/0` audit row.
+
+    `/revoke` is idempotent and its contract invites the retry a flaky mobile
+    connection makes. A refresh token whose grant is already revoked is still
+    *found* by `inspect_refresh_token` (it returns the row, revoked), so the
+    handler calls `revoke_auth_grant` again — revoking nothing. Recording
+    `auth.credentials_revoked` on that no-op buries the real revocations under
+    `0/0` rows, the more so now that the retention sweep no longer ages them out.
+    """
+    body = sign_in(api).json()
+    first = api.post("/api/v1/auth/revoke", json={"refreshToken": body["refreshToken"]})
+    assert first.status_code == 200 and first.json()["accessTokensRevoked"] >= 1
+
+    # The same, now-revoked refresh token again: the grant is found but already
+    # revoked, so this call revokes nothing.
+    second = api.post("/api/v1/auth/revoke", json={"refreshToken": body["refreshToken"]})
+    assert second.status_code == 200 and second.json()["accessTokensRevoked"] == 0
+
+    events = await audit_events(api.factory, "auth.credentials_revoked")
+    assert len(events) == 1, (
+        f"a no-op revoke wrote an audit row: {[json.loads(e.payload_json) for e in events]}"
+    )
+
+
+async def test_a_last_minute_rotation_does_not_outlive_the_grant_deadline(api) -> None:
+    """A rotation near the grant's end must not mint an access token past it.
+
+    The grant has an absolute lifetime (`refreshTokenExpiresAt`, carried forward
+    unchanged). Minting `access_expires_at = now + access_TTL` on the last legal
+    rotation put the access token's expiry *after* the grant deadline, and
+    `GET /auth/me` answered 200 with it past the deadline the grant is documented
+    to enforce. The access expiry is capped at the grant deadline.
+    """
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    async with api.factory() as s:
+        await store.issue_auth_grant(
+            s,
+            grant_id="g-deadline",
+            access_token="old-access",
+            refresh_token="old-refresh",
+            client_id="codexbridge-mobile",
+            user_id="alice",
+            scopes=["codexbridge.read"],
+            access_expires_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+            refresh_expires_at=deadline,
+            event_type="auth.signed_in",
+        )
+
+    rotated = api.post("/api/v1/auth/refresh", json={"refreshToken": "old-refresh"})
+    assert rotated.status_code == 200
+    body = rotated.json()
+
+    access_exp = datetime.fromisoformat(body["accessTokenExpiresAt"].replace("Z", "+00:00"))
+    refresh_exp = datetime.fromisoformat(body["refreshTokenExpiresAt"].replace("Z", "+00:00"))
+    assert access_exp <= refresh_exp, (
+        f"the rotated access token expires at {access_exp}, past the grant deadline {refresh_exp}"
+    )
+    # expiresIn is capped too, not left at the full TTL — it is the field the
+    # contract tells the client to schedule its refresh from.
+    assert body["expiresIn"] <= 30, f"expiresIn stayed at the full TTL: {body['expiresIn']}"
+
+
+async def test_a_rotation_far_from_the_deadline_still_gets_the_full_access_ttl(api) -> None:
+    """The deadline cap must not shorten a normal rotation — the fix's floor.
+
+    Capping `access_expires_at` at the grant deadline is right only when the
+    deadline is nearer than the TTL. A rotation 30 days out must still mint an
+    access token good for the full access TTL, not the whole grant; dropping the
+    `min` and always using the deadline would hand out a 30-day access token and
+    this is what catches it.
+    """
+    from gateway.app.core.config import settings
+
+    ttl = settings.oauth_access_token_ttl_seconds
+    async with api.factory() as s:
+        await store.issue_auth_grant(
+            s,
+            grant_id="g-far",
+            access_token="far-access",
+            refresh_token="far-refresh",
+            client_id="codexbridge-mobile",
+            user_id="alice",
+            scopes=["codexbridge.read"],
+            access_expires_at=datetime.now(timezone.utc) + timedelta(seconds=ttl),
+            refresh_expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            event_type="auth.signed_in",
+        )
+
+    body = api.post("/api/v1/auth/refresh", json={"refreshToken": "far-refresh"}).json()
+    now = datetime.now(timezone.utc)
+    access_exp = datetime.fromisoformat(body["accessTokenExpiresAt"].replace("Z", "+00:00"))
+    assert access_exp - now <= timedelta(seconds=ttl + 5), (
+        f"a far-deadline rotation minted an access token good for {access_exp - now}, "
+        f"past the {ttl}s TTL"
+    )
+    assert body["expiresIn"] <= ttl + 5
+
+
+async def test_the_retention_sweep_keeps_a_refresh_reuse_record(api) -> None:
+    """The spam sweep must not age out the record that a token was replayed.
+
+    `auth.credentials_revoked{reason:"refresh_token_reuse"}` is the one durable
+    artefact saying a stolen refresh token was replayed on a grant. Scoping the
+    retention window to `entity_type == "auth"` deleted it along with rejected
+    sign-ins; it is scoped to `event_type == "auth.sign_in_failed"` so only the
+    unauthenticated spam ages out, while a rejected sign-in of the same age is
+    still swept.
+    """
+    async with api.factory() as s:
+        old = datetime.now(timezone.utc) - timedelta(days=120)
+        s.add(
+            AuditEventModel(
+                entity_type="auth",
+                entity_id="alice",
+                event_type="auth.credentials_revoked",
+                payload_json=json.dumps({"grant_id": "g1", "reason": "refresh_token_reuse"}),
+                created_at=old,
+            )
+        )
+        s.add(
+            AuditEventModel(
+                entity_type="auth",
+                entity_id="alice",
+                event_type="auth.sign_in_failed",
+                payload_json=json.dumps({"reason": "bad_password"}),
+                created_at=old,
+            )
+        )
+        await s.commit()
+
+        purged = await store.purge_expired_audit_events(s, retention_days=90)
+        survivors = sorted(
+            row.event_type for row in (await s.execute(select(AuditEventModel))).scalars()
+        )
+
+    assert purged == 1, "the sweep took something other than the rejected sign-in"
+    assert survivors == ["auth.credentials_revoked"], (
+        f"the theft record was aged out by a spam control: survivors={survivors}"
+    )
+
+
 # --------------------------------------------------------------------------
 # Who am I, and what may I do
 # --------------------------------------------------------------------------

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -12,6 +12,7 @@ from gateway.app.core.users import (
     AuthenticatedPrincipal,
     authenticate,
     load_user_registry,
+    lookup_user,
     verify_password,
 )
 
@@ -260,3 +261,118 @@ def test_authenticated_principal_checks_scopes_and_projects() -> None:
     assert not principal.has_scope("codexbridge.task.submit")
     assert principal.can_access_project("p1")
     assert not principal.can_access_project("p2")
+
+
+# --------------------------------------------------------------------------
+# Adversarial review (issue #4 council): the registry loader fails closed
+# --------------------------------------------------------------------------
+
+
+def test_a_malformed_registry_fails_closed_instead_of_raising(tmp_path) -> None:
+    """A hand-edit that leaves invalid JSON must refuse every credential, not raise.
+
+    The request path (`authenticate`, `lookup_user`) reaches `load_user_registry`;
+    an unhandled `json.JSONDecodeError` there surfaces as an unauthenticated
+    `500 internal_error retryable:true` on `/auth/sign-in` and `/auth/me` — a new
+    distinguishing channel and a "keep hammering" signal. `load_user_registry`
+    must swallow it and return `{}` (fail closed), so `authenticate` answers the
+    uniform unknown-user refusal at the registry's fallback cost.
+    """
+    path = tmp_path / "users.json"
+    path.write_text('{"users": [ truncated mid-edit', encoding="utf-8")
+
+    assert load_user_registry(str(path)) == {}
+    outcome = authenticate(str(path), "alice", "s3cret")
+    assert not outcome.ok and outcome.user is None
+
+
+def test_a_shape_pydantic_refuses_fails_closed(tmp_path) -> None:
+    """A structurally-valid JSON whose entries lack required fields also fails closed."""
+    path = tmp_path / "users.json"
+    path.write_text(json.dumps({"users": [{"user_id": "alice"}]}), encoding="utf-8")
+
+    assert load_user_registry(str(path)) == {}
+    assert not authenticate(str(path), "alice", "s3cret").ok
+
+
+def test_a_duplicate_user_id_refuses_the_whole_registry(tmp_path) -> None:
+    """Last-write-wins on a colliding key silently rebinds a live token's privileges.
+
+    `current_principal` re-resolves a token's `user_id` against the registry on
+    every request, so a second `alice` entry — say one carrying `roles:["admin"]`
+    — would inherit the first alice's already-issued tokens. The loader refuses a
+    registry it cannot make unambiguous rather than pick the last entry.
+    """
+    first = _user(user_id="alice", email="alice@example.com", roles=[])
+    second = _user(
+        user_id="alice", email="other@example.com", roles=["admin"], scopes=["codexbridge.admin"]
+    )
+    path = _registry_file(tmp_path, first, second)
+
+    assert load_user_registry(path) == {}, "a duplicate user_id must refuse the registry"
+    assert not authenticate(path, "alice", "s3cret").ok
+
+
+def test_a_user_id_colliding_with_another_email_refuses_the_registry(tmp_path) -> None:
+    """A `user_id` equal to another account's e-mail is the same collision."""
+    victim = _user(user_id="ops", email="ops@example.com")
+    attacker = _user(user_id="ops@example.com", email="mallory@example.com", roles=["admin"])
+    path = _registry_file(tmp_path, victim, attacker)
+
+    assert load_user_registry(path) == {}
+
+
+def test_a_case_variant_collision_is_refused(tmp_path) -> None:
+    """The collision is case-insensitive, because resolution is.
+
+    `lookup_user` folds the input with `.lower()` first, so an attacker whose
+    `user_id` is `"OPS@EXAMPLE.COM"` resolves to the victim's `ops@example.com`
+    e-mail even though the two never byte-match. Detecting the collision on the
+    raw key would miss exactly this, and leave the escalation open.
+    """
+    victim = _user(user_id="Ops", email="ops@example.com", roles=["admin"])
+    attacker = _user(user_id="OPS@EXAMPLE.COM", email="mallory@example.com", roles=[])
+    path = _registry_file(tmp_path, victim, attacker)
+
+    assert load_user_registry(path) == {}
+    assert lookup_user(path, "OPS@EXAMPLE.COM") is None
+
+
+def test_a_non_pbkdf2_hash_does_not_set_the_derivation_cost(tmp_path) -> None:
+    """An argon2/scrypt string in the registry must not dictate the PBKDF2 target.
+
+    `verify_password` only ever derives `pbkdf2_sha256`, so an `argon2id$N$...`
+    entry is never actually verified — reading its second field as a PBKDF2 round
+    count let one migrated hash impose `N` rounds on every unauthenticated
+    attempt. `argon2id$99000000$...` is worth 0, like an unparseable hash, so the
+    registry falls back to its cost rather than to 99 million rounds.
+    """
+    from gateway.app.core.users import _iterations_of, _registry_iterations
+
+    assert _iterations_of("argon2id$99000000$c2FsdA$ZGln") == 0
+    registry = load_user_registry(
+        _registry_file(tmp_path, _user(password_hash="argon2id$99000000$c2FsdA$ZGln"))
+    )
+    # No parseable pbkdf2 cost present -> fallback, not the argon2 number.
+    assert _registry_iterations(registry) == 600000
+
+
+def test_an_over_ceiling_pbkdf2_hash_is_unusable_and_uncosted(tmp_path) -> None:
+    """A typo'd pbkdf2 round count cannot turn one line into an authentication DoS.
+
+    Above `_MAX_ITERATIONS` the hash is refused by `verify_password` (the account
+    cannot sign in) and worth 0 to `_iterations_of` (it does not set the
+    derivation target either) — so an attempt that names the account does not
+    spend the absurd count, and the decoy/padding cost falls back to the
+    registry's real ceiling rather than the absurd one. The hash is hand-built
+    with a dummy digest so the test never itself derives 99 million rounds.
+    """
+    from gateway.app.core.users import _iterations_of, _registry_iterations, verify_password
+
+    absurd = "pbkdf2_sha256$99000000$c2FsdA$ZGln"
+    assert _iterations_of(absurd) == 0
+    assert verify_password("anything", absurd) is False
+
+    registry = load_user_registry(_registry_file(tmp_path, _user(password_hash=absurd)))
+    # No usable pbkdf2 cost present -> fallback, not 99 million and not the ceiling.
+    assert _registry_iterations(registry) == 600000


### PR DESCRIPTION
Adversarial review of the merged issue #4 auth/mobile-sessions delivery — the review the issue's RESUME asked for as "DO THIS FIRST". Two council rounds, three lenses (security, skeptic, second-caller), per `.docs/agents/council.md`.

## Fixed here (each with a test that fails without the fix)

- **S2** — a malformed/unreadable `users.json` answered an unauthenticated `500 internal_error retryable:true` on `/auth/sign-in` and `/auth/me`. `load_user_registry` now fails **closed** (`{}` → uniform 401); `_read_user_registry` is the raising form for the startup diagnostic.
- **S4** — last-write-wins on a colliding registry key silently rebound a live token's privileges (a duplicate `user_id`, or a `user_id` equal to another account's e-mail). The loader now refuses a **case-folded** duplicate key, matching how lookup resolves it.
- **S5** — a non-pbkdf2 or absurd round count (`…$99000000$…`) set the PBKDF2 cost for every unauthenticated attempt (authentication DoS). `_iterations_of`/`verify_password` refuse it; ceiling `_MAX_ITERATIONS = 10_000_000`.
- **SC#1** — a last-minute rotation minted an access token (and `expiresIn`) good past the grant's absolute deadline; `/auth/me` answered 200 with it after the deadline. Now capped at the grant deadline.
- **SC#7** — an idempotent-retry no-op `/revoke` (an already-revoked refresh token is still found) wrote a `0/0` audit row. Recorded only when something was revoked.
- **S3** — the retention sweep aged out `auth.credentials_revoked{refresh_token_reuse}` (the durable theft record). Scoped to `AUTH_SWEEPABLE_EVENT_TYPES`; incident rows preserved.

## Left to the operator (see `docs/security.md`)

These contradict an established rule or a fenced decision, so per `.docs/agents/council.md` §1 they leave the council rather than being fixed silently:

- **S1 (ship-blocking)** — a `roles:["admin"]` account gets a grant with scopes intersected to `CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES` (possibly `[]`) yet `is_admin()` reads `roles`, not the grant, so a **narrowed OAuth delegation still confers full admin**. Fixing it points against the roles model pinned by `test_auth.py:1120-1156` — operator's direction.
- **Rotation-race theft policy** — the skeptic (concurrent race loser is not revoked/audited) and the second-caller (a benign retry after a lost response is punished as theft, killing a healthy session) point in **opposite directions** → governance-precedence → operator.
- **/revoke counter oracle** — the counters leak token validity/rotation history to an unauthenticated caller, but the response body is **entangled with the operator-fenced finding 17's pinning test**, so changing it needs the operator.
- **S6** (`/mcp` non-dict body → 500 before auth; out of #4 scope) and **S7** (per-request registry parse on the event loop; scaling).

**Finding 17** (a spent refresh token still ends its grant) — confirmed still true, untouched.

## Checks

`.venv/bin/python -m pytest -q` → **561 passed, 3 skipped**. Each new test was verified failing against the unfixed source. The contract suite needs the project `.venv` (system python lacks `fastapi.routing.iter_route_contexts`).

Not validated: Postgres; any deployed environment. `governancekit council --record` was not produced (no pre-commit hook here) — the four counts per round are in `docs/issues/004-.../RESUME.md` and `docs/napkin-lessons.md`.

Do not merge / do not close #4 — operator merges and closes.
