### PR TITLE
feat(gh-14): contract artifact, compatibility gate and body/example conformance tests

### DIFF
--- a/contract/1.6.0/codex-bridge.openapi.yaml
+++ b/contract/1.6.0/codex-bridge.openapi.yaml
@@ -34,9 +34,12 @@ info:
 
     ## Conventions
 
-    These are review rules for every endpoint added to this document. No test
-    enforces them yet — response-body conformance is issue #14's scope — so they
-    are checked by the reviewer, not by CI.
+    These are review rules for every endpoint added to this document. Issue #14
+    made the *third* one machine-checked, and only as far as it reaches: the
+    error envelope is validated against `components/schemas/Error` for the
+    failure responses `tests/contract/test_declared_examples_are_real.py` can
+    drive without a credential. The other three, and every authenticated
+    endpoint, are still checked by the reviewer and not by CI.
 
     - All timestamps are RFC 3339 with an explicit UTC offset (`Z`). Note that
       `format: date-time` alone does not require `Z`; the rule is stricter than
@@ -2294,6 +2297,20 @@ paths:
           $ref: '#/components/responses/RateLimited'
         '500':
           $ref: '#/components/responses/InternalError'
+
+# The oldest *published* contract version this build still promises to serve —
+# the floor `EDortta/CodexBridgeMobile` may pin. It lives here rather than in a
+# repository-local constant so it travels with the artifact: a consumer that
+# fetched `contract/<v>/codex-bridge.openapi.yaml` reads the floor without
+# cloning this repository, the same reason `x-contract-excluded-paths` is here
+# and not in the test.
+#
+# `scripts/check_contract_compatibility.py` compares this document against the
+# published copy of this version and fails on any change §"What is a breaking
+# change" forbids. Raising it is a deliberate act: it drops the promise to
+# every client still on the older pin, and needs the same conversation with the
+# mobile team as a deprecation does.
+x-minimum-supported-version: '1.6.0'
 
 # Public HTTP routes the gateway serves that are deliberately NOT part of this
 # contract. Every entry needs a reason: `tests/contract/test_openapi_document.py`

--- a/contract/1.6.0/codex-bridge.openapi.yaml
+++ b/contract/1.6.0/codex-bridge.openapi.yaml
@@ -1,0 +1,3733 @@
+openapi: 3.1.0
+
+info:
+  title: CodexBridge Mobile API
+  summary: Contract-first HTTP API consumed by CodexBridgeMobile.
+  version: 1.6.0
+  description: |
+    Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
+    consumes. For that API this document is the **source of truth**: an
+    endpoint under `/api` that is not here is not public, and a field that is
+    not here is not part of the contract.
+
+    This is the **only** OpenAPI description of this gateway. FastAPI's
+    auto-generated document and its UIs (`/openapi.json`, `/docs`, `/redoc`) are
+    switched off in `gateway/app/main.py`: they described the internal MCP and
+    OAuth surfaces and carried none of the rules below, and serving them put two
+    public descriptions of one gateway on the wire — with the reachable one not
+    being the canonical one. There is no second document to reconcile against.
+
+    ## What this document does not cover
+
+    The MCP transport (`POST /mcp`), the OAuth authorization endpoints, the
+    Prometheus scrape endpoint (`GET /metrics`) and the reverse executor
+    WebSocket are **internal or third-party-facing** surfaces with their own
+    contracts. Each one is listed in `x-contract-excluded-paths` below with the
+    reason it is out of scope — see `docs/api/README.md` §"Contract scope".
+
+    ## Versioning
+
+    The public namespace is `/api/v1`. Compatibility, deprecation and the rules
+    that force a new namespace are specified in `docs/api/README.md`. The
+    `info.version` above is the **contract** version (semver) and is independent
+    of the gateway application version.
+
+    ## Conventions
+
+    These are review rules for every endpoint added to this document. No test
+    enforces them yet — response-body conformance is issue #14's scope — so they
+    are checked by the reviewer, not by CI.
+
+    - All timestamps are RFC 3339 with an explicit UTC offset (`Z`). Note that
+      `format: date-time` alone does not require `Z`; the rule is stricter than
+      the schema can express.
+    - Collection endpoints use the cursor pagination described by `PageInfo`.
+      **Append-only log streams are not collections** and page differently: the
+      underlying store addresses log lines by a monotonic integer offset
+      (`store.get_logs`), which the MCP client already consumes that way. Issue
+      #9 defines that scheme; do not force a cursor over it retroactively.
+    - All errors use the `Error` envelope. No endpoint returns a bare string.
+    - No response exposes a server filesystem path, a credential, or an internal
+      executor address. See `docs/api/README.md` §"Fields that must never ship".
+
+servers:
+  - url: https://{host}
+    description: |
+      Public CodexBridge deployment, reached through an nginx edge proxy.
+
+      The default `host` matches `settings.public_base_url` in
+      `gateway/app/core/config.py`, so a generated client names the real
+      deployment rather than a placeholder. **It does not promise that every
+      contracted route is reachable there.** The contract test inventories
+      `gateway.app.main.app.routes` in-process; the edge proxy in
+      `deploy/incus/` decides separately what it forwards, and it already
+      answers 404 or 403 for surfaces the application serves. End-to-end
+      reachability is unverified by this repository's tests.
+    variables:
+      host:
+        default: codexbridge.inovacaosistemas.com.br:8443
+        description: |
+          Hostname and port of the deployment. Override it when developing
+          against a local gateway — the default is production.
+
+paths:
+
+  /api/v1/auth/sign-in:
+    post:
+      operationId: signIn
+      tags: [auth]
+      summary: Exchange a username and password for an access and refresh token
+      description: |
+        The mobile session starts here. The credential checked is the one in the
+        gateway's user registry — the same hash the browser OAuth flow verifies
+        — and the response is the pair every other endpoint uses.
+
+        **Device authorization (RFC 8628) is not implemented.** It exists for
+        clients that cannot show a keyboard, and this client can. `GET
+        /api/version` reports `deviceAuthorization: false` so the difference is
+        visible rather than assumed.
+
+        Every failure is `401 unauthenticated` with one message, whether the
+        account is unknown, the password is wrong, or the account is disabled.
+        Distinguishing them turns this endpoint into a user directory. The
+        server also spends the same password-derivation work on an unknown
+        username, because a response that is identical but faster says the same
+        thing.
+
+        `scopes` in the response is the account's scopes **intersected with the
+        server's configured allowlist**, so it can be narrower than what the
+        registry grants the account. Read the field; do not assume the request
+        got everything the account has. The same ceiling applies to the browser
+        OAuth flow, and both flows write to the same token store.
+
+        The response is `Cache-Control: no-store`. It carries credentials.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [username, password]
+              properties:
+                username:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  description: User id or email, as registered in the gateway.
+                password:
+                  type: string
+                  minLength: 1
+                  maxLength: 1024
+                  format: password
+      responses:
+        '200':
+          description: A new grant.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokens'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/auth/refresh:
+    post:
+      operationId: refreshTokens
+      tags: [auth]
+      summary: Rotate a refresh token into a new pair
+      description: |
+        Returns a new access token **and a new refresh token**. The presented
+        refresh token is consumed by the exchange: it is single use.
+
+        Presenting a consumed refresh token revokes the entire grant — both
+        tokens, immediately. Replay and theft are indistinguishable from the
+        server side, and the safe reading of that ambiguity is theft: signing in
+        again is cheap, sharing a session with whoever holds the copy is not.
+
+        `refreshTokenExpiresAt` does **not** move. A grant has an absolute
+        lifetime, so rotation cannot extend a stolen credential into a session
+        that never ends. When it passes, sign in again.
+
+        Scopes are re-read from the registry on every rotation and intersected
+        with what the grant already carried — never widened. A disabled or
+        removed account ends the grant here rather than at the next expiry.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [refreshToken]
+              properties:
+                refreshToken:
+                  type: string
+                  minLength: 1
+                  maxLength: 1024
+      responses:
+        '200':
+          description: A rotated grant. The presented refresh token is now dead.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokens'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/auth/revoke:
+    post:
+      operationId: revokeTokens
+      tags: [auth]
+      summary: Sign out — end the grant now rather than at expiry
+      description: |
+        Accepts either credential: the access token in the `Authorization`
+        header, the refresh token in the body, or both. Both are accepted
+        because the usual moment to sign out on a phone is after the access
+        token has already expired, and requiring a live one would mean the only
+        way to end a session is to wait for it.
+
+        Revocation reaches **both** tokens of the grant, not only the one
+        presented. A revoked access token stops working immediately, on this API
+        and on the MCP transport alike — they read one credential store.
+
+        Idempotent and deliberately incurious: an unknown, expired or
+        already-revoked credential is answered `200` like any other (RFC 7009).
+        The counters report how many credentials this call actually revoked, so
+        `0` is a meaningful answer and not an error.
+
+        `401` here means nothing usable was presented — no body, and no access
+        token the server recognises. It is a statement about the request, not
+        about a credential. A client whose access token has already expired
+        signs out with the refresh token, which is the half that keeps the grant
+        alive.
+      security:
+        - bearerAuth: []
+        - {}
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                refreshToken:
+                  type: string
+                  maxLength: 1024
+                  description: |
+                    Required when no access token is sent. Supplying both
+                    revokes the same grant once.
+      responses:
+        '200':
+          description: The credential can no longer be used.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [revoked, revokedAt]
+                properties:
+                  revoked:
+                    type: boolean
+                    description: Always `true`. The credential is unusable after this call.
+                  revokedAt:
+                    $ref: '#/components/schemas/Timestamp'
+                  accessTokensRevoked:
+                    type: integer
+                    description: |
+                      How many access tokens this call revoked. `0` when the
+                      credential was already revoked, expired or unknown — which
+                      is not an error.
+                  refreshTokensRevoked:
+                    type: integer
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/auth/me:
+    get:
+      operationId: getCurrentActor
+      tags: [auth]
+      summary: The authenticated actor and what it may do
+      description: |
+        What a client reads **before** it renders a screen. `permissions` is the
+        server's own authorization table evaluated for this actor, so a control
+        the client offers and a `403` from the endpoint behind it cannot
+        disagree — both are decided by the same list.
+
+        The list contains only actions this build serves. An action absent from
+        it is not "denied", it is "not offered by this server", and a client
+        should treat an unknown action the same way: ignore it. New entries may
+        be added within a major version.
+
+        `projects.all` is a flag rather than an empty-list convention, because
+        "every project" and "no projects" are otherwise one character apart, and
+        the direction that mistake fails in is the one that grants everything.
+
+        **This operation declares no `403`, and that is deliberate.** On this
+        surface `403 permission_denied` comes from the per-action guard and from
+        nowhere else, and there is no action to guard here — every authenticated
+        actor may ask who they are. A token whose account has since been
+        disabled or removed is a `401`, like any other dead credential: the
+        recovery is to sign in again, not to tell the operator they lack a
+        permission.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The actor, its scopes, and its effective permissions.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [actor, scopes, projects, permissions, generatedAt]
+                properties:
+                  actor:
+                    $ref: '#/components/schemas/Actor'
+                  roles:
+                    type: array
+                    items:
+                      type: string
+                  scopes:
+                    type: array
+                    description: OAuth scopes carried by the presented token.
+                    items:
+                      type: string
+                  projects:
+                    type: object
+                    required: [all, ids]
+                    properties:
+                      all:
+                        type: boolean
+                        description: |
+                          The actor sees every project. `ids` is then empty and
+                          means nothing — do not read it as a restriction.
+                      ids:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ProjectId'
+                  permissions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Permission'
+                  authScheme:
+                    type: string
+                    description: How the caller authenticated, e.g. `oauth`.
+                  generatedAt:
+                    $ref: '#/components/schemas/Timestamp'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/projects:
+    get:
+      operationId: listProjects
+      tags: [projects]
+      summary: Projects the caller may see, ordered by id
+      description: |
+        A **project** is a registry entry, addressed by `ProjectId` and never by
+        its server filesystem path — `ProjectModel.path` is excluded by
+        contract, see `docs/api/README.md` "Fields that must never ship".
+
+        `health`, `pendingDecisions`, `activeMissions` and `totalSessions` are
+        derived at read time from `TaskModel` and from executor liveness, not
+        stored columns of their own. See `docs/api/README.md` "Projects" for
+        what "mission" and "decision" mean here ahead of issues #6 and #7.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          description: Case-insensitive substring match against project id or name.
+          schema:
+            type: string
+            maxLength: 255
+        - name: status
+          in: query
+          required: false
+          description: Restrict to projects that are enabled or disabled in the registry.
+          schema:
+            type: string
+            enum: [enabled, disabled]
+        - name: attention
+          in: query
+          required: false
+          description: |
+            When `true`, only projects that are enabled and unhealthy, or that
+            hold at least one pending decision. When `false`, the complement.
+            Absent means unfiltered. Combining this with `cursor` and `limit`
+            still yields authoritative pages — see `docs/api/README.md` for how
+            this filter is computed.
+          schema:
+            type: boolean
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of projects.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ProjectStatus'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/projects/{projectId}:
+    get:
+      operationId: getProject
+      tags: [projects]
+      summary: One project's status
+      description: |
+        A project in a project scope the caller cannot see returns `404`, never
+        `403` — confirming that an identifier exists is what probing is for.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProjectId'
+      responses:
+        '200':
+          description: The project's status.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectStatus'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/projects/{projectId}/summary:
+    get:
+      operationId: getProjectSummary
+      tags: [projects]
+      summary: The full operational dashboard for one project
+      description: |
+        Everything `GET /api/v1/projects/{projectId}` returns, plus the
+        per-executor liveness breakdown `health` is derived from and a
+        `generatedAt` timestamp. Split from the plain read because a list of
+        projects does not need one executor array repeated per row — opening a
+        single project's dashboard does.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProjectId'
+      responses:
+        '200':
+          description: The project's full operational summary.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectSummary'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions:
+    get:
+      operationId: listSessions
+      tags: [sessions]
+      summary: Sessions the caller may see, newest first
+      description: |
+        A **session** is one `codex exec` run on an executor. Only sessions in
+        projects the caller may see are returned, and the filter is applied to
+        the query — so `page.hasMore` describes what the caller can actually
+        reach, not what exists.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+        - name: state
+          in: query
+          required: false
+          description: Repeatable. Restricts to these session states.
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: A page of sessions.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Session'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}:
+    get:
+      operationId: getSession
+      tags: [sessions]
+      summary: One session
+      description: |
+        Returns an `ETag` derived from the session's revision. Send it back as
+        `If-Match` on any write to this session.
+
+        A session in a project the caller cannot see returns `404`, never `403`:
+        confirming that an identifier exists is what probing is for.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The session.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}/logs:
+    get:
+      operationId: getSessionLogs
+      tags: [sessions]
+      summary: Log lines, by offset
+      description: |
+        **Offset-paged, not cursor-paged.** Log lines are append-only and
+        addressed by a monotonic integer offset in the store, and the MCP client
+        already reads the same rows that way; giving one table two paging
+        vocabularies would be a v1-breaking mistake to undo. This is the
+        exception `PageInfo` names, not a contradiction of it.
+
+        Lines are redacted on the way out — credentials in query strings,
+        absolute filesystem paths and `host:port` pairs — on top of whatever was
+        applied when they were stored. Do not treat stored log text as safe: the
+        gateway's own logs have carried a credential (issue #15).
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - name: offset
+          in: query
+          required: false
+          description: First log offset to return. Resume with `nextOffset`.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 200
+      responses:
+        '200':
+          description: A slice of the log.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, nextOffset, hasMore]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LogLine'
+                  nextOffset:
+                    type: integer
+                    description: Pass as `offset` to continue. Authoritative; do not add to it yourself.
+                  hasMore:
+                    type: boolean
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}/stop:
+    post:
+      operationId: stopSession
+      tags: [sessions]
+      summary: Cancel a queued or running session
+      description: |
+        `stop` sends `task.cancel` to the executor when it is connected, and
+        otherwise records the session as cancelled immediately.
+
+        Requires `If-Match`. With `Idempotency-Key`, a retry returns the first
+        response and stops nothing twice; the replay carries
+        `Idempotent-Replay: true`.
+
+        A disconnected executor does not fail the call: refusing would leave the
+        operator unable to stop a session exactly when the executor is
+        unreachable. The response then carries `executorNotified: false`, and
+        that distinction was load-bearing before issue #16: nothing resent
+        `task.cancel` on reconnect at all — not on a plain reconnect, and not
+        on a full gateway restart either, since the startup recovery sweep has
+        always skipped tasks already in `cancelled` (issue #17) — so the run
+        could continue indefinitely while the session read as cancelled.
+        Issue #16 built exactly that replay — for `task.cancel` and for
+        pending `task.pause`/`task.resume`/`task.restart` alike — as a side
+        effect of fixing the equivalent gap for its own three controls, so a
+        reconnect now resends whichever control a task is still waiting on.
+        `executorNotified: false` still means the executor did not hear about
+        it *yet*; it is resolved on the next reconnect rather than left open
+        indefinitely. The replay itself is bounded — `cancel_replay_max_age_seconds`
+        (default 24h) — so an executor that reappears long after the
+        cancellation is not chased with a `task.cancel` for a run that has
+        almost certainly already finished.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The session after cancellation.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}/pause:
+    post:
+      operationId: pauseSession
+      tags: [sessions]
+      summary: Ask the executor to pause a running session
+      description: |
+        Sends `task.pause` to a **connected** executor and moves the session to
+        `pausing` until the executor acknowledges it with `task.ack`.
+
+        Requires `If-Match`. With `Idempotency-Key`, a retry returns the first
+        response and does not enqueue a second pause request.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The session in its transitional control state.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}/resume:
+    post:
+      operationId: resumeSession
+      tags: [sessions]
+      summary: Ask the executor to resume a paused session
+      description: |
+        Sends `task.resume` to a **connected** executor and moves the session
+        to `resuming` until the executor acknowledges it with `task.ack`.
+
+        Requires `If-Match`. With `Idempotency-Key`, a retry returns the first
+        response and does not enqueue a second resume request.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The session in its transitional control state.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}/restart:
+    post:
+      operationId: restartSession
+      tags: [sessions]
+      summary: Ask the executor to restart a running or paused session
+      description: |
+        Sends `task.restart` to a **connected** executor and moves the session
+        to `restarting` until the executor acknowledges it with `task.ack`.
+
+        Requires `If-Match`. With `Idempotency-Key`, a retry returns the first
+        response and does not enqueue a second restart request.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The session in its transitional control state.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/sessions/{sessionId}/explain-error:
+    post:
+      operationId: explainSessionError
+      tags: [sessions]
+      summary: Why this session failed, assembled server-side
+      description: |
+        Gathers the recorded state, the stored error and the last `stderr`
+        lines, all redacted, in one response.
+
+        It is **not** a generated explanation: no model runs and the executor is
+        not contacted. It is the evidence in one place, so the client does not
+        stitch together a detail call and a log call and guess which lines
+        mattered. `POST` because it is expected to grow into something that
+        does more; it changes nothing today.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The evidence.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [sessionId, state, reasons, generatedAt]
+                properties:
+                  sessionId:
+                    $ref: '#/components/schemas/Id'
+                  state:
+                    type: string
+                  reasons:
+                    type: array
+                    items:
+                      type: string
+                  lastError:
+                    type: [string, 'null']
+                  recentStderr:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LogLine'
+                  generatedAt:
+                    $ref: '#/components/schemas/Timestamp'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/decisions:
+    get:
+      operationId: listDecisions
+      tags: [decisions]
+      summary: Decisions the caller may see, newest first
+      description: |
+        A **decision** is a session (`Session`/`TaskModel`) that needed
+        approval — the same mechanism the MCP transport's `approve_codex_task`
+        tool has driven since before this API existed. Only decisions in
+        projects the caller may see are returned, and the filter is applied to
+        the query — so `page.hasMore` describes what the caller can actually
+        reach, not what exists.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+        - name: project
+          in: query
+          required: false
+          description: |
+            Repeatable. Restricts to these projects, further narrowing —
+            never widening — whatever the caller's own authorization already
+            allows.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProjectId'
+        - name: state
+          in: query
+          required: false
+          description: Repeatable. Restricts to these decision states.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/DecisionState'
+        - name: urgency
+          in: query
+          required: false
+          description: Repeatable. Restricts to these urgency (priority) values.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: risk
+          in: query
+          required: false
+          description: Repeatable. Restricts to these risk levels.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/DecisionRiskLevel'
+        - name: deadlineBefore
+          in: query
+          required: false
+          description: Restricts to decisions whose deadline is at or before this instant.
+          schema:
+            type: string
+            format: date-time
+        - name: deadlineAfter
+          in: query
+          required: false
+          description: Restricts to decisions whose deadline is at or after this instant.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: A page of decisions.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Decision'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/decisions/{decisionId}:
+    get:
+      operationId: getDecision
+      tags: [decisions]
+      summary: One decision
+      description: |
+        Returns an `ETag` derived from the decision's revision. Send it back as
+        `If-Match` on `approve`, `reject`, or `request-revision`.
+
+        A decision in a project the caller cannot see returns `404`, never
+        `403` — and so does a session id that exists but never required
+        approval, for the same reason: confirming that an identifier exists,
+        or what kind of resource it names, is what probing is for.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: decisionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The decision.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Decision'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/decisions/{decisionId}/approve:
+    post:
+      operationId: approveDecision
+      tags: [decisions]
+      summary: Approve a pending decision
+      description: |
+        Requires `If-Match`. A **critical** decision (`risk: sensitive` — every
+        decision this build produces) additionally requires `confirm: true` in
+        the body: `If-Match` proves the client saw the current state, not that
+        the operator meant to approve it, so a critical approval needs one more
+        deliberate bit set. A request missing it is refused with
+        `validation_failed`, naming `/confirm`.
+
+        With `Idempotency-Key`, a retry returns the first response and approves
+        nothing twice; the replay carries `Idempotent-Replay: true`.
+
+        Only a `pending` decision may be approved; a decision already resolved,
+        or otherwise no longer awaiting approval, answers `409`.
+
+        If the task's executor is connected and has a free concurrency slot,
+        it is dispatched the task in the same request — not left for a later,
+        unrelated event to discover it. An offline or already-busy executor
+        is unaffected: the task stays `waiting_executor`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: decisionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  maxLength: 4000
+                confirm:
+                  type: boolean
+                  default: false
+                  description: Required `true` to approve a critical decision. See the operation description.
+      responses:
+        '200':
+          description: The decision after approval.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Decision'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/decisions/{decisionId}/reject:
+    post:
+      operationId: rejectDecision
+      tags: [decisions]
+      summary: Reject a pending decision
+      description: |
+        Requires `If-Match` and a non-empty `reason`: a rejection with no
+        justification is refused with `validation_failed` before it reaches the
+        session, because the operator on the other end of a Decision Center
+        needs to know why their request will not run.
+
+        With `Idempotency-Key`, a retry returns the first response and rejects
+        nothing twice; the replay carries `Idempotent-Replay: true`.
+
+        Only a `pending` decision may be rejected; a decision already resolved,
+        or otherwise no longer awaiting approval, answers `409`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: decisionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 4000
+      responses:
+        '200':
+          description: The decision after rejection.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Decision'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/decisions/{decisionId}/request-revision:
+    post:
+      operationId: requestDecisionRevision
+      tags: [decisions]
+      summary: Send a pending decision back for revision
+      description: |
+        Requires `If-Match` and a non-empty `reason` describing what needs to
+        change, for the same reason `reject` requires one.
+
+        This still cancels the underlying session — see `Decision`'s and
+        `DecisionState`'s descriptions. The agent protocol has no message that
+        reopens a session for editing, so `revision_requested` is a distinct
+        **outcome** from `rejected`, not a state that holds the session open for
+        a resubmission.
+
+        With `Idempotency-Key`, a retry returns the first response and acts
+        nothing twice; the replay carries `Idempotent-Replay: true`.
+
+        Only a `pending` decision accepts this; a decision already resolved, or
+        otherwise no longer awaiting approval, answers `409`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: decisionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason:
+                  type: string
+                  minLength: 1
+                  maxLength: 4000
+      responses:
+        '200':
+          description: The decision after the revision request.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Decision'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+
+  /api/v1/missions:
+    get:
+      operationId: listMissions
+      tags: [missions]
+      summary: Missions the caller may see, newest first
+      description: |
+        A **mission** is the same run `GET /api/v1/sessions` returns, reframed
+        in mission-control vocabulary: `objective` for the instruction,
+        `assignedAgent` for the executor, `stage`/`risk`/`blocked` derived from
+        recorded state. There is no separate mission entity — see
+        `docs/api/README.md` "Missions (issue #7)".
+
+        `stage` is a coarser grouping over `state` (`pending`/`active`/`done`)
+        and is a separate filter from it; both may be given together, and an
+        empty intersection returns an empty page rather than an error.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+        - name: projectId
+          in: query
+          required: false
+          description: Repeatable. Restricts to these projects, intersected with what the caller may see.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProjectId'
+        - name: stage
+          in: query
+          required: false
+          description: Repeatable. Restricts to these coarse stages.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/MissionStage'
+        - name: state
+          in: query
+          required: false
+          description: Repeatable. Restricts to these exact states.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: risk
+          in: query
+          required: false
+          description: Repeatable. Restricts to these risk levels.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/RiskLevel'
+        - name: blocked
+          in: query
+          required: false
+          description: Restricts to missions currently blocked (or not).
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: A page of missions.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Mission'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/missions/{missionId}:
+    get:
+      operationId: getMission
+      tags: [missions]
+      summary: One mission
+      description: |
+        Returns an `ETag` derived from the mission's revision — the same
+        validator `GET /api/v1/sessions/{sessionId}` returns, since they are
+        the same underlying row. Send it back as `If-Match` on `cancel`.
+
+        A mission in a project the caller cannot see returns `404`, never
+        `403`: confirming that an identifier exists is what probing is for.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: missionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The mission.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Mission'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/missions/{missionId}/timeline:
+    get:
+      operationId: getMissionTimeline
+      tags: [missions]
+      summary: The mission's recorded events, oldest first
+      description: |
+        Backed by the same `audit_events` rows every mutator in
+        `gateway/app/services/store.py` already writes — not a new log.
+        Cursor-paginated like any other collection (unlike session logs,
+        which are an append-only stream addressed by offset): a timeline is
+        read forward from creation, so unlike other collections in this
+        contract it pages oldest-first.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: missionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of the mission's timeline, oldest first.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MissionTimelineEvent'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/missions/{missionId}/cancel:
+    post:
+      operationId: cancelMission
+      tags: [missions]
+      summary: Cancel a mission that has not finished
+      description: |
+        `cancel` is the only lifecycle command this API offers for missions,
+        for the same protocol reason `POST /api/v1/sessions/{sessionId}/stop`
+        is the only one for sessions: `task.cancel` is the only lifecycle
+        message the agent protocol defines. `pause` and `resume` need
+        protocol and executor work — see issue #16 — and are deliberately
+        absent rather than present and inert.
+
+        Requires `If-Match`. With `Idempotency-Key`, a retry returns the
+        first response and cancels nothing twice; the replay carries
+        `Idempotent-Replay: true`. This is the one destructive command in
+        this build: it requires an authenticated actor and is audited
+        (`docs/api/README.md`, "Missions (issue #7)").
+
+        A disconnected executor does not fail the call, and the response then
+        carries `executorNotified: false` — nothing replays `task.cancel` on
+        reconnect (issue #17), so the run may continue while the mission
+        reads as cancelled.
+
+        `reason` (issue #36) is optional free text — an operator-typed
+        explanation for the cancellation. It has no dedicated field on
+        `Mission`; it is recorded on the mission's timeline the same way
+        a decision's resolution reason already is.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: missionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  maxLength: 4000
+                  description: Optional. Recorded on the mission's timeline.
+      responses:
+        '200':
+          description: The mission after cancellation.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Mission'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/missions/{missionId}/explain:
+    post:
+      operationId: explainMission
+      tags: [missions]
+      summary: Why this mission is in its current state, assembled server-side
+      description: |
+        The same evidence `POST /api/v1/sessions/{sessionId}/explain-error`
+        gathers — recorded state, stored error, recent `stderr`, all
+        redacted — plus `stage`, `risk`, `blocked` and `blockedReason`, so a
+        client does not need a second call to explain a block. No model runs
+        and the executor is not contacted.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: missionId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The evidence.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [missionId, state, stage, risk, blocked, reasons, generatedAt]
+                properties:
+                  missionId:
+                    $ref: '#/components/schemas/Id'
+                  state:
+                    type: string
+                  stage:
+                    $ref: '#/components/schemas/MissionStage'
+                  risk:
+                    $ref: '#/components/schemas/RiskLevel'
+                  blocked:
+                    type: boolean
+                  blockedReason:
+                    $ref: '#/components/schemas/BlockedReason'
+                  reasons:
+                    type: array
+                    items:
+                      type: string
+                  lastError:
+                    type: [string, 'null']
+                  recentStderr:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LogLine'
+                  generatedAt:
+                    $ref: '#/components/schemas/Timestamp'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/projects/{projectId}/epics:
+    get:
+      operationId: listEpics
+      tags: [epics]
+      summary: Epics in one project, newest first
+      description: |
+        `projectId` outside the caller's visible projects answers `404`, never
+        `403` — the same probing-prevention rule a single hidden session
+        answers with.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProjectId'
+        - name: status
+          in: query
+          required: false
+          description: Repeatable. Restricts to these epic statuses.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/EpicStatus'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of epics.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Epic'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/projects/{projectId}/issues:
+    get:
+      operationId: listIssues
+      tags: [issues]
+      summary: Issues in one project, newest first
+      description: |
+        Filters combine with AND. `projectId` outside the caller's visible
+        projects answers `404`, never `403`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProjectId'
+        - name: status
+          in: query
+          required: false
+          description: Repeatable. Restricts to these issue statuses.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/IssueStatus'
+        - name: priority
+          in: query
+          required: false
+          description: Repeatable. Restricts to these priorities.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/IssuePriority'
+        - name: epicId
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Id'
+        - name: assigneeUserId
+          in: query
+          required: false
+          schema:
+            type: string
+            maxLength: 255
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of issues.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Issue'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/issues/{issueId}:
+    get:
+      operationId: getIssue
+      tags: [issues]
+      summary: One issue
+      description: |
+        Returns an `ETag` derived from the issue's revision. Send it back as
+        `If-Match` on `PATCH` or on the epic-link endpoint.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: issueId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The issue.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    patch:
+      operationId: updateIssue
+      tags: [issues]
+      summary: Change status, priority, labels, assignee, dependencies or blocked reason
+      description: |
+        A field the caller does not mention is left untouched; a field sent
+        explicitly as `null` is cleared. `epicId` cannot be changed here —
+        `POST /api/v1/epics/{epicId}/issues/{issueId}` is the one way to move
+        an issue between epics, so there is exactly one mechanism to test and
+        audit instead of two that can disagree.
+
+        Requires `If-Match`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: issueId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateIssueRequest'
+      responses:
+        '200':
+          description: The issue after the update.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/issues:
+    post:
+      operationId: createIssue
+      tags: [issues]
+      summary: Create an issue
+      description: |
+        `projectId` outside the caller's visible projects answers `404`, never
+        `403`. With `Idempotency-Key`, a retry returns the first response
+        rather than creating a second issue.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateIssueRequest'
+      responses:
+        '201':
+          description: The created issue.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/epics:
+    post:
+      operationId: createEpic
+      tags: [epics]
+      summary: Create an epic
+      description: |
+        `projectId` outside the caller's visible projects answers `404`, never
+        `403`. With `Idempotency-Key`, a retry returns the first response
+        rather than creating a second epic.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateEpicRequest'
+      responses:
+        '201':
+          description: The created epic.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Epic'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/epics/{epicId}/issues/{issueId}:
+    post:
+      operationId: linkIssueToEpic
+      tags: [epics]
+      summary: Attach an issue to an epic
+      description: |
+        Both `epicId` and `issueId` must be in a project the caller may see, or
+        the response is `404`. Requires `If-Match` on the issue's current
+        revision. With `Idempotency-Key`, a retry replays the first response.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: epicId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - name: issueId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The issue after linking.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+            Idempotent-Replay:
+              description: Present and `true` when this is a replayed response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Issue'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/conversations:
+    get:
+      operationId: listConversations
+      tags: [conversations]
+      summary: Conversations the caller may see, newest-created first
+      description: |
+        Ordered by creation time, never by `lastActivityAt` — sorting by an
+        activity timestamp would move a conversation's position in the list
+        the instant a new message lands, which can skip or repeat rows across
+        a paginated walk. See `docs/api/README.md` "Conversations (issue
+        #10)". A client that wants "most recently active first" sorts the
+        page client-side using `lastActivityAt`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+        - name: projectId
+          in: query
+          required: false
+          description: Repeatable. Restricts to these projects, intersected with what the caller may see.
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ProjectId'
+      responses:
+        '200':
+          description: A page of conversations.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Conversation'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    post:
+      operationId: createConversation
+      tags: [conversations]
+      summary: Start a conversation
+      description: |
+        `context` must name at least one product entity — the acceptance
+        criterion this field exists to satisfy. Every reference is resolved
+        and authorization-checked the same way `POST /api/v1/epics/{epicId}/issues/{issueId}`
+        checks both sides of its link: a reference to an entity the caller
+        cannot see answers `404`, indistinguishable from a reference to one
+        that does not exist. Every reference must resolve to the same
+        project, or the request is rejected (`400`); there is no `projectId`
+        field of its own — the project is derived from `context`.
+
+        With `Idempotency-Key`, a retry returns the first response rather
+        than creating a second conversation.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateConversationRequest'
+      responses:
+        '201':
+          description: The created conversation.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/conversations/{conversationId}:
+    get:
+      operationId: getConversation
+      tags: [conversations]
+      summary: One conversation
+      description: |
+        `conversationId` outside the caller's visible projects answers
+        `404`, never `403` — the same probing-prevention rule a single hidden
+        session answers with.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The conversation.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversation'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/conversations/{conversationId}/messages:
+    get:
+      operationId: listMessages
+      tags: [conversations]
+      summary: A conversation's messages, oldest first
+      description: |
+        Oldest first, unlike every newest-first collection elsewhere in this
+        API — a thread is read forward from where it starts, the same
+        reasoning `GET /api/v1/missions/{missionId}/timeline` uses.
+
+        Fetching a page advances the caller's read cursor to the newest
+        message *in that page*, not to "now" — a client that has only fetched
+        an early page must not have later, unfetched messages marked as seen.
+        `docs/api/README.md` "Conversations (issue #10)" has the full
+        reasoning behind `unread`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of messages.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Message'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    post:
+      operationId: postMessage
+      tags: [conversations]
+      summary: Post a message
+      description: |
+        `Idempotency-Key` is what makes an offline retry safe: a mobile
+        client that loses the network right after sending cannot know
+        whether the message landed, and retrying with the same key returns
+        the first response rather than posting a second copy. This is issue
+        #10's acceptance criterion ("message creation is idempotent for
+        offline retries") verbatim.
+
+        `attachments` are opaque artifact/file identifiers, recorded and
+        returned unvalidated — no `ArtifactModel` exists yet (issue #11). See
+        `docs/api/README.md` "Conversations (issue #10)".
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMessageRequest'
+      responses:
+        '201':
+          description: The created message.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /health:
+    get:
+      operationId: getHealth
+      tags: [probes]
+      summary: Liveness probe
+      description: |
+        Reports that the process is running. Touches no dependency, so it stays
+        `ok` even when the database is down — a liveness probe that queries the
+        database restarts a healthy process because the database blinked.
+
+        Unauthenticated, and safe to poll.
+      security: []
+      responses:
+        '200':
+          description: The process is running.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, time]
+                properties:
+                  status:
+                    type: string
+                    enum: [ok]
+                  time:
+                    $ref: '#/components/schemas/Timestamp'
+              example:
+                status: ok
+                time: '2026-08-10T14:32:07Z'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /ready:
+    get:
+      operationId: getReady
+      tags: [probes]
+      summary: Readiness probe
+      description: |
+        Reports whether the server can actually serve requests, and names the
+        dependency when it cannot.
+
+        **Degraded is not unready.** With no executor connected, new tasks cannot
+        run but every read still works, so this returns `200` with
+        `status: degraded`. Returning `503` there would take the API offline
+        exactly when an operator needs it to see why nothing is executing.
+
+        A `503` carries the standard `Error` envelope plus the same `checks`
+        array, so one parser handles both outcomes.
+      security: []
+      responses:
+        '200':
+          description: Ready to serve, possibly with non-required dependencies degraded.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [status, time, checks]
+                properties:
+                  status:
+                    type: string
+                    enum: [ready, degraded]
+                  time:
+                    $ref: '#/components/schemas/Timestamp'
+                  checks:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DependencyCheck'
+              examples:
+                ready:
+                  value:
+                    status: ready
+                    time: '2026-08-10T14:32:07Z'
+                    checks:
+                      - name: database
+                        status: ok
+                        required: true
+                      - name: executors
+                        status: ok
+                        required: false
+                degraded:
+                  value:
+                    status: degraded
+                    time: '2026-08-10T14:32:07Z'
+                    checks:
+                      - name: database
+                        status: ok
+                        required: true
+                      - name: executors
+                        status: degraded
+                        required: false
+        '503':
+          description: |
+            A required dependency is unavailable. The body is the standard
+            `Error` envelope with an added `checks` array naming what failed.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Error'
+                  - type: object
+                    properties:
+                      checks:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/DependencyCheck'
+              example:
+                code: dependency_unavailable
+                message: A required dependency is unavailable.
+                requestId: 5a3f1c88-90b1-4e2a-8a6f-2f9c0d1e7b43
+                retryable: true
+                details:
+                  - field: database
+                    code: unavailable
+                    message: Dependency is not reachable.
+                checks:
+                  - name: database
+                    status: unavailable
+                    required: true
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/version:
+    get:
+      operationId: getApiVersion
+      tags: [probes]
+      summary: Server and contract versions, and capability flags
+      description: |
+        Lets a client decide whether it can talk to this server *before* it
+        commits to a namespace — which is why this path sits outside `/api/v1`.
+        It reports every namespace served, not the one it is nested in, and that
+        obligation is what keeps it from being a versioning hole.
+
+        `contractVersion` is the version of this document the build implements;
+        a contract test asserts the two are equal, so a client that pinned a
+        contract version can tell what the server actually speaks.
+
+        `capabilities` states what is true in this build. A flag is `true` only
+        when a **served endpoint** honours it — never because the server has the
+        code for it. Reporting `idempotencyKeys: true` while no endpoint accepts
+        the header produces exactly the 404 these flags exist to prevent, so a
+        test binds them to the served route table.
+
+        A `false` flag is an honest report of work not yet done, and lets a
+        client degrade instead of meeting a 404. Unknown flags must be ignored:
+        new ones may be added within a major version.
+      security: []
+      responses:
+        '200':
+          description: Version and capability report.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [application, applicationVersion, apiVersions, contractVersion, capabilities, time]
+                properties:
+                  application:
+                    type: string
+                  applicationVersion:
+                    type: string
+                  apiVersions:
+                    type: array
+                    description: Every namespace this server serves, e.g. `["v1"]`.
+                    items:
+                      type: string
+                  contractVersion:
+                    type: string
+                    description: Version of this OpenAPI document the build implements.
+                  buildRevision:
+                    type: string
+                    description: |
+                      Build or commit identifier. Absent when the deployment did
+                      not inject one; absence means "not reported", never "no build".
+                  capabilities:
+                    type: object
+                    additionalProperties:
+                      type: boolean
+                  time:
+                    $ref: '#/components/schemas/Timestamp'
+              example:
+                application: codex-bridge-gateway
+                applicationVersion: '0.1.0'
+                apiVersions: [v1]
+                contractVersion: '1.3.0'
+                buildRevision: b76a391
+                capabilities:
+                  errorEnvelope: true
+                  cursorPagination: true
+                  idempotencyKeys: true
+                  optimisticConcurrency: true
+                  passwordSignIn: true
+                  tokenRefresh: true
+                  tokenRevocation: true
+                  effectivePermissions: true
+                  deviceAuthorization: false
+                  eventStream: false
+                  artifactDownloads: false
+                time: '2026-08-10T14:32:07Z'
+        '429':
+          $ref: '#/components/responses/RateLimited'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+# Public HTTP routes the gateway serves that are deliberately NOT part of this
+# contract. Every entry needs a reason: `tests/contract/test_openapi_document.py`
+# rejects an empty one. A route that is neither in `paths` nor listed here fails
+# that test, so an endpoint can never be omitted by accident — only on purpose,
+# in writing. The human-readable version of this table is `docs/api/README.md`.
+x-contract-excluded-paths:
+
+  - path: /healthz
+    methods: [GET]
+    reason: >-
+      Pre-existing infrastructure probe with no version or capability data.
+      Superseded for mobile by GET /health (issue #3); kept for the existing
+      deployment health checks.
+
+  - path: /metrics
+    methods: [GET]
+    reason: >-
+      Prometheus text exposition format, operator-facing. Its contract is the
+      Prometheus exposition spec, not this document.
+
+  - path: /mcp
+    methods: [POST]
+    reason: >-
+      JSON-RPC/MCP transport for ChatGPT. Its contract is docs/protocol.md and
+      the Model Context Protocol specification.
+
+  - path: /agent/ws
+    methods: [WEBSOCKET]
+    reason: >-
+      Reverse executor channel. Executors dial in over wss and receive tasks;
+      no client of this API ever opens it. Its contract is docs/protocol.md,
+      which specifies the envelope, the handshake and the message types.
+
+  - path: /oauth/authorize
+    methods: [GET, POST]
+    reason: >-
+      OAuth 2.1 authorization endpoint, returning HTML for a browser flow. Its
+      contract is RFC 6749 as profiled by OAuth 2.1, not this document.
+      docs/chatgpt-oauth-rollout.md is a rollout plan and does NOT specify these
+      request/response shapes — do not follow it expecting one.
+
+  - path: /oauth/token
+    methods: [POST]
+    reason: >-
+      OAuth 2.1 token endpoint. Its contract is RFC 6749 plus RFC 7636 (PKCE).
+      See gateway/app/core/oauth.py for what this deployment actually issues.
+
+  - path: /.well-known/oauth-authorization-server
+    methods: [GET]
+    reason: >-
+      OAuth 2.0 Authorization Server Metadata (RFC 8414). Shape is fixed by the
+      RFC and by what ChatGPT's client expects; served from
+      gateway/app/core/oauth.py issuer_metadata().
+
+  - path: /.well-known/openid-configuration
+    methods: [GET]
+    reason: >-
+      OpenID Provider Metadata alias of the RFC 8414 document, served for
+      clients that probe the OIDC path first.
+
+  - path: /.well-known/oauth-protected-resource
+    methods: [GET]
+    reason: >-
+      OAuth 2.0 Protected Resource Metadata (RFC 9728), consumed by the MCP
+      client during discovery.
+
+  # FastAPI's /openapi.json, /docs, /docs/oauth2-redirect and /redoc are NOT
+  # listed here. They are not served at all — main.py passes openapi_url=None,
+  # docs_url=None and redoc_url=None. An exclusion entry for a route the gateway
+  # does not serve would be caught by test_no_exclusion_outlives_its_route, which
+  # is the correct behaviour: this list describes served surfaces, and a surface
+  # that no longer exists needs no exclusion.
+
+# Components that exist in this document but are not referenced by any endpoint
+# yet, each with the issue that will use it. `tests/contract/test_openapi_document.py`
+# rejects an unreferenced component that is not listed here, and rejects an entry
+# with no issue — the same rule as `x-contract-excluded-paths`: a thing may be
+# unused only on purpose and in writing.
+#
+# A client must not build against these. They are published so that a later
+# issue adds endpoints rather than re-litigating shapes, not as a promise of
+# behaviour.
+#
+# Empty today: `Actor` was the last entry and issue #4 wired it into
+# `GET /api/v1/auth/me`, which `test_no_pending_component_is_stale` requires be
+# recorded here by removal. The key stays so the mechanism is visible to whoever
+# declares the next shape ahead of its endpoint.
+x-pending-components: []
+
+components:
+
+  headers:
+
+    XRequestId:
+      description: |
+        Identifier for this one request, echoed on every response including
+        errors. A client may send it to tie its own log to the server's; a value
+        that is not a valid `Id` is replaced rather than echoed, because this
+        header is written into response headers and log lines.
+      required: true
+      schema:
+        $ref: '#/components/schemas/Id'
+
+    RetryAfter:
+      description: |
+        Seconds to wait before repeating the request. Sent with `429` and with
+        `503`. A client that ignores it and retries immediately will be limited
+        again — treat it as the earliest useful retry, not a suggestion.
+      schema:
+        type: integer
+        minimum: 0
+
+    ETag:
+      description: |
+        Entity tag for the returned representation, quoted per RFC 9110. Send it
+        back as `If-Match` on any write to this entity. It is derived from a
+        monotonic revision, so it changes on every mutation — including ones
+        that leave every timestamp untouched.
+      schema:
+        type: string
+      example: '"7"'
+
+    CacheControl:
+      description: |
+        `no-store` on every response that carries a credential or an
+        authorization decision. A client must not write these bodies to disk,
+        and an intermediary must not hold them.
+      schema:
+        type: string
+      example: 'no-store'
+
+  parameters:
+
+    Cursor:
+      name: cursor
+      in: query
+      required: false
+      description: |
+        Opaque position from a previous `page.nextCursor`. Cursors are
+        single-purpose: one issued by a different endpoint, or by this endpoint
+        under different filters, is rejected rather than reinterpreted, because
+        silently paging through the wrong rows is worse than an error.
+      schema:
+        type: string
+        maxLength: 512
+
+    Limit:
+      name: limit
+      in: query
+      required: false
+      description: |
+        Maximum items to return. Values above the server maximum are clamped,
+        not rejected — a client that guessed the ceiling wrong should get a
+        smaller page, not a failure. Always read `page.hasMore` rather than
+        comparing the item count to `limit`.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 200
+        default: 50
+
+    IfMatch:
+      name: If-Match
+      in: header
+      required: true
+      description: |
+        The `ETag` from the read that produced the value being changed. Required
+        on every write that mutates an existing entity: absent, the request is
+        refused with `428`. Treating a missing header as "no opinion" would make
+        concurrency protection opt-in on exactly the requests likeliest to
+        forget it.
+      schema:
+        type: string
+      example: '"7"'
+
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      description: |
+        Client-generated key making a write safe to repeat. A retry carrying the
+        same key returns the first response and changes nothing, which is what
+        lets a mobile client retry after losing the network mid-request without
+        risking a double approval.
+
+        The key is scoped to the endpoint and the authenticated actor, so the
+        same key from a different actor is a different operation. Reusing one
+        key for a *different* body is a client bug and is refused with `409`
+        rather than answered with the earlier response, which would silently
+        drop the second write.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
+
+  responses:
+
+    ValidationFailed:
+      description: The request was malformed or failed validation.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    Unauthenticated:
+      description: |
+        No usable credential was presented. Absent, malformed, unknown, expired,
+        revoked, or belonging to an account that has since been disabled or
+        removed — one status, one code, one message for all of them, because
+        telling them apart tells a caller holding a token they were never given
+        whether it was ever real.
+
+        This is the branch a client answers by signing in again. `403` is the
+        other one.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    PermissionDenied:
+      description: |
+        The actor is authenticated but not permitted. Returned in preference to
+        `404` only when the resource's existence is already known to the caller.
+
+        Signing in again does not help — the credential is fine, the permission
+        is not. On `/api/v1` this comes from the per-action guard and from
+        nowhere else, which is why operations with no action to guard (such as
+        `getCurrentActor`) do not declare it.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    NotFound:
+      description: |
+        No such resource — or the actor may not know whether it exists. Hidden
+        resources return this rather than `403`, so that probing cannot map what
+        the caller cannot see.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    Conflict:
+      description: |
+        The request cannot be applied to the resource's current state — an
+        invalid transition, or an `Idempotency-Key` reused for a different body.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    PreconditionRequired:
+      description: |
+        The write needs an `If-Match` header and none was sent. Re-read the
+        entity, then retry with the `ETag` it returned.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    StaleWrite:
+      description: |
+        The entity changed since the client read it, so the write was refused.
+        The response carries the current `ETag`; re-read, show the current state,
+        and let the operator decide again — never retry automatically.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+        ETag:
+          $ref: '#/components/headers/ETag'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    RateLimited:
+      description: Too many requests. `retryable` is true; honour `Retry-After`.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+        Retry-After:
+          $ref: '#/components/headers/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+    InternalError:
+      description: |
+        Unexpected server failure. The body carries only a `requestId`; the
+        detail stays in the server log, because raw driver errors and stack
+        traces leak schema, filesystem paths and sometimes credentials.
+      headers:
+        X-Request-Id:
+          $ref: '#/components/headers/XRequestId'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  securitySchemes:
+
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+      description: |
+        Opaque access token, presented as `Authorization: Bearer <token>`.
+
+        Two issuers, one credential store. `POST /api/v1/auth/sign-in` mints
+        tokens for CodexBridgeMobile, and the OAuth 2.1 + PKCE authorization
+        endpoints mint them for ChatGPT's MCP client. Both land in the same
+        table, so `POST /api/v1/auth/revoke` takes effect on both surfaces and
+        an expired or revoked token is refused everywhere.
+
+        A token is opaque: it carries no readable claims and must not be parsed.
+        Read `expiresIn` from the response that issued it, and refresh before it
+        elapses rather than waiting for a `401`.
+
+        Every rejection is `401` with code `unauthenticated` and the same
+        message — absent, unknown, expired and revoked are not distinguished,
+        because doing so tells a caller holding a token they were never given
+        whether it was ever real. A client that receives `401` should refresh
+        once, and sign in again if that also fails.
+
+  schemas:
+
+    Id:
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: '^[A-Za-z0-9._:-]+$'
+      description: |
+        Opaque identifier. Clients must treat it as an opaque string and must
+        not parse, order or derive meaning from it. Some identifiers are UUIDs
+        and some are operator-assigned slugs; that difference is an
+        implementation detail and may change without a new API version.
+      examples:
+        - 'codexbridge-demo'
+        - '9f0d6b2c-2f5a-4c2b-9d5e-1a7c3f8e4b10'
+
+    ProjectId:
+      allOf:
+        - $ref: '#/components/schemas/Id'
+      description: Identifier of a project registered in the gateway registry.
+      examples:
+        - 'codexbridge-demo'
+
+    ExecutorId:
+      allOf:
+        - $ref: '#/components/schemas/Id'
+      description: Identifier of a registered executor machine.
+      examples:
+        - 'devel3'
+
+    Timestamp:
+      type: string
+      format: date-time
+      description: |
+        RFC 3339 instant, always in UTC and always carrying the `Z` offset.
+        Clients must not assume the server and the device clocks agree; use
+        server timestamps for ordering and display, never for elapsed-time
+        arithmetic against the device clock.
+      examples:
+        - '2026-08-10T14:32:07Z'
+
+    ActorKind:
+      type: string
+      enum:
+        - user
+        - executor
+        - system
+      description: |
+        What produced an action. `user` is a human principal authenticated
+        through the gateway. `executor` is a registered executor machine acting
+        under its own machine token. `system` is the gateway itself — startup
+        recovery, expiry sweeps and other unattended transitions.
+
+    Actor:
+      type: object
+      description: |
+        Who performed an auditable action. Present on every entity that records
+        provenance. `id` and `displayName` are always safe to render; `email` is
+        omitted when the caller is not authorized to see it.
+      required:
+        - kind
+        - id
+      properties:
+        kind:
+          $ref: '#/components/schemas/ActorKind'
+        id:
+          $ref: '#/components/schemas/Id'
+        displayName:
+          type: string
+          maxLength: 255
+          description: Human-readable label, safe to render in any context.
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          description: |
+            Omitted unless the caller is authorized to see the actor's email.
+            Absence means "not disclosed", never "the actor has no email".
+      examples:
+        - kind: user
+          id: esteban
+          displayName: Esteban D.Dortta
+        - kind: system
+          id: gateway
+          displayName: CodexBridge Gateway
+
+    AuthTokens:
+      type: object
+      description: |
+        One grant: a short-lived access token and the refresh token that renews
+        it. Returned by sign-in and by every rotation.
+
+        Both values are opaque credentials. Store them where the platform stores
+        secrets, never in application logs or crash reports, and treat the whole
+        object as `no-store`.
+      required:
+        - tokenType
+        - accessToken
+        - accessTokenExpiresAt
+        - expiresIn
+        - refreshToken
+        - refreshTokenExpiresAt
+        - scopes
+      properties:
+        tokenType:
+          type: string
+          enum: [Bearer]
+        accessToken:
+          type: string
+          description: |
+            Present in the `Authorization` header as `Bearer <accessToken>`.
+        accessTokenExpiresAt:
+          $ref: '#/components/schemas/Timestamp'
+        expiresIn:
+          type: integer
+          description: |
+            Seconds until the access token expires, counted from the response.
+            Prefer it over `accessTokenExpiresAt` for scheduling a refresh: it
+            is the only form that survives a device whose clock is wrong.
+        refreshToken:
+          type: string
+          description: |
+            Single use. Exchanging it returns a new one and kills this one, and
+            presenting a spent token revokes the whole grant.
+        refreshTokenExpiresAt:
+          $ref: '#/components/schemas/Timestamp'
+          description: |
+            The grant's absolute expiry. It does **not** move when the token is
+            rotated: after this instant the operator signs in again.
+        scopes:
+          type: array
+          description: |
+            What this grant carries. A rotation may return fewer — the registry
+            is re-read each time — and never more.
+          items:
+            type: string
+
+    PermissionCategory:
+      type: string
+      enum:
+        - read
+        - operational
+        - administrative
+      description: |
+        How much an action can do. `read` observes state. `operational` changes
+        what an executor is doing. `administrative` reaches beyond the actor's
+        own projects. A client may use this to group or to gate a confirmation
+        step, but must not infer `allowed` from it.
+
+    Permission:
+      type: object
+      description: |
+        One action, and whether this actor may perform it. The server's own
+        authorization table, evaluated for the caller — not a hint. An endpoint
+        guarded by an action refuses exactly when `allowed` is `false`.
+      required: [action, category, allowed]
+      properties:
+        action:
+          type: string
+          maxLength: 64
+          description: |
+            Stable identifier, e.g. `sessions.stop`. Clients branch on this.
+            Actions may be added within a major version, so an unrecognized one
+            must be ignored rather than treated as denied.
+        category:
+          $ref: '#/components/schemas/PermissionCategory'
+        requiredScope:
+          type: string
+          maxLength: 128
+          description: |
+            The scope that grants this action. Informational: a client must read
+            `allowed` and never re-derive it from the token's scope list, which
+            is how a client's copy of the rules drifts from the server's.
+        allowed:
+          type: boolean
+      examples:
+        - action: sessions.read
+          category: read
+          requiredScope: codexbridge.read
+          allowed: true
+        - action: sessions.stop
+          category: operational
+          requiredScope: codexbridge.task.cancel
+          allowed: false
+        - action: sessions.pause
+          category: operational
+          requiredScope: codexbridge.task.cancel
+          allowed: false
+
+    PageInfo:
+      type: object
+      description: |
+        Cursor pagination state for **collections** — projects, sessions,
+        decisions and the like. A collection response carries this object under
+        the `page` key alongside its `items` array.
+
+        It does **not** apply to append-only log streams. Those are addressed by
+        a monotonic integer offset in the store (`store.get_logs`) and are
+        already consumed that way by the MCP client; issue #9 defines their
+        paging shape. The distinction is repeated here, and not only in
+        `info.description`, because this schema is what a code generator and a
+        reviewer of a single endpoint actually read.
+
+        Cursors are opaque and single-purpose: a cursor obtained from one
+        endpoint, or from the same endpoint under different filters, is not
+        valid elsewhere and the server rejects it. Clients page forward by
+        resending `nextCursor` until `hasMore` is `false`.
+      required:
+        - hasMore
+      properties:
+        hasMore:
+          type: boolean
+          description: |
+            Whether more items exist after this page. This is authoritative;
+            do not infer the end of a list from a short page, because a page may
+            be short when items are filtered out by authorization.
+        nextCursor:
+          type:
+            - string
+            - 'null'
+          maxLength: 512
+          description: |
+            Cursor to pass as the `cursor` query parameter to fetch the next
+            page. `null` (or absent) exactly when `hasMore` is `false`.
+      examples:
+        - hasMore: true
+          nextCursor: 'eyJhZnRlciI6IjIwMjYtMDgtMTBUMTQ6MzI6MDdaIn0'
+        - hasMore: false
+          nextCursor: null
+
+    ProjectHealth:
+      type: string
+      enum: [ok, degraded, unknown, disabled]
+      description: |
+        Derived at read time, never stored. `ok` — the project is enabled and
+        at least one assigned executor is live right now. `degraded` — enabled,
+        executors are assigned, none are live. `unknown` — enabled, no executor
+        names this project at all, so there is nothing to judge liveness from.
+        `disabled` — the project itself is turned off in the registry; this is
+        an operator decision, not an incident.
+
+    ProjectStatus:
+      type: object
+      description: |
+        A project plus the counts and health a dashboard list row needs.
+        `pendingDecisions`, `activeMissions` and `totalSessions` all read the
+        same underlying `TaskModel` rows `GET /api/v1/sessions` (issue #9)
+        serves — under the vocabulary issues #6 and #7 will eventually give
+        their own endpoints, not a second entity. `issues` (issue #8) and
+        `artifacts` (issue #11) counts are not included: this build has no
+        backing entity for either, and an always-zero field would be a claim
+        with nothing behind it.
+      required: [id, name, enabled, health, pendingDecisions, activeMissions, totalSessions]
+      properties:
+        id:
+          $ref: '#/components/schemas/ProjectId'
+        name:
+          type: string
+        enabled:
+          type: boolean
+        health:
+          $ref: '#/components/schemas/ProjectHealth'
+        pendingDecisions:
+          type: integer
+          description: Sessions in this project currently `awaiting_approval`.
+        activeMissions:
+          type: integer
+          description: Sessions in this project in any non-terminal state.
+        totalSessions:
+          type: integer
+          description: All sessions this project has ever had, any state.
+        lastActivityAt:
+          type: [string, 'null']
+          format: date-time
+          description: |
+            The most recent session's creation time, or `null` when the project
+            has never had one. There is no separate "branch" or "last commit"
+            metadata in this build — `ProjectModel` and the onboarding registry
+            carry neither.
+
+    ProjectExecutorStatus:
+      type: object
+      description: |
+        One executor allowed to run a project, and whether it is live right
+        now. Never a hostname, IP or port — `docs/api/README.md` "Fields that
+        must never ship" excludes all three from every response.
+      required: [executorId, connected]
+      properties:
+        executorId:
+          $ref: '#/components/schemas/ExecutorId'
+        connected:
+          type: boolean
+          description: |
+            Staleness-derived, not the raw connection flag: `true` only when the
+            executor's last heartbeat is within `reconnect_grace_seconds` of now.
+        lastSeenAt:
+          type: [string, 'null']
+          format: date-time
+
+    ProjectSummary:
+      description: |
+        Everything `ProjectStatus` has, plus the executor breakdown `health` is
+        derived from and a `generatedAt` timestamp.
+      allOf:
+        - $ref: '#/components/schemas/ProjectStatus'
+        - type: object
+          required: [executors, generatedAt]
+          properties:
+            executors:
+              type: array
+              items:
+                $ref: '#/components/schemas/ProjectExecutorStatus'
+            generatedAt:
+              $ref: '#/components/schemas/Timestamp'
+
+    Session:
+      type: object
+      description: |
+        One `codex exec` run. Deliberately omits the project's filesystem path,
+        the command line and the raw result blob: the first is forbidden by
+        "Fields that must never ship", and the other two carry paths and
+        unaudited executor output.
+      required: [id, projectId, executorId, state, revision, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        executorId:
+          $ref: '#/components/schemas/ExecutorId'
+        instruction:
+          type: string
+          description: What the operator asked for.
+        mode:
+          type: string
+        state:
+          type: string
+          enum:
+            - queued
+            - waiting_executor
+            - awaiting_approval
+            - pausing
+            - paused
+            - resuming
+            - restarting
+            - running
+            - completed
+            - failed
+            - cancelled
+            - expired
+            - lost
+        priority:
+          type: string
+        revision:
+          type: integer
+          description: |
+            Monotonic; the `ETag` is derived from it. Exposed so a client can
+            tell staleness without parsing the header.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        startedAt:
+          type: [string, 'null']
+          format: date-time
+        completedAt:
+          type: [string, 'null']
+          format: date-time
+        expiresAt:
+          $ref: '#/components/schemas/Timestamp'
+        approvalState:
+          type: [string, 'null']
+        requestedBy:
+          type: [string, 'null']
+        interventionRequired:
+          type: boolean
+          description: The session is held awaiting an approval decision.
+        lastError:
+          type: [string, 'null']
+          description: Redacted before it leaves the process.
+        executorNotified:
+          type: boolean
+          description: |
+            Present on the response to `stop`. Whether the executor was actually
+            told to cancel. `false` means the session is recorded as cancelled
+            **and the run may still be going right now**: the gateway resends
+            `task.cancel` the next time that executor reconnects (issue #16),
+            but until then a disconnected executor keeps running its
+            `codex exec`. Show the difference; do not present a `false` here
+            as an immediately stopped run. That resend is bounded by
+            `cancel_replay_max_age_seconds` (default 24h) since the
+            cancellation — an executor that stays disconnected longer than
+            that (a long weekend, a stuck redeploy) is not chased with
+            `task.cancel` on reconnect, and the session simply stays
+            `cancelled` in the gateway.
+
+    DecisionState:
+      type: string
+      enum: [pending, approved, rejected, revision_requested]
+      description: |
+        `pending` is the only state `approve`/`reject`/`request-revision` accept.
+        The other three are terminal: the underlying session has already left
+        `awaiting_approval` and none of these operations may run again.
+        `revision_requested` still cancels the session — see `Decision`'s
+        description — it is a distinct outcome from `rejected`, not a state that
+        holds the session open for editing.
+
+    DecisionRiskLevel:
+      type: string
+      enum: [read, controlled_write, sensitive]
+      description: |
+        The policy level a decision was raised at (`shared/policy.py`). Every
+        decision this build produces is `sensitive` — that level is the only one
+        `evaluate_task_policy` ever withholds approval for — but the field and
+        this enum are not narrowed to it, so a future policy change that starts
+        holding other levels for approval needs no contract change to be
+        filtered or reported.
+
+    Decision:
+      type: object
+      description: |
+        A sensitive session held for a human to approve, reject, or send back
+        for revision. Not a new domain object: it is the same `Session`
+        (`TaskModel`) in or past `awaiting_approval`, reshaped for the mobile
+        Decision Center. `id` is a session id and `GET /api/v1/sessions/{id}`
+        returns the same underlying row.
+
+        Omits `impact`, `evidence` and `recommendation` on purpose: no
+        submission path in this build populates them, and a field that is
+        always null is indistinguishable from one a client may reasonably build
+        against — the same reasoning `x-pending-components` applies to unused
+        components. `rationale` is different: it is genuinely absent before a
+        decision is made and populated by whoever resolves it.
+      required: [id, projectId, executorId, request, state, revision, createdAt, deadline]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        executorId:
+          $ref: '#/components/schemas/ExecutorId'
+        request:
+          type: string
+          description: What the operator asked for. Redacted like every other operator-authored field on this API.
+        mode:
+          type: string
+        state:
+          $ref: '#/components/schemas/DecisionState'
+        risk:
+          description: |
+            `DecisionRiskLevel`, or `null` — cannot be null in practice today
+            (see that schema's description) but is nullable in the contract
+            rather than assumed, since nothing here computes it for a session
+            this endpoint would refuse to serve anyway.
+          oneOf:
+            - $ref: '#/components/schemas/DecisionRiskLevel'
+            - type: 'null'
+        urgency:
+          type: string
+          description: The session's priority, reused as the decision's urgency.
+        revision:
+          type: integer
+          description: Monotonic; the `ETag` is derived from it. Same column and same meaning as `Session.revision`.
+        requestedBy:
+          type: [string, 'null']
+        rationale:
+          type: [string, 'null']
+          description: |
+            The reason recorded when this decision was resolved. `null` while
+            `state` is `pending` — there is no rationale yet because nobody has
+            decided.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        deadline:
+          $ref: '#/components/schemas/Timestamp'
+          description: The underlying session's `expiresAt`, renamed for this view.
+        decidedAt:
+          type: [string, 'null']
+          format: date-time
+          description: When `state` left `pending`. `null` while still pending.
+
+    MissionStage:
+      type: string
+      enum:
+        - pending
+        - active
+        - done
+      description: |
+        Coarse grouping over a mission's exact `state`, for a mission-control
+        list that groups rather than enumerates every state. `pending` covers
+        `queued` and `waiting_executor`; `active` covers `running` and
+        `awaiting_approval`; `done` covers every terminal state. `state` is
+        still returned unchanged and remains its own, finer-grained filter.
+
+    RiskLevel:
+      type: string
+      enum:
+        - read
+        - controlled_write
+        - sensitive
+      description: |
+        Derived from the mission's mode and, when the instruction matched a
+        sensitive keyword at creation, from the approval decision that
+        followed (`shared/policy.py`). It is not a live re-evaluation of the
+        instruction text.
+
+    BlockedReason:
+      type: object
+      description: |
+        Present exactly when `Mission.blocked` is `true`. `code` is stable and
+        machine-readable; `summary` is redacted human text, safe to render
+        directly. This build reports one code: `awaiting_approval` — the only
+        state a mission is held in without the agent protocol having a way to
+        move it forward on its own.
+      required: [code, summary]
+      properties:
+        code:
+          type: string
+          maxLength: 64
+        summary:
+          type: string
+          maxLength: 1024
+
+    Mission:
+      type: object
+      description: |
+        The mission-control view of one `codex exec` run — the same row
+        `Session` describes, reframed. There is no separate mission entity in
+        this build: see `docs/api/README.md` "Missions (issue #7)" for what
+        that means for `dependencies` and `relatedEntities`, named in issue
+        #7's scope but not present here because nothing in this codebase's
+        domain model links one mission to another or to any other entity yet.
+
+        Omits the project's filesystem path, the command line and the raw
+        result blob, for the same reason `Session` does.
+      required: [id, projectId, assignedAgent, state, stage, risk, blocked, revision, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        assignedAgent:
+          $ref: '#/components/schemas/ExecutorId'
+          description: The executor this mission is dispatched to. Same identifier `Session.executorId` names.
+        objective:
+          type: string
+          description: What the operator asked for. Redacted, like every other free-text field here.
+        mode:
+          type: string
+        state:
+          type: string
+        stage:
+          $ref: '#/components/schemas/MissionStage'
+        risk:
+          $ref: '#/components/schemas/RiskLevel'
+        blocked:
+          type: boolean
+        blockedReason:
+          $ref: '#/components/schemas/BlockedReason'
+        priority:
+          type: string
+        revision:
+          type: integer
+          description: Monotonic; the `ETag` is derived from it.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        startedAt:
+          type: [string, 'null']
+          format: date-time
+        completedAt:
+          type: [string, 'null']
+          format: date-time
+        expiresAt:
+          $ref: '#/components/schemas/Timestamp'
+        approvalState:
+          type: [string, 'null']
+        requestedBy:
+          type: [string, 'null']
+        lastError:
+          type: [string, 'null']
+          description: Redacted before it leaves the process.
+        executorNotified:
+          type: boolean
+          description: |
+            Present on the response to `cancel`. Whether the executor was
+            actually told to cancel — see the `cancel` operation description
+            for why `false` must not be read as a stopped run.
+
+    MissionTimelineEvent:
+      type: object
+      description: |
+        One recorded event from the mission's audit trail
+        (`gateway/app/services/audit.py:record_event`), not a new log —
+        the same rows Sessions' actor-audit writes already produce.
+      required: [type, at, summary]
+      properties:
+        type:
+          type: string
+          description: Stable event identifier, e.g. `task.created`, `task.state_changed`.
+        at:
+          $ref: '#/components/schemas/Timestamp'
+        state:
+          type: [string, 'null']
+          description: The mission's state at this event, when the event carries one.
+        actor:
+          type: [string, 'null']
+          description: Who performed the action, when the event records an actor.
+        summary:
+          type: string
+          maxLength: 1024
+          description: |
+            Human-readable, redacted. Built server-side from an explicit
+            per-event allowlist, never from the raw stored payload.
+
+    EpicStatus:
+      type: string
+      enum: [open, in_progress, done, cancelled]
+
+    IssueStatus:
+      type: string
+      enum: [open, in_progress, blocked, in_review, done, cancelled]
+
+    IssuePriority:
+      type: string
+      enum: [low, medium, high, urgent]
+
+    Epic:
+      type: object
+      description: |
+        A group of issues within one project. This build owns epics itself —
+        there is no GitHub sync — so every epic returned today came from
+        `POST /api/v1/epics`, never from an external tracker.
+      required: [id, projectId, title, status, revision, createdAt, updatedAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        title:
+          type: string
+          maxLength: 255
+        description:
+          type: [string, 'null']
+          maxLength: 20000
+        status:
+          $ref: '#/components/schemas/EpicStatus'
+        revision:
+          type: integer
+          description: Monotonic; the `ETag` is derived from it.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        updatedAt:
+          $ref: '#/components/schemas/Timestamp'
+        createdBy:
+          type: [string, 'null']
+          description: Email, or id when no email is on record, of who created this.
+        updatedBy:
+          type: [string, 'null']
+          description: Who last changed this. Absent when it has never been updated.
+
+    Issue:
+      type: object
+      description: |
+        One unit of work, optionally grouped under an `epicId`. Provider-neutral
+        by construction: nothing here is a GitHub node id, a GraphQL shape, or
+        anything else a mobile client would have to unlearn if the backing
+        system changed.
+      required: [id, projectId, title, status, priority, revision, createdAt, updatedAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        epicId:
+          type: [string, 'null']
+          description: The epic this issue belongs to, or `null` when ungrouped.
+        title:
+          type: string
+          maxLength: 255
+        description:
+          type: [string, 'null']
+          maxLength: 20000
+        status:
+          $ref: '#/components/schemas/IssueStatus'
+        priority:
+          $ref: '#/components/schemas/IssuePriority'
+        labels:
+          type: array
+          items:
+            type: string
+        assigneeUserId:
+          type: [string, 'null']
+        assigneeEmail:
+          type: [string, 'null']
+        dependencies:
+          type: array
+          description: Ids of issues this one is blocked on.
+          items:
+            $ref: '#/components/schemas/Id'
+        blockedReason:
+          type: [string, 'null']
+        revision:
+          type: integer
+          description: Monotonic; the `ETag` is derived from it.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        updatedAt:
+          $ref: '#/components/schemas/Timestamp'
+        createdBy:
+          type: [string, 'null']
+        updatedBy:
+          type: [string, 'null']
+
+    CreateEpicRequest:
+      type: object
+      required: [projectId, title]
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 20000
+        status:
+          $ref: '#/components/schemas/EpicStatus'
+          description: Defaults to `open` when omitted.
+
+    CreateIssueRequest:
+      type: object
+      required: [projectId, title]
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        epicId:
+          type: string
+          description: Must name an epic already in `projectId`, or the request is rejected.
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: string
+          maxLength: 20000
+        status:
+          $ref: '#/components/schemas/IssueStatus'
+          description: Defaults to `open` when omitted.
+        priority:
+          $ref: '#/components/schemas/IssuePriority'
+          description: Defaults to `medium` when omitted.
+        labels:
+          type: array
+          items:
+            type: string
+        assigneeUserId:
+          type: string
+          maxLength: 255
+        assigneeEmail:
+          type: string
+          maxLength: 255
+        dependencies:
+          type: array
+          description: Ids of issues this one is blocked on, all within `projectId`.
+          items:
+            $ref: '#/components/schemas/Id'
+        blockedReason:
+          type: string
+          maxLength: 20000
+
+    UpdateIssueRequest:
+      type: object
+      description: |
+        Every field is optional. A field the caller does not mention is left
+        unchanged; a field sent explicitly as `null` is cleared. There is no
+        `epicId` here — see the `PATCH` operation's description.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: [string, 'null']
+          maxLength: 20000
+        status:
+          $ref: '#/components/schemas/IssueStatus'
+        priority:
+          $ref: '#/components/schemas/IssuePriority'
+        labels:
+          type: array
+          items:
+            type: string
+        assigneeUserId:
+          type: [string, 'null']
+          maxLength: 255
+        assigneeEmail:
+          type: [string, 'null']
+          maxLength: 255
+        dependencies:
+          type: array
+          description: Replaces the whole set. Ids must all be within the issue's project.
+          items:
+            $ref: '#/components/schemas/Id'
+        blockedReason:
+          type: [string, 'null']
+          maxLength: 20000
+
+    ConversationContextType:
+      type: string
+      enum: [project, session, decision, mission, issue]
+      description: |
+        `session`, `decision` and `mission` all name the same `TaskModel` row
+        under three vocabularies — see `docs/api/README.md`'s "Decisions" and
+        "Missions" sections. `artifact` is deliberately absent: no
+        `ArtifactModel` exists yet (issue #11), so a reference of that type
+        could not be checked for existence or for project visibility. See
+        `docs/api/README.md` "Conversations (issue #10)".
+
+    ContextReference:
+      type: object
+      description: One product entity a conversation is about.
+      required: [type, id]
+      properties:
+        type:
+          $ref: '#/components/schemas/ConversationContextType'
+        id:
+          $ref: '#/components/schemas/Id'
+
+    Conversation:
+      type: object
+      description: |
+        A thread linked to at least one product entity. `projectId` is
+        derived from `context`, not supplied independently — every reference
+        in `context` resolves to the same project.
+      required: [id, projectId, context, unread, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        title:
+          type: [string, 'null']
+          maxLength: 255
+        context:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/ContextReference'
+        unread:
+          type: boolean
+          description: |
+            Whether the caller has unseen activity. `false` for a
+            conversation with no messages yet. Advances only through
+            `GET .../messages` (up to the newest message actually fetched)
+            and `POST .../messages` (the sender's own cursor) — issue #10
+            names no "mark as read" endpoint. See `docs/api/README.md`
+            "Conversations (issue #10)".
+        lastActivityAt:
+          type: [string, 'null']
+          format: date-time
+          description: Timestamp of the most recent message, or `null` when there are none yet.
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+        createdBy:
+          type: [string, 'null']
+          description: Email, or id when no email is on record, of who started this.
+
+    CreateConversationRequest:
+      type: object
+      required: [context]
+      properties:
+        title:
+          type: string
+          maxLength: 255
+        context:
+          type: array
+          minItems: 1
+          maxItems: 16
+          description: |
+            At least one context reference is required — the acceptance
+            criterion this field exists to satisfy. Every reference must
+            resolve to the same project.
+          items:
+            $ref: '#/components/schemas/ContextReference'
+
+    Message:
+      type: object
+      required: [id, conversationId, body, attachments, createdAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        conversationId:
+          $ref: '#/components/schemas/Id'
+        author:
+          type: [string, 'null']
+          description: Email, or id when no email is on record, of who sent this.
+        body:
+          type: string
+          maxLength: 50000
+          description: Markdown source, stored and returned unrendered. Rendering is the client's responsibility.
+        attachments:
+          type: array
+          description: |
+            Opaque artifact/file identifiers. Unvalidated: no `ArtifactModel`
+            exists yet (issue #11), so these are recorded and returned
+            exactly as sent.
+          items:
+            type: string
+            maxLength: 255
+        createdAt:
+          $ref: '#/components/schemas/Timestamp'
+
+    CreateMessageRequest:
+      type: object
+      required: [body]
+      properties:
+        body:
+          type: string
+          minLength: 1
+          maxLength: 50000
+          description: Markdown source.
+        attachments:
+          type: array
+          maxItems: 20
+          items:
+            type: string
+            minLength: 1
+            maxLength: 255
+
+    LogLine:
+      type: object
+      required: [offset, stream, line]
+      properties:
+        offset:
+          type: integer
+          description: Position in the append-only stream; resume from it.
+        stream:
+          type: string
+          enum: [stdout, stderr]
+        line:
+          type: string
+          description: Redacted — credentials, filesystem paths and host:port pairs.
+        at:
+          type: [string, 'null']
+          format: date-time
+
+    DependencyCheck:
+      type: object
+      description: |
+        One dependency's state, as `/ready` sees it. `required: false` means a
+        failure here degrades the service without making it unready.
+      required: [name, status, required]
+      properties:
+        name:
+          type: string
+          description: |
+            Logical dependency name — `database`, `executors`. Never a hostname,
+            port or connection string: this endpoint is unauthenticated.
+        status:
+          type: string
+          enum: [ok, degraded, unavailable]
+        required:
+          type: boolean
+          description: Whether the service is unready when this check is not `ok`.
+
+    ErrorCode:
+      type: string
+      description: |
+        Stable, machine-readable error identifier. Clients branch on this, never
+        on `message`. New codes may be added within a major version, so clients
+        must treat an unrecognized code as a generic failure of the response's
+        HTTP status class rather than crashing.
+      enum:
+        - validation_failed
+        - unauthenticated
+        - token_expired
+        - permission_denied
+        - not_found
+        - conflict
+        - stale_write
+        - rate_limited
+        - dependency_unavailable
+        - internal_error
+      # `stale_write` was deliberately withheld by issue #2 and added here by
+      # issue #12, together with the `tasks.revision` column
+      # (migrations/0002_api_foundation.sql) that makes it possible to detect.
+      # Before that column there was nothing to compare against — the existing
+      # timestamps do not move when approval_state or last_error changes, so an
+      # ETag derived from them would match on both sides of a concurrent
+      # approval and the code could never fire. Publishing it first would have
+      # put a promise in v1 that v1 could not keep and could not withdraw.
+
+    ErrorDetail:
+      type: object
+      description: |
+        One specific problem inside a failed request. Validation errors carry
+        one entry per offending field.
+      required:
+        - message
+      properties:
+        field:
+          type: string
+          maxLength: 255
+          description: |
+            JSON Pointer-style path to the offending input, relative to the
+            request body or query string — for example `/instruction` or
+            `?limit`. Absent when the problem is not attributable to one field.
+        code:
+          type: string
+          maxLength: 64
+          description: Machine-readable sub-code, scoped to the parent `code`.
+        message:
+          type: string
+          maxLength: 1024
+          description: Human-readable explanation of this specific problem.
+
+    Error:
+      type: object
+      description: |
+        The single error envelope returned by every endpoint in this contract
+        for every non-2xx response. An endpoint that returns anything else is a
+        contract violation, not a variant.
+      required:
+        - code
+        - message
+        - requestId
+        - retryable
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        message:
+          type: string
+          maxLength: 1024
+          description: |
+            Human-readable summary, safe to log. It is written for an operator,
+            not for an end user, and it is not localized. Clients must not parse
+            it and must not assume it is stable across releases.
+        requestId:
+          $ref: '#/components/schemas/Id'
+          description: |
+            Identifier tying this response to the server-side log record for
+            **this one request**. Always present, including on `internal_error`,
+            so an operator can find the failure from a mobile screenshot alone.
+
+            Named `requestId`, not `correlationId`, on purpose: `correlation_id`
+            already exists in this codebase as a column on `TaskModel`, scoped to
+            the whole lifetime of a task and shared by the executor protocol.
+            Populating this field from that column would make every failure on a
+            given task report the same identifier, defeating the only reason the
+            field exists — while the response stayed schema-valid, so no test
+            would catch it. The two are different identifiers and must not be
+            merged. When a response concerns a task, expose that task's
+            correlation id as its own named field instead.
+        retryable:
+          type: boolean
+          description: |
+            Whether repeating the identical request may succeed later without
+            the caller changing anything. `true` on transient failures
+            (`rate_limited`, `dependency_unavailable`); `false` on failures that
+            require caller action (`validation_failed`, `permission_denied`).
+
+            This is advice about the failure, not permission to retry blindly:
+            a client retrying a non-idempotent write still needs the idempotency
+            rules that issue #12 defines.
+        details:
+          type: array
+          description: |
+            Per-problem breakdown. Present on `validation_failed`; may be
+            omitted entirely on other codes. An empty array and an absent array
+            mean the same thing.
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+      examples:
+        - code: validation_failed
+          message: 'Request body failed validation.'
+          requestId: '5a3f1c88-90b1-4e2a-8a6f-2f9c0d1e7b43'
+          retryable: false
+          details:
+            - field: /timeoutSeconds
+              code: above_maximum
+              message: 'timeoutSeconds must not exceed the project limit of 3600.'
+        - code: permission_denied
+          message: 'The authenticated actor may not read this project.'
+          requestId: 'c1d2e3f4-a5b6-4708-9a0b-1c2d3e4f5061'
+          retryable: false
+        - code: rate_limited
+          message: 'Too many requests. Retry after the interval in Retry-After.'
+          requestId: '7e8f9a0b-1c2d-4e3f-a405-162738495a6b'
+          retryable: true
+        - code: internal_error
+          message: 'Unexpected server error. Report the requestId to the operator.'
+          requestId: 'b4c5d6e7-f809-4a1b-8c2d-3e4f50617283'
+          retryable: true

--- a/contract/1.6.0/manifest.json
+++ b/contract/1.6.0/manifest.json
@@ -1,0 +1,6 @@
+{
+  "artifactFormat": 1,
+  "contractVersion": "1.6.0",
+  "document": "codex-bridge.openapi.yaml",
+  "sha256": "0f11de2c2898427d84738cf1cdafd123eca47ff1888c1e0b426699edef2d2e6a"
+}

--- a/contract/1.6.0/manifest.json
+++ b/contract/1.6.0/manifest.json
@@ -2,5 +2,5 @@
   "artifactFormat": 1,
   "contractVersion": "1.6.0",
   "document": "codex-bridge.openapi.yaml",
-  "sha256": "0f11de2c2898427d84738cf1cdafd123eca47ff1888c1e0b426699edef2d2e6a"
+  "sha256": "1e229f267ccfde75dce7e92dd5063a9115d64667a18beed9b0b79c7046a958f4"
 }

--- a/contract/index.json
+++ b/contract/index.json
@@ -1,0 +1,7 @@
+{
+  "artifactFormat": 1,
+  "latest": "1.6.0",
+  "versions": [
+    "1.6.0"
+  ]
+}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -86,9 +86,19 @@ read a single `requestBody` or `responses` block. An endpoint that returns a
 shape this document does not describe — FastAPI's default `{"detail": ...}` with
 HTTP 422, for instance, which matches no field of `Error` — passes this gate.
 
-Body-level conformance is issue #14's scope. Until it lands, read a green run as
-*"the same endpoints exist on both sides"*, never as *"the implementation matches
-the contract"*.
+Body-level conformance is a **separate** gate,
+`tests/contract/test_declared_examples_are_real.py` (issue #14). It validates
+live response bodies against the schemas declared here, checks that no response
+carries a top-level field this document omits, and checks every declared example
+against the schema it illustrates. It reaches only what it can drive without a
+credential — the operations that declare `security: []` — so **authenticated
+endpoints' bodies are still unchecked against this document**; they are covered
+in `tests/integration` against expectations written in Python, which is the
+weaker form, because two independent statements of one contract drift.
+
+Read a green route-drift run as *"the same endpoints exist on both sides"*,
+never as *"the implementation matches the contract"*. `docs/api/testing.md`
+has the table of which gate guards which pair.
 
 ---
 
@@ -103,8 +113,21 @@ The public namespace is `/api/v1`.
   patch versions move within a namespace.
 - **Every change to the document moves `info.version`.** A client that pins
   `1.0.0` must receive the same bytes tomorrow; leaving the version still while
-  the content changes is what makes a pin meaningless. Nothing enforces this
-  today — see "Getting the contract to the mobile repository".
+  the content changes is what makes a pin meaningless.
+- `x-minimum-supported-version` names the oldest **published** version this
+  build still promises to serve. `scripts/check_contract_compatibility.py`
+  compares the working document against the published copy of that version and
+  fails the build on any change the next section forbids. Raising the floor
+  drops the promise to every client still on the older pin, and needs the same
+  conversation with the mobile team that a deprecation does.
+
+What is enforced, and what is still on trust: the digest of a published version
+is enforced (a version edited after publication fails
+`tests/contract/test_published_contract_artifact.py`), and so is the absence of
+a mechanically visible break against the floor. **`info.version` moving on every
+change is not enforced** — a byte change with the version left still fails the
+publish check, which is satisfied by republishing under the same number. See
+"Getting the contract to the mobile repository".
 
 ### The `/api/version` carve-out
 
@@ -1196,16 +1219,30 @@ python3 scripts/apply_migrations.py
 
 ## Getting the contract to the mobile repository
 
-Today there is none: the document lives in this repository and a consumer copies
-it by hand. Nothing publishes it, nothing checksums it, and nothing detects that
-a copy has diverged — so the drift gate protects the *gateway ↔ document* pair
-and leaves the *document ↔ mobile client* pair, which is the pair this epic
-exists for, unguarded.
+`scripts/publish_contract.py` writes the document to `contract/<version>/` with
+a `manifest.json` carrying its SHA-256, and refreshes `contract/index.json`.
+`EDortta/CodexBridgeMobile` fetches that directory and verifies the digest, so a
+pin is a pin: the mechanics, the consumer-side commands and the immutability
+rule are in **[`testing.md`](./testing.md)**.
 
-That gap is issue #14's scope ("publish a machine-consumable contract artifact
-for the mobile project", "the mobile repository can consume a pinned contract
-version"). It is recorded here rather than left implicit so that nobody reads
-the `info.version` field as a working pin before #14 lands.
+`tests/contract/test_published_contract_artifact.py` fails when the published
+copy falls behind the document, and separately when a version that was already
+published no longer hashes to its own manifest — two failures with opposite
+remedies, which is why they are reported apart.
+
+Before this existed the document lived here and a consumer copied it by hand:
+nothing published it, nothing checksummed it, and nothing detected a diverged
+copy, so the drift gate protected the *gateway ↔ document* pair and left the
+*document ↔ mobile client* pair — the pair this epic exists for — unguarded.
+
+**One hole is left open on purpose, and it is not small.** Republishing an
+edited document under the *same* `info.version` rewrites both the copy and its
+manifest, so the digest agrees again and every gate goes green while the bytes
+behind a number a client pinned have changed. Only the version-control history
+shows it. Enforcing "every change moves `info.version`" in the publisher is the
+fix; it was left out here because doing it would have forced a version bump that
+belongs to the endpoint work in flight, not to this gate. Until then: **review
+any diff that touches `contract/` without adding a directory.**
 
 ---
 
@@ -1228,6 +1265,11 @@ CI runs the same suite on every push and pull request
 only when a human remembered to — which is the same reliability as no gate at
 all, and it went unnoticed until adversarial review pointed at the empty
 `.github/` directory.
+
+`tests/contract` now holds five gates, each guarding one pair, and a green run
+on one says nothing about the others. The table naming them, and what each one
+cannot see, is in [`testing.md`](./testing.md) — read it before concluding from
+a green build that the implementation matches the contract.
 
 Changing an endpoint means changing this document **first**. The drift test
 exists so that "the implementation and the contract disagree" is a red test and

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1220,10 +1220,17 @@ python3 scripts/apply_migrations.py
 ## Getting the contract to the mobile repository
 
 `scripts/publish_contract.py` writes the document to `contract/<version>/` with
-a `manifest.json` carrying its SHA-256, and refreshes `contract/index.json`.
-`EDortta/CodexBridgeMobile` fetches that directory and verifies the digest, so a
-pin is a pin: the mechanics, the consumer-side commands and the immutability
-rule are in **[`testing.md`](./testing.md)**.
+a `manifest.json` carrying its SHA-256, and refreshes `contract/index.json`. The
+mechanics, the consumer-side fetch-and-verify commands and the immutability rule
+are in **[`testing.md`](./testing.md)**.
+
+**The producing half is done; the consuming half is not.** This repository now
+publishes a pinnable, checksummed artifact and refuses to let it drift.
+`EDortta/CodexBridgeMobile` does **not** consume it yet: it has no `contract/`
+directory, fetches nothing, verifies no digest, and still cites this document by
+hand. The artifact also has not reached `main`, which carries no `docs/api/` at
+all — `development` is where it lives today. Nothing here is a pin until the
+mobile build does the verifying, and that is a change in the other repository.
 
 `tests/contract/test_published_contract_artifact.py` fails when the published
 copy falls behind the document, and separately when a version that was already
@@ -1266,10 +1273,10 @@ only when a human remembered to — which is the same reliability as no gate at
 all, and it went unnoticed until adversarial review pointed at the empty
 `.github/` directory.
 
-`tests/contract` now holds five gates, each guarding one pair, and a green run
-on one says nothing about the others. The table naming them, and what each one
-cannot see, is in [`testing.md`](./testing.md) — read it before concluding from
-a green build that the implementation matches the contract.
+`tests/contract` holds six gates — one per file in it — each guarding one pair,
+and a green run on one says nothing about the others. The table naming them, and
+what each one cannot see, is in [`testing.md`](./testing.md) — read it before
+concluding from a green build that the implementation matches the contract.
 
 Changing an endpoint means changing this document **first**. The drift test
 exists so that "the implementation and the contract disagree" is a red test and

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -119,7 +119,11 @@ The public namespace is `/api/v1`.
   compares the working document against the published copy of that version and
   fails the build on any change the next section forbids. Raising the floor
   drops the promise to every client still on the older pin, and needs the same
-  conversation with the mobile team that a deprecation does.
+  conversation with the mobile team that a deprecation does — so it must be the
+  oldest published version unless `x-minimum-supported-version-raised` records
+  why not, naming the mobile release that stopped using it. That is not
+  bureaucracy: raising the floor is also the cheapest way to silence this gate
+  permanently, and a one-line diff should not be able to do that unremarked.
 
 What is enforced, and what is still on trust: the digest of a published version
 is enforced (a version edited after publication fails
@@ -151,10 +155,27 @@ stop working because of it:
 - renaming anything, in either direction;
 - narrowing a type, tightening a constraint (`maxLength`, `pattern`, `required`),
   or making an optional request field required;
+- **a field of a *response* leaving that schema's `required` list.** A generated
+  client makes a required field non-nullable and reads it unconditionally, so
+  "it might not be there now" breaks it. On a request-only schema the same edit
+  is a relaxation — the gate reports both and names the direction, because a
+  JSON pointer cannot tell which a shared schema is, and most here are shared;
+- **changing a `default`.** A client that omits the field gets different
+  behaviour with no code change on either side and no error to notice;
+- **changing which credential an operation accepts** — a different scheme, or a
+  scope a client's token does not carry. An endpoint that stops being
+  unauthenticated is the same rule at its limit;
+- **requiring a request body where the operation accepted none**, or pointing an
+  operation at an already-required component parameter;
 - changing the meaning of an existing field while keeping its name and type
   — the most dangerous kind, because no schema diff catches it;
 - changing the HTTP status or the `code` returned for an existing failure;
 - changing default sort order, or the identity/lifetime of a pagination cursor.
+
+The five bold rules were added by issue #14 alongside the gate that enforces
+them. They were always true; nothing stated them, so nothing could be held to
+them. `scripts/check_contract_compatibility.py` transcribes **this** list, and
+`docs/api/testing.md` records which of these it can and cannot see.
 
 ### What is not breaking
 
@@ -1228,9 +1249,10 @@ are in **[`testing.md`](./testing.md)**.
 publishes a pinnable, checksummed artifact and refuses to let it drift.
 `EDortta/CodexBridgeMobile` does **not** consume it yet: it has no `contract/`
 directory, fetches nothing, verifies no digest, and still cites this document by
-hand. The artifact also has not reached `main`, which carries no `docs/api/` at
-all — `development` is where it lives today. Nothing here is a pin until the
-mobile build does the verifying, and that is a change in the other repository.
+hand. And **no branch carries `contract/` yet** — not `development`, and `main`
+has no `docs/api/` at all; it exists only on the branch that introduced it.
+Nothing here is a pin until this work merges *and* the mobile build does the
+verifying, and the second half is a change in the other repository.
 
 `tests/contract/test_published_contract_artifact.py` fails when the published
 copy falls behind the document, and separately when a version that was already

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -34,9 +34,12 @@ info:
 
     ## Conventions
 
-    These are review rules for every endpoint added to this document. No test
-    enforces them yet — response-body conformance is issue #14's scope — so they
-    are checked by the reviewer, not by CI.
+    These are review rules for every endpoint added to this document. Issue #14
+    made the *third* one machine-checked, and only as far as it reaches: the
+    error envelope is validated against `components/schemas/Error` for the
+    failure responses `tests/contract/test_declared_examples_are_real.py` can
+    drive without a credential. The other three, and every authenticated
+    endpoint, are still checked by the reviewer and not by CI.
 
     - All timestamps are RFC 3339 with an explicit UTC offset (`Z`). Note that
       `format: date-time` alone does not require `Z`; the rule is stricter than
@@ -2294,6 +2297,20 @@ paths:
           $ref: '#/components/responses/RateLimited'
         '500':
           $ref: '#/components/responses/InternalError'
+
+# The oldest *published* contract version this build still promises to serve —
+# the floor `EDortta/CodexBridgeMobile` may pin. It lives here rather than in a
+# repository-local constant so it travels with the artifact: a consumer that
+# fetched `contract/<v>/codex-bridge.openapi.yaml` reads the floor without
+# cloning this repository, the same reason `x-contract-excluded-paths` is here
+# and not in the test.
+#
+# `scripts/check_contract_compatibility.py` compares this document against the
+# published copy of this version and fails on any change §"What is a breaking
+# change" forbids. Raising it is a deliberate act: it drops the promise to
+# every client still on the older pin, and needs the same conversation with the
+# mobile team as a deprecation does.
+x-minimum-supported-version: '1.6.0'
 
 # Public HTTP routes the gateway serves that are deliberately NOT part of this
 # contract. Every entry needs a reason: `tests/contract/test_openapi_document.py`

--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -19,11 +19,11 @@ migration is applied.
 
 ---
 
-## The four gates, and the pair each one guards
+## The six gates, and the pair each one guards
 
-The contract is a chain, and each link has its own test file. Reading a green
-run as "everything matches" is the mistake this table exists to prevent — each
-gate sees exactly one pair.
+The contract is a chain, and each link has its own test file — six of them, one
+per file in `tests/contract/`. Reading a green run as "everything matches" is
+the mistake this table exists to prevent: each gate sees exactly one pair.
 
 | pair | file | what a red run means |
 |---|---|---|
@@ -31,6 +31,7 @@ gate sees exactly one pair.
 | runtime body ↔ document | `test_declared_examples_are_real.py` | a response body does not match the schema, or an example lies |
 | document ↔ published artifact | `test_published_contract_artifact.py` | `contract/` is behind, or a published version was edited |
 | document ↔ minimum supported version | `test_contract_compatibility.py` | the change breaks a client on the pinned floor |
+| document ↔ nginx front door | `test_proxy_routes.py` | a contracted path no vhost forwards — a 404 in production with the suite green |
 | prose ↔ runtime | `test_docs_match_the_runtime.py` | a document states a runtime fact that stopped being true |
 
 ---
@@ -58,9 +59,23 @@ until you do, and the failure names the stale file. That is deliberate: the
 gate is the only thing standing between a merged contract change and a mobile
 team reading yesterday's YAML.
 
-**A published version directory is immutable.** `--check` recomputes every
-manifest digest, so editing `contract/1.6.0/…` in place fails rather than
-quietly rewriting what a client already pinned. Ship a new version instead.
+**A published version directory is immutable — with one hole, and it is not a
+small one.** `--check` recomputes every manifest digest, so editing
+`contract/1.6.0/…` *by hand* fails rather than quietly rewriting what a client
+already pinned.
+
+It does **not** stop the publisher. Changing the document without moving
+`info.version` and re-running `python3 scripts/publish_contract.py` — which is
+exactly what the "stale" failure message tells you to do — overwrites the copy
+**and** its manifest together, so the digest agrees again and the whole suite is
+green while the bytes behind a number a client pinned have changed. Only the
+version-control history shows it.
+
+Closing this means enforcing "every change moves `info.version`" in the
+publisher; it was left open here because doing it would have forced a version
+bump belonging to the endpoint work in flight. Until then: **move
+`info.version` whenever you change the document, and review any diff that
+touches `contract/` without adding a directory.**
 
 ---
 
@@ -70,13 +85,16 @@ Fetch the version directory, verify the digest, and keep the digest in the
 mobile repository. The pin is the *digest*, not the version number — a number
 alone is what the contract had before this existed.
 
-`main` below is the versioned deploy cut of `EDortta/CodexBridge`; it moves, and
-that is what the digest check is for. A build that must be reproducible should
-name a tag or a commit sha in `REF` instead.
+**Not usable yet, and the reason matters.** `origin/main` carries no
+`contract/` directory — it carries no `docs/api/` at all — so every command
+below 404s until the API work reaches it. `development` is where the artifact
+lives today. Point `REF` at `development`, at a tag, or at a commit sha; a build
+that must be reproducible should never name a moving branch anyway, which is
+also why the digest check below is the real guard rather than the URL.
 
 ```bash
 VERSION=1.6.0
-REF=main
+REF=development
 BASE=https://raw.githubusercontent.com/EDortta/CodexBridge/$REF/contract/$VERSION
 
 curl -fsSL "$BASE/codex-bridge.openapi.yaml" -o codex-bridge.openapi.yaml
@@ -119,44 +137,82 @@ exits 1, naming every incompatible pointer, on anything §"What is a breaking
 change" forbids. The output is a list of JSON pointers, most general first:
 
 ```
-paths[/api/v1/projects].get.responses[200]: this response was removed or renamed. …
-components.schemas[Error].properties[retryable]: this property was removed or renamed. …
+2 breaking change(s) against the minimum supported contract version (contract/1.6.0/codex-bridge.openapi.yaml):
+  - components.schemas[Error].properties[retryable]: this property was removed or renamed. …
+  - paths[/api/v1/projects].get.responses[200]: this response was removed or renamed. …
 ```
 
-Raising the floor is a deliberate act, not housekeeping: it drops the promise to
-every client still on the older pin and needs the same conversation with the
-mobile team that a deprecation does.
+Sorted by pointer, so the endpoint always precedes its own leaves; `components.…`
+sorts before `paths[…]`.
+
+**Adding things is not breaking, and this gate knows it.** A new endpoint, a new
+component schema, a new optional field — including the constraints they arrive
+with, and the `required: true` that OpenAPI forces on every path parameter —
+pass. A constraint only counts as a tightening when the thing it constrains
+already existed.
+
+### Raising the floor
+
+Raising `x-minimum-supported-version` is a deprecation, not housekeeping: it
+drops the promise to every client still on the older pin. It is also the
+cheapest way to make this gate green without fixing anything — after which the
+document is compared against a published copy of itself and the gate can never
+fire again. So the floor must be the oldest published version unless the
+document records why not, in `x-minimum-supported-version-raised`, naming the
+mobile release that stopped using it
+(`test_raising_the_floor_past_a_published_version_is_written_down`).
 
 ### What the compatibility gate cannot see
 
 Read a green run as *"no mechanically visible break"*, never as *"compatible"*.
-Four classes pass, three of them straight from the README's own list:
+**Three** classes pass in silence, all three straight from the README's own list:
 
 - **a meaning change that keeps the name and the type** — the README calls this
   "the most dangerous kind, because no schema diff catches it", and nothing here
   changes that;
-- **default sort order**, and the **identity or lifetime of a pagination cursor**;
-- a **rename is reported as a removal** — the verdict is right, the wording is not;
-- a constraint tightened **inside** an `allOf` / `anyOf` / `oneOf` branch:
-  composition members are compared as a set and not recursed into, because
-  comparing them positionally would report two breaks every time two equivalent
-  branches are reordered.
+- **default sort order** — a `default` *value* is compared, the order rows come
+  back in is not expressible in the schema;
+- the **identity or lifetime of a pagination cursor**.
+
+Two more are imprecise rather than silent:
+
+- a **rename is reported as a removal** — the verdict and the pointer are right,
+  the wording is not;
+- a constraint tightened **inside an existing** `allOf` / `anyOf` / `oneOf`
+  branch reports as "1 branch removed" instead of naming the constraint:
+  composition members are compared as a set, because comparing them positionally
+  would report two breaks every time two equivalent branches are reordered. A
+  branch *added* to an `allOf` is caught, since `allOf` is an AND.
+
+One more is neither, because the gate refuses to guess: a **restriction keyword
+the walker does not model** (`dependentRequired`, `readOnly`, `uniqueItems`,
+`if`/`then`, …) makes it **fail**, saying it abstained rather than approved.
+None appears in the contract today.
+
+Still uncompared: the **contents** of a `components.securitySchemes` entry — its
+removal reports, a bearer-to-apiKey swap on the scheme itself does not. Which
+scheme and scopes an *operation* requires is compared.
 
 ---
 
 ## Fixtures for the mobile client
 
-The response examples in the document are checked, one parametrized test per
-example, against the schema they illustrate
+Every example the document declares — 24 of them today — is checked, one
+parametrized test per example, against the schema it illustrates
 (`test_declared_examples_are_real.py::test_a_declared_example_satisfies_its_own_schema`).
-So they are usable as fixtures directly out of the pinned YAML — an example that
+So they are usable as fixtures directly out of the pinned YAML: an example that
 contradicts its own schema cannot be merged.
 
 There is **no fixture generator in this repository**, and no fixture files are
 committed. Extract them from the pinned document with whatever the mobile build
-already uses for YAML; every example lives under
-`paths.<path>.<method>.responses.<status>.content.<media>.example` or
-`.examples.<name>.value`.
+already uses for YAML. Examples live in three shapes, and a reader who knows
+only the first finds 5 of the 24:
+
+| where | shape | validates against |
+|---|---|---|
+| `…responses.<status>.content.<media>` (and `requestBody.content.<media>`) | `example`, or `examples.<name>.value` | that media type's `schema` |
+| `components.schemas.<Name>` | `examples` — a plain **list of values** | that schema |
+| `components.{headers,parameters}.<Name>`, and inline response headers | `example` | that entry's `schema` |
 
 ## A local mock server
 
@@ -188,7 +244,13 @@ pytest -q                         # the whole suite
 ```
 
 `tests/contract` needs no running gateway: it imports `gateway.app.main.app` and
-drives it through `TestClient` in-process, against the default SQLite file. That
-is also its limit — the nginx edge in `deploy/incus/` decides separately what it
-forwards, so **end-to-end reachability of a contracted route is not verified by
-this repository's tests.**
+drives it through `TestClient` in-process, against the default SQLite file.
+
+The front door is checked **statically**, not end to end:
+`test_proxy_routes.py` reads the vhost files in `deploy/nginx/` and fails when a
+contracted path no terminating vhost forwards — "they would answer 404 in
+production with the suite green". That is a check of the *configuration*, not of
+a deployment: **no test here sends a request to a real host**, so end-to-end
+reachability remains unverified by this repository. (`deploy/incus/` is the
+retired dom1 edge — its one Python file says so on line 1 — and is not what
+serves CodexBridge.)

--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -1,0 +1,194 @@
+# Testing against the contract, and consuming it from the mobile repository
+
+- work_id: WK-20260826-gh14-contract-tests
+- data: 2026-08-26
+- owner: Esteban D.Dortta
+- issue: #14 (epic #1)
+
+`README.md` in this directory holds the *rules*. This file holds the *mechanics*:
+which gate runs when, what each one can and cannot see, how to publish a version,
+and how `EDortta/CodexBridgeMobile` pins one.
+
+Everything described here runs from `pytest tests/contract`, which
+`.github/workflows/contract.yml` runs on every push and pull request. No gate
+below needs a separate CI step, no network, and no gateway process: the app is
+imported and driven in-process. It is **not** true that they touch no database
+— `TestClient(app)` runs the startup hook, which creates the default SQLite file
+in the working directory, and `/ready` probes it. No Postgres is involved and no
+migration is applied.
+
+---
+
+## The four gates, and the pair each one guards
+
+The contract is a chain, and each link has its own test file. Reading a green
+run as "everything matches" is the mistake this table exists to prevent — each
+gate sees exactly one pair.
+
+| pair | file | what a red run means |
+|---|---|---|
+| gateway ↔ document | `test_openapi_document.py` | a route exists on one side only |
+| runtime body ↔ document | `test_declared_examples_are_real.py` | a response body does not match the schema, or an example lies |
+| document ↔ published artifact | `test_published_contract_artifact.py` | `contract/` is behind, or a published version was edited |
+| document ↔ minimum supported version | `test_contract_compatibility.py` | the change breaks a client on the pinned floor |
+| prose ↔ runtime | `test_docs_match_the_runtime.py` | a document states a runtime fact that stopped being true |
+
+---
+
+## Publishing a version
+
+The document is the source; `contract/` is what a consumer downloads.
+
+```bash
+python3 scripts/publish_contract.py            # write contract/<info.version>/
+python3 scripts/publish_contract.py --check    # verify only; exit 1 on drift
+```
+
+Publishing writes three things and nothing else — no timestamp, no hostname, no
+user name, because `--check` works by regenerating and comparing bytes:
+
+```
+contract/<version>/codex-bridge.openapi.yaml   byte-identical copy of the document
+contract/<version>/manifest.json               contractVersion + sha256 of that copy
+contract/index.json                            every published version, and the latest
+```
+
+**Changing the document means republishing.** `pytest tests/contract` fails
+until you do, and the failure names the stale file. That is deliberate: the
+gate is the only thing standing between a merged contract change and a mobile
+team reading yesterday's YAML.
+
+**A published version directory is immutable.** `--check` recomputes every
+manifest digest, so editing `contract/1.6.0/…` in place fails rather than
+quietly rewriting what a client already pinned. Ship a new version instead.
+
+---
+
+## Consuming a pinned version from `EDortta/CodexBridgeMobile`
+
+Fetch the version directory, verify the digest, and keep the digest in the
+mobile repository. The pin is the *digest*, not the version number — a number
+alone is what the contract had before this existed.
+
+`main` below is the versioned deploy cut of `EDortta/CodexBridge`; it moves, and
+that is what the digest check is for. A build that must be reproducible should
+name a tag or a commit sha in `REF` instead.
+
+```bash
+VERSION=1.6.0
+REF=main
+BASE=https://raw.githubusercontent.com/EDortta/CodexBridge/$REF/contract/$VERSION
+
+curl -fsSL "$BASE/codex-bridge.openapi.yaml" -o codex-bridge.openapi.yaml
+curl -fsSL "$BASE/manifest.json"             -o manifest.json
+
+# Refuse to build against a document that is not the one that was published.
+python3 - <<'PY'
+import hashlib, json, sys
+manifest = json.load(open("manifest.json"))
+digest = hashlib.sha256(open(manifest["document"], "rb").read()).hexdigest()
+sys.exit(0 if digest == manifest["sha256"] else "contract digest mismatch")
+PY
+```
+
+`contract/index.json` names `latest` and every version published so far, for a
+consumer that has not pinned yet. Following `latest` automatically is a choice
+to be unpinned; say so out loud if you make it.
+
+---
+
+## The floor: `x-minimum-supported-version`
+
+The document declares the oldest published version this build still promises to
+serve:
+
+```yaml
+x-minimum-supported-version: '1.6.0'
+```
+
+It lives in the document, not in a constant here, so it travels with the
+artifact: a consumer that fetched `contract/<v>/codex-bridge.openapi.yaml` reads
+the floor without cloning this repository.
+
+```bash
+python3 scripts/check_contract_compatibility.py
+```
+
+compares the working document against the published copy of that version and
+exits 1, naming every incompatible pointer, on anything §"What is a breaking
+change" forbids. The output is a list of JSON pointers, most general first:
+
+```
+paths[/api/v1/projects].get.responses[200]: this response was removed or renamed. …
+components.schemas[Error].properties[retryable]: this property was removed or renamed. …
+```
+
+Raising the floor is a deliberate act, not housekeeping: it drops the promise to
+every client still on the older pin and needs the same conversation with the
+mobile team that a deprecation does.
+
+### What the compatibility gate cannot see
+
+Read a green run as *"no mechanically visible break"*, never as *"compatible"*.
+Four classes pass, three of them straight from the README's own list:
+
+- **a meaning change that keeps the name and the type** — the README calls this
+  "the most dangerous kind, because no schema diff catches it", and nothing here
+  changes that;
+- **default sort order**, and the **identity or lifetime of a pagination cursor**;
+- a **rename is reported as a removal** — the verdict is right, the wording is not;
+- a constraint tightened **inside** an `allOf` / `anyOf` / `oneOf` branch:
+  composition members are compared as a set and not recursed into, because
+  comparing them positionally would report two breaks every time two equivalent
+  branches are reordered.
+
+---
+
+## Fixtures for the mobile client
+
+The response examples in the document are checked, one parametrized test per
+example, against the schema they illustrate
+(`test_declared_examples_are_real.py::test_a_declared_example_satisfies_its_own_schema`).
+So they are usable as fixtures directly out of the pinned YAML — an example that
+contradicts its own schema cannot be merged.
+
+There is **no fixture generator in this repository**, and no fixture files are
+committed. Extract them from the pinned document with whatever the mobile build
+already uses for YAML; every example lives under
+`paths.<path>.<method>.responses.<status>.content.<media>.example` or
+`.examples.<name>.value`.
+
+## A local mock server
+
+**Nothing here vendors, wraps or tests a mock server.** The published document
+is a plain OpenAPI 3.1 file, so any tool that reads one works, and the pinned
+copy is the right input because it is the copy the client was built against:
+
+```bash
+npx @stoplight/prism-cli mock contract/1.6.0/codex-bridge.openapi.yaml
+```
+
+That command is a pointer, not a supported path: it is not in CI, not in
+`pyproject.toml`, and no test in this repository exercises it. A mock replays
+the document, so it agrees with the contract by construction and proves nothing
+about the gateway — which is what the gates in the table above are for.
+
+To develop against the **real** gateway instead, override the `host` server
+variable; its default is production
+(`docs/api/codex-bridge.openapi.yaml`, `servers`).
+
+---
+
+## Running the gates locally
+
+```bash
+pip install -e '.[test]'
+pytest tests/contract -q          # every gate in the table above
+pytest -q                         # the whole suite
+```
+
+`tests/contract` needs no running gateway: it imports `gateway.app.main.app` and
+drives it through `TestClient` in-process, against the default SQLite file. That
+is also its limit — the nginx edge in `deploy/incus/` decides separately what it
+forwards, so **end-to-end reachability of a contracted route is not verified by
+this repository's tests.**

--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -85,16 +85,20 @@ Fetch the version directory, verify the digest, and keep the digest in the
 mobile repository. The pin is the *digest*, not the version number — a number
 alone is what the contract had before this existed.
 
-**Not usable yet, and the reason matters.** `origin/main` carries no
-`contract/` directory — it carries no `docs/api/` at all — so every command
-below 404s until the API work reaches it. `development` is where the artifact
-lives today. Point `REF` at `development`, at a tag, or at a commit sha; a build
-that must be reproducible should never name a moving branch anyway, which is
-also why the digest check below is the real guard rather than the URL.
+**Not usable yet, and the reason matters.** **No branch carries `contract/`.**
+It exists only on the unmerged `feature/gh-14/contract-integration-compat-tests`
+branch that introduced it; `origin/development` does not have it, and
+`origin/main` carries no `docs/api/` at all. Every command below 404s until this
+work merges, and it is written down here rather than left to be discovered by
+whoever runs it first.
+
+Once it merges, point `REF` at the branch it landed on — or better, at a tag or
+a commit sha, since a build that must be reproducible should never name a moving
+branch. The digest check below is the real guard either way.
 
 ```bash
 VERSION=1.6.0
-REF=development
+REF=development     # once contract/ has merged there; see above
 BASE=https://raw.githubusercontent.com/EDortta/CodexBridge/$REF/contract/$VERSION
 
 curl -fsSL "$BASE/codex-bridge.openapi.yaml" -o codex-bridge.openapi.yaml

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- 100 file(s) · 955 symbol(s) indexed
+- 100 file(s) · 959 symbol(s) indexed
 - Languages: config (2), python (96), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -716,6 +716,8 @@ tests/
 - `change_a_default(document)` — "A client that omits the field gets different behaviour and no error."
 - `rename_a_server_variable(document)` — "`servers` was not walked at all; every generated client embeds it."
 - `add_a_required_parameter_to_a_path_item(document)` — "Path-item parameters apply to every operation under the path."
+- `demand_a_request_body_where_there_was_none(document)` — "An operation that starts requiring a body every existing caller omits."
+- `point_an_operation_at_a_required_component_parameter(document)` — "A `$ref` to an already-required component parameter, added to an operation."
 - `use_a_restriction_keyword_the_gate_does_not_model(document)` — "The tripwire: abstaining loudly beats abstaining silently."
 - `test_a_breaking_change_is_caught_and_named(baseline, mutate)` — "Every rule in §"What is a breaking change" that a schema diff can see."
 - `add_an_endpoint(document)`
@@ -751,6 +753,8 @@ tests/
 - `test_the_codemap_names_every_module_it_claims_to_index()` — "`.docs/agents/programmer.md` tells the next agent to read this instead of scanning."
 - `test_the_api_readme_does_not_deny_the_limiter_that_ships(denial)` — "§"Rate limiting — vocabulary only, so far" outlived the wiring."
 - `test_the_api_readme_does_not_deny_the_publication_machinery_that_ships(denial)` — "§"Getting the contract to the mobile repository" described its own absence."
+- `test_the_testing_doc_counts_the_gates_that_exist()` — "`docs/api/testing.md` enumerates the gates; the enumeration must be true."
+- `test_the_contract_docs_do_not_deny_what_ships(denial)` — "Sentences that were false when written, pinned so they cannot come back."
 
 ### `tests/contract/test_openapi_document.py`
 

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- 100 file(s) · 944 symbol(s) indexed
+- 100 file(s) · 955 symbol(s) indexed
 - Languages: config (2), python (96), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -689,6 +689,7 @@ tests/
 - `test_the_document_declares_a_minimum_supported_version(spec)` — "Without it there is no floor, and this whole file has nothing to compare against."
 - `test_the_minimum_supported_version_is_published(spec)` — "A floor naming an unpublished version is a floor over nothing."
 - `test_the_minimum_supported_version_is_not_ahead_of_the_document(spec)` — "A floor above the ceiling means the build serves nothing it promises."
+- `test_raising_the_floor_past_a_published_version_is_written_down(spec)` — "The one edit that silently disarms this whole file."
 - `test_the_error_code_exemption_still_has_a_schema(spec)` — "The one enum allowed to grow must still be the one the reason applies to."
 - `test_the_document_is_compatible_with_the_minimum_supported_version()` — "The acceptance criterion: a breaking change is caught before merge."
 - `test_the_gate_names_the_incompatible_endpoint_in_its_output(tmp_path)` — ""CI output identifies the incompatible endpoint/schema" — asserted, not assumed."
@@ -709,15 +710,24 @@ tests/
 - `make_a_field_required(document)`
 - `change_a_reference(document)`
 - `require_authentication_on_an_open_endpoint(document)`
+- `stop_requiring_a_response_field(document)` — "A response field that becomes optional is a break, not a relaxation."
+- `swap_the_credential_an_operation_accepts(document)` — "Collapsing `security` to "is it empty" hid every scheme and scope change."
+- `add_a_branch_to_an_all_of(document)` — "`allOf` is an AND: a new branch narrows every value that validated before."
+- `change_a_default(document)` — "A client that omits the field gets different behaviour and no error."
+- `rename_a_server_variable(document)` — "`servers` was not walked at all; every generated client embeds it."
+- `add_a_required_parameter_to_a_path_item(document)` — "Path-item parameters apply to every operation under the path."
+- `use_a_restriction_keyword_the_gate_does_not_model(document)` — "The tripwire: abstaining loudly beats abstaining silently."
 - `test_a_breaking_change_is_caught_and_named(baseline, mutate)` — "Every rule in §"What is a breaking change" that a schema diff can see."
 - `add_an_endpoint(document)`
+- `add_a_realistic_endpoint(document)` — "An endpoint shaped like one someone would actually add."
+- `add_a_component_schema(document)` — "A new schema arrives with its own `required` and constraints, and is referenced."
+- `hoist_parameters_to_the_path_item(document)` — "A pure refactor: path-item parameters apply to every operation under it."
 - `add_an_optional_response_field(document)`
 - `add_a_value_to_error_code(document)`
 - `relax_a_ceiling(document)`
 - `drop_a_pattern(document)`
 - `widen_a_type(document)`
 - `rewrite_prose(document)`
-- `drop_a_required_request_field(document)`
 - `test_a_compatible_change_is_left_alone(baseline, mutate)` — "§"What is not breaking", asserted as loudly as its opposite."
 
 ### `tests/contract/test_declared_examples_are_real.py`
@@ -729,6 +739,7 @@ tests/
 - `test_the_validator_rejects_what_the_schema_forbids(body, why)` — "Everything below is worthless if `_validator` accepts anything."
 - `test_a_declared_example_satisfies_its_own_schema(label, schema, example)` — "An example that contradicts its schema misleads the reader who trusts it most."
 - `test_at_least_one_operation_can_be_driven()` — "Anti-vacuity, again: `security: []` disappearing must not read as green."
+- `test_the_undeclared_field_check_is_not_skipping_everything(client)` — "The third anti-vacuity guard, and the one that was missing."
 - `test_the_gateway_returns_the_declared_shape(client, path, method, operation)` — "The success half of "representative examples are tested"."
 - `test_the_gateway_returns_no_field_the_contract_omits(client, path, method, operation)` — "The body-level mirror of the undocumented-route check."
 - `test_a_failure_response_is_the_declared_error_envelope(client, label, trigger)` — "`Error` is a promise about *every* non-2xx, so it is checked against the schema."

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-08-22 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
+> Generated: 2026-08-26 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
 > Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge map`
 
 ## Summary
 
-- 95 file(s) · 876 symbol(s) indexed
-- Languages: config (2), python (91), shell (2)
+- 97 file(s) · 894 symbol(s) indexed
+- Languages: config (2), python (93), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -20,7 +20,7 @@
 ## Ignored Paths
 
 - Built-in: `.docs-migration-bak`, `.git`, `.idea`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `.tox`, `.venv`, `.vscode`, `__pycache__`, `build`, `dist`, `env`, `node_modules`, `venv`
-- `.gitignore`: `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, `.coverage`, `codex_bridge.db`, `dist/`, `build/`, `*.egg-info/`, `.venv/`, `venv/`, `AGENTS.md`, `.cursorrules`, `CLAUDE.md`, `.windsurfrules`, `GEMINI.md`, `.github/copilot-instructions.md`, `.amazonq/rules/ai-agents.md`, `.credentials`, `handoff.md`, `new-tag.sh`, `scripts/install-agents-kit.sh`, `scripts/agent-worktree.sh`, `.docs-migration-bak/`, `.gk/operator.json`, `.gk/secrets.json`, `.gk/context-telemetry.jsonl`, `.gk/overwritten/`, `.env`, `.env.*`, `.envrc`, `.npmrc`, `.pypirc`, `.netrc`, `*.pem`, `*.key`, `.credentials/*`, `!.env.example`, `!.env.sample`, `!.env.template`, `!.env.dist`, `!.env-example`, `!.env.missing`, `!.credentials/.gitignore`, `!.credentials/.keep`, `!.credentials/README*`, `!.credentials/*.example`, `!.credentials/*.sample`, `!.credentials/*.template`, `!.credentials/*.dist`
+- `.gitignore`: `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, `.coverage`, `codex_bridge.db`, `dist/`, `build/`, `*.egg-info/`, `.venv/`, `venv/`, `.governancekit-identity.json`, `AGENTS.md`, `.cursorrules`, `CLAUDE.md`, `.windsurfrules`, `GEMINI.md`, `.github/copilot-instructions.md`, `.amazonq/rules/ai-agents.md`, `handoff.md`, `new-tag.sh`, `scripts/install-agents-kit.sh`, `scripts/agent-worktree.sh`, `.docs-migration-bak/`, `.gk/operator.json`, `.gk/secrets.json`, `.gk/context-telemetry.jsonl`, `.gk/overwritten/`, `.gk/pre-upgrade/`, `.gk/pre-migrate/`, `.gk/remove-agents-backup/`, `.gk/remove-agents-plan.json`, `.gk/context-proposal/`, `*.kit-new`, `*.pre-draft`, `.env`, `.env.*`, `.envrc`, `.npmrc`, `.pypirc`, `.netrc`, `*.pem`, `*.key`, `.credentials/*`, `!.env.example`, `!.env.sample`, `!.env.template`, `!.env.dist`, `!.env-example`, `!.env.missing`, `!.credentials/.gitignore`, `!.credentials/.keep`, `!.credentials/README*`, `!.credentials/*.example`, `!.credentials/*.sample`, `!.credentials/*.template`, `!.credentials/*.dist`
 
 ## Entry Points
 
@@ -102,6 +102,7 @@ scripts/
   apply_migrations.py  — "Apply the SQL files in `migrations/`, once each, in filename order."
   diagnose.sh
   install.sh
+  publish_contract.py  — "Publish the OpenAPI contract as a pinned, checksummed artifact."
 shared/
   __init__.py  — "Shared contracts for the gateway and the agent."
   policy.py
@@ -113,6 +114,7 @@ tests/
     test_docs_match_the_runtime.py  — "Prose that states a runtime fact, checked against the runtime."
     test_openapi_document.py  — "Contract tests for the canonical OpenAPI document."
     test_proxy_routes.py  — "Every contracted path must be routed by the proxies in front of the gateway."
+    test_published_contract_artifact.py  — "The pinned contract artifact `EDortta/CodexBridgeMobile` consumes."
   integration/
     test_agent_ack_handling.py  — "`task.ack` handling in the `/agent/ws` message loop — issue #16 council."
     test_agent_hub.py
@@ -625,6 +627,16 @@ tests/
 
 - `main()`
 
+### `scripts/publish_contract.py`
+
+> Publish the OpenAPI contract as a pinned, checksummed artifact.
+
+- `sha256_of(path)`
+- `contract_version(source)` — "`info.version` of the document at `source`."
+- `publish(source, output)` — "Write the version directory and refresh the index. Returns the version."
+- `check(source, output)` — "Everything wrong with the published artifact, in messages an operator can act on."
+- `main(argv)`
+
 ### `shared/policy.py`
 
 - **`PolicyDecision`** *(class)*
@@ -690,6 +702,24 @@ tests/
 - `test_nginx_configs_exist()` — "If the configs move, this gate must fail loudly rather than pass empty."
 - `test_every_contract_path_is_routed_by_every_terminating_vhost(contract_paths)`
 - `test_every_proxied_location_reaches_an_upstream()` — "A location block with no `proxy_pass` silently drops its path."
+
+### `tests/contract/test_published_contract_artifact.py`
+
+> The pinned contract artifact `EDortta/CodexBridgeMobile` consumes.
+
+- `run(*args)`
+- `spec()`
+- `test_the_publisher_exists_and_runs()` — "If the script moves, every other test here would pass vacuously."
+- `test_the_published_artifact_matches_the_current_document()` — "A merged contract change that never reached `contract/` is drift."
+- `test_the_current_version_is_published(spec)` — "`info.version` must name a directory a client can fetch."
+- `test_the_index_names_the_current_version_as_latest(spec)` — "The pointer a consumer follows when it has not pinned yet."
+- `test_a_published_version_is_byte_identical_to_the_document(spec)` — "Not "equivalent YAML" — identical bytes."
+- `test_every_published_version_hashes_to_its_manifest()` — "The property that makes a pin worth pinning."
+- `test_check_reports_a_document_that_moved_ahead_of_the_artifact(tmp_path)` — "Change the document, do not republish: the check must name the stale file."
+- `test_check_reports_a_published_version_edited_after_the_fact(tmp_path)` — "Rewriting a pinned version is the failure the digest exists to catch."
+- `test_check_reports_a_contract_that_was_never_published(tmp_path)`
+- `test_publishing_a_new_version_leaves_the_old_one_untouched(tmp_path)` — "A pin survives the next release, or it was never a pin."
+- `test_publishing_is_deterministic(tmp_path)` — "Two runs over one input produce identical bytes."
 
 ### `tests/integration/test_agent_ack_handling.py`
 

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,8 +5,8 @@
 
 ## Summary
 
-- 97 file(s) · 894 symbol(s) indexed
-- Languages: config (2), python (93), shell (2)
+- 100 file(s) · 944 symbol(s) indexed
+- Languages: config (2), python (96), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -100,6 +100,7 @@ gateway/
 pyproject.toml
 scripts/
   apply_migrations.py  — "Apply the SQL files in `migrations/`, once each, in filename order."
+  check_contract_compatibility.py  — "Refuse a contract change that breaks the minimum API version mobile still supports."
   diagnose.sh
   install.sh
   publish_contract.py  — "Publish the OpenAPI contract as a pinned, checksummed artifact."
@@ -111,6 +112,8 @@ shared/
 tests/
   conftest.py
   contract/
+    test_contract_compatibility.py  — "The gate that fails a pull request before it breaks the pinned mobile client."
+    test_declared_examples_are_real.py  — "Response **bodies**, checked against the contract — the half the route gate skips."
     test_docs_match_the_runtime.py  — "Prose that states a runtime fact, checked against the runtime."
     test_openapi_document.py  — "Contract tests for the canonical OpenAPI document."
     test_proxy_routes.py  — "Every contracted path must be routed by the proxies in front of the gateway."
@@ -627,6 +630,16 @@ tests/
 
 - `main()`
 
+### `scripts/check_contract_compatibility.py`
+
+> Refuse a contract change that breaks the minimum API version mobile still supports.
+
+- `facts(document)` — "Comparable facts for one OpenAPI document."
+- `incompatibilities(baseline, candidate)` — "Every breaking change in `candidate` relative to `baseline`."
+- `minimum_supported_version(document)`
+- `baseline_path(document, published)`
+- `main(argv)`
+
 ### `scripts/publish_contract.py`
 
 > Publish the OpenAPI contract as a pinned, checksummed artifact.
@@ -666,12 +679,67 @@ tests/
 - `ensure_within_root(root, target)`
 - `filtered_environment(allowed_keys)`
 
+### `tests/contract/test_contract_compatibility.py`
+
+> The gate that fails a pull request before it breaks the pinned mobile client.
+
+- `run(*args)`
+- `spec()`
+- `baseline(spec)` — "The published copy of the minimum supported version."
+- `test_the_document_declares_a_minimum_supported_version(spec)` — "Without it there is no floor, and this whole file has nothing to compare against."
+- `test_the_minimum_supported_version_is_published(spec)` — "A floor naming an unpublished version is a floor over nothing."
+- `test_the_minimum_supported_version_is_not_ahead_of_the_document(spec)` — "A floor above the ceiling means the build serves nothing it promises."
+- `test_the_error_code_exemption_still_has_a_schema(spec)` — "The one enum allowed to grow must still be the one the reason applies to."
+- `test_the_document_is_compatible_with_the_minimum_supported_version()` — "The acceptance criterion: a breaking change is caught before merge."
+- `test_the_gate_names_the_incompatible_endpoint_in_its_output(tmp_path)` — ""CI output identifies the incompatible endpoint/schema" — asserted, not assumed."
+- `test_the_gate_refuses_a_floor_that_is_not_published(tmp_path)` — "Pointing the floor at a version nobody can download is not a green run."
+- `test_a_document_with_no_declared_floor_is_an_error(tmp_path)`
+- `test_a_document_compared_with_itself_reports_nothing(baseline)` — "The precondition every other case rests on."
+- `remove_an_endpoint(document)`
+- `remove_an_operation(document)`
+- `remove_a_response_status(document)`
+- `remove_a_response_field(document)`
+- `rename_a_response_field(document)`
+- `remove_an_enum_value(document)`
+- `add_a_value_to_another_enum(document)`
+- `close_an_open_field_with_an_enum(document)` — "`type: string` -> `enum: [...]`: yesterday's valid value may be rejected today."
+- `narrow_a_type(document)`
+- `tighten_a_ceiling(document)`
+- `add_a_pattern(document)`
+- `make_a_field_required(document)`
+- `change_a_reference(document)`
+- `require_authentication_on_an_open_endpoint(document)`
+- `test_a_breaking_change_is_caught_and_named(baseline, mutate)` — "Every rule in §"What is a breaking change" that a schema diff can see."
+- `add_an_endpoint(document)`
+- `add_an_optional_response_field(document)`
+- `add_a_value_to_error_code(document)`
+- `relax_a_ceiling(document)`
+- `drop_a_pattern(document)`
+- `widen_a_type(document)`
+- `rewrite_prose(document)`
+- `drop_a_required_request_field(document)`
+- `test_a_compatible_change_is_left_alone(baseline, mutate)` — "§"What is not breaking", asserted as loudly as its opposite."
+
+### `tests/contract/test_declared_examples_are_real.py`
+
+> Response **bodies**, checked against the contract — the half the route gate skips.
+
+- `client()`
+- `test_the_document_declares_response_examples_at_all()` — "Anti-vacuity: the parametrized test below is empty if discovery breaks."
+- `test_the_validator_rejects_what_the_schema_forbids(body, why)` — "Everything below is worthless if `_validator` accepts anything."
+- `test_a_declared_example_satisfies_its_own_schema(label, schema, example)` — "An example that contradicts its schema misleads the reader who trusts it most."
+- `test_at_least_one_operation_can_be_driven()` — "Anti-vacuity, again: `security: []` disappearing must not read as green."
+- `test_the_gateway_returns_the_declared_shape(client, path, method, operation)` — "The success half of "representative examples are tested"."
+- `test_the_gateway_returns_no_field_the_contract_omits(client, path, method, operation)` — "The body-level mirror of the undocumented-route check."
+- `test_a_failure_response_is_the_declared_error_envelope(client, label, trigger)` — "`Error` is a promise about *every* non-2xx, so it is checked against the schema."
+
 ### `tests/contract/test_docs_match_the_runtime.py`
 
 > Prose that states a runtime fact, checked against the runtime.
 
 - `test_the_codemap_names_every_module_it_claims_to_index()` — "`.docs/agents/programmer.md` tells the next agent to read this instead of scanning."
 - `test_the_api_readme_does_not_deny_the_limiter_that_ships(denial)` — "§"Rate limiting — vocabulary only, so far" outlived the wiring."
+- `test_the_api_readme_does_not_deny_the_publication_machinery_that_ships(denial)` — "§"Getting the contract to the mobile repository" described its own absence."
 
 ### `tests/contract/test_openapi_document.py`
 

--- a/docs/issues/014-contract-integration-compat-tests/RESUME.md
+++ b/docs/issues/014-contract-integration-compat-tests/RESUME.md
@@ -6,8 +6,8 @@
 
 ## Next Step (DO THIS FIRST)
 
-Nothing is pushed and no PR exists. The branch is three (soon four) commits
-ahead of `development` and the full suite is green.
+Nothing is pushed and no PR exists. The branch is five commits ahead of
+`development` and the full suite is green.
 
 **Before merging, and before merging #11 or #13:** whoever merges a branch that
 changed `docs/api/codex-bridge.openapi.yaml` must run
@@ -16,9 +16,14 @@ changed `docs/api/codex-bridge.openapi.yaml` must run
 python3 scripts/publish_contract.py
 ```
 
-and commit `contract/`. `tests/contract` fails until they do, and the failure
-message names the file — but the person seeing it will not have read this, so
-say it in the pull request.
+and commit `contract/`. `pytest tests/contract` fails until they do and the
+message names the command — but the person seeing it will not have read this,
+so say it in the pull request.
+
+Verified against the real sibling branches, read-only: the compatibility gate
+reports **0 breaking changes** for both `feature/gh-11` (1.7.0) and
+`feature/gh-13` (1.8.0). Their merges will fail only the publish check, which
+the command above fixes.
 
 ## Current state
 
@@ -36,11 +41,11 @@ paths dynamically. No test in it names an endpoint.
 
 | acceptance criterion | already met before this work | added here |
 |---|---|---|
-| PRs fail when the implementation diverges from the contract | route-inventory drift, both directions: `tests/contract/test_openapi_document.py:290` (`test_no_public_route_is_missing_from_the_contract`) and `:298` (`test_no_contract_path_is_unimplemented`); run on every push/PR by `.github/workflows/contract.yml:29` | **response-body** divergence, which `docs/api/README.md` §"What the gate does not cover" named as the open half: `tests/contract/test_declared_examples_are_real.py` validates live bodies against the declared schemas and rejects a top-level field the contract omits |
-| representative success **and** failure examples tested | behaviour-level, in `tests/integration` — `test_probes.py:53,140,154` (health / ready / 503) and `test_api_conventions.py:151,164,173,186` (422 / HTTPException / 500 / 429 envelopes) — asserted against expectations **written in Python** | the same responses asserted against the **document**: every declared example validated against its own schema, every drivable success body against the declared schema, and failure bodies against `components/schemas/Error` |
-| a machine-consumable contract artifact / the mobile repo can pin a version | nothing. `docs/api/README.md` §"Getting the contract to the mobile repository" said so in as many words: *"Today there is none […] a consumer copies it by hand"* | `scripts/publish_contract.py` → `contract/<version>/{codex-bridge.openapi.yaml,manifest.json}` + `contract/index.json`, with `tests/contract/test_published_contract_artifact.py` |
-| breaking changes detected before merge | nothing. `info.version` was a number with no comparison behind it; `test_openapi_document.py:414` only asserts the runtime **reports** the same number | `x-minimum-supported-version` in the document + `scripts/check_contract_compatibility.py` + `tests/contract/test_contract_compatibility.py` |
-| CI output identifies the incompatible endpoint/schema | route drift already named `(path, method)` pairs | every compatibility finding is a JSON pointer, most-general-first, asserted by `test_the_gate_names_the_incompatible_endpoint_in_its_output` and by the whole mutation matrix (each mutation returns the pointer it broke and the finding must name it) |
+| PRs fail when the implementation diverges from the contract | route-inventory drift, both directions: `tests/contract/test_openapi_document.py:290` and `:298`; run on every push/PR by `.github/workflows/contract.yml:29` | **response-body** divergence, which `docs/api/README.md` §"What the gate does not cover" named as the open half: `tests/contract/test_declared_examples_are_real.py` validates live bodies against the declared schemas and rejects a top-level field the contract omits |
+| representative success **and** failure examples tested | behaviour-level, in `tests/integration` — `test_probes.py:53,140,154` and `test_api_conventions.py:151,164,173,186` — asserted against expectations **written in Python** | the same responses asserted against the **document**: all 24 declared examples validated against the schema each illustrates, drivable success bodies against the declared schema, failure bodies against `components/schemas/Error` |
+| a machine-consumable contract artifact / the mobile repo can pin a version | nothing. `docs/api/README.md` said so in as many words: *"Today there is none […] a consumer copies it by hand"* | `scripts/publish_contract.py` → `contract/<version>/{codex-bridge.openapi.yaml,manifest.json}` + `contract/index.json`, with `tests/contract/test_published_contract_artifact.py` |
+| breaking changes detected before merge | nothing. `info.version` was a number with no comparison behind it; `test_openapi_document.py:414` only asserts the runtime **reports** the same number | `x-minimum-supported-version` + `scripts/check_contract_compatibility.py` + `tests/contract/test_contract_compatibility.py` |
+| CI output identifies the incompatible endpoint/schema | route drift already named `(path, method)` pairs | every compatibility finding is a JSON pointer, most-general-first, asserted by `test_the_gate_names_the_incompatible_endpoint_in_its_output` and by the whole mutation matrix — each mutation returns the pointer it broke and the finding must name it |
 
 Building a second route-drift gate would have been duplicate coverage; it was
 not built.
@@ -49,21 +54,18 @@ not built.
 
 **Artifact publication.** `scripts/publish_contract.py` copies the document
 byte-for-byte into `contract/<info.version>/`, writes a `manifest.json` with its
-SHA-256, and refreshes `contract/index.json` (`latest` + every version). Nothing
-carries a timestamp, a hostname or a user name, because `--check` verifies by
-regenerating into a temp tree and comparing bytes — a field that moved between
-two runs would make the gate fire on itself. `--check` *also* re-hashes every
-previously published version against its own manifest, which is the check that
-makes a pin mean anything. Consumer-side commands: `docs/api/testing.md`.
+SHA-256, and refreshes `contract/index.json`. Nothing carries a timestamp,
+hostname or user name, because `--check` verifies by regenerating into a temp
+tree and comparing bytes. `--check` *also* re-hashes every previously published
+version against its own manifest. Consumer-side commands: `docs/api/testing.md`.
 
 **Minimum supported version.** Declared as `x-minimum-supported-version` at the
 root of the OpenAPI document — in the document, not in a repo constant, so it
-travels with the published artifact and a consumer reads the floor without
-cloning this repository (the same argument `docs/api/README.md` makes for
-`x-contract-excluded-paths` living there).
+travels with the published artifact.
 `scripts/check_contract_compatibility.py` flattens both documents into
 `pointer → (kind, value)` facts and diffs them in the direction that hurts a
-client.
+client. A constraint counts as a tightening only when the thing it constrains
+already existed.
 
 The baseline is the **published copy** `contract/<floor>/codex-bridge.openapi.yaml`,
 not a second snapshot under `tests/contract/baselines/`. That is a deliberate
@@ -77,21 +79,20 @@ New: `scripts/publish_contract.py`, `scripts/check_contract_compatibility.py`,
 `contract/index.json`, `contract/1.6.0/{codex-bridge.openapi.yaml,manifest.json}`,
 `docs/api/testing.md`,
 `tests/contract/{test_published_contract_artifact,test_contract_compatibility,test_declared_examples_are_real}.py`,
-this file.
+this file and `council-round-{1,2}.json` beside it.
 
 Changed: `docs/api/codex-bridge.openapi.yaml` (only `x-minimum-supported-version`
 and one Conventions paragraph that had gone stale — no endpoint, no version
 move), `docs/api/README.md`, `docs/required-reading.md`,
-`tests/contract/test_docs_match_the_runtime.py`, `pyproject.toml`
-(`jsonschema` declared in the `test` extra rather than resting on a transitive
-dependency), `docs/codemap.md`.
+`tests/contract/test_docs_match_the_runtime.py`, `pyproject.toml`, `docs/codemap.md`.
 
 ## Checks
 
-`PYTHONPATH=. .venv/bin/python -m pytest -q` from the worktree → **615 passed,
+`PYTHONPATH=. .venv/bin/python -m pytest -q` from the worktree → **652 passed,
 3 skipped**. Baseline on the same worktree before this session's new tests: 561
-passed, 3 skipped — so +54 tests, no regression, same 3 skips.
-`pytest tests/contract -q` → 91 passed (26 before).
+passed, 3 skipped — so **+91 tests**, no regression, the same 3 skips (the
+opt-in `RUN_REAL_CODEX_TESTS` real-process tests).
+`pytest tests/contract -q` → **128 passed** (26 before).
 
 The known `test_agent_ws_handshake.py` flake did not appear: `codex_bridge.db`
 was deleted before each full run.
@@ -103,47 +104,55 @@ Not validated:
   never run.
 - **Authenticated endpoints' response bodies.** The body-conformance gate drives
   only operations the document marks `security: []`; a session fixture lives in
-  `tests/integration` and reaching across suites would put the authorization
-  model's setup into the contract suite. Stated in the module docstring and in
+  `tests/integration`. Stated in the module docstring and in
   `docs/api/README.md`, not implied away.
 - **`format` keywords.** `jsonschema` does not assert `format` by default and it
   is left off, so `format: date-time` is unenforced — and the contract's actual
-  rule (RFC 3339 *with* `Z`) is not expressible in a schema at all, as the
-  document's own Conventions section says.
-- **The consumer-side recipe in `docs/api/testing.md`.** The `curl` +
-  digest-verify snippet was never run against `raw.githubusercontent.com`; the
-  branch is not pushed, so the URL it names does not resolve yet.
-- **The mock-server line** (`npx @stoplight/prism-cli`). Documented explicitly as
-  a pointer and not a supported path: not in CI, not in `pyproject.toml`, not
-  exercised by any test.
-- **End-to-end reachability** through the nginx edge in `deploy/incus/` —
-  unchanged and still unverified by this repository's tests.
+  rule (RFC 3339 *with* `Z`) is not expressible in a schema at all.
+- **The consumer-side recipe in `docs/api/testing.md`.** Never run against
+  `raw.githubusercontent.com`: **no branch carries `contract/` yet**, so the
+  URLs do not resolve until this work merges. Said plainly in the document.
+- **The mock-server line** (`npx @stoplight/prism-cli`). Documented as a pointer
+  and not a supported path: not in CI, not in `pyproject.toml`, not exercised.
+- **End-to-end reachability.** `tests/contract/test_proxy_routes.py` checks the
+  vhost *configuration* in `deploy/nginx/` statically; no test in this
+  repository sends a request to a real host.
 
 ## Risks accepted
 
 1. **Republishing under the same `info.version` rewrites a pin.** `publish()`
    overwrites the version directory and its manifest together, so the digest
-   agrees again and every gate goes green while the bytes behind a number a
-   client pinned have changed. Only the version-control history shows it.
-   Closing it in the publisher means enforcing "every change moves
-   `info.version`", which would have forced a version bump belonging to #11/#13.
-   Written into `docs/api/README.md` §"Getting the contract to the mobile
-   repository" with the mitigation: **review any diff that touches `contract/`
-   without adding a directory.**
-2. **The compatibility gate is honest about four blind spots**, three of them
-   from the README's own breaking list: a meaning change under an unchanged name
-   and type, default sort order / cursor identity and lifetime, a rename
-   reported as a removal, and a tightening inside an `allOf`/`anyOf`/`oneOf`
-   branch (members compared as a set, because positional comparison would report
-   two breaks on every harmless reorder). Enumerated in the module docstring and
-   in `docs/api/testing.md`.
-3. **The floor equals the current version today** (`1.6.0` both), so the live
-   compatibility comparison cannot fail on a version bump. It is not vacuous —
-   it compares the working document against an immutable published copy, so an
-   in-place removal under `1.6.0` fails it — but its full value arrives when
-   #11/#13 move `info.version` above the floor.
-4. **`x-minimum-supported-version` is a one-line addition to a file two sibling
+   agrees again and every gate goes green while the bytes behind a pinned number
+   have changed. Only the version-control history shows it. Closing it means
+   enforcing "every change moves `info.version`" in the publisher, which would
+   have forced a version bump belonging to #11/#13. Written into
+   `docs/api/README.md` and `docs/api/testing.md` with the mitigation: **move
+   `info.version` whenever you change the document, and review any diff that
+   touches `contract/` without adding a directory.**
+2. **Three classes of breaking change pass the compatibility gate in silence**,
+   all three from the README's own list: a meaning change under an unchanged
+   name and type, default sort order, and cursor identity/lifetime. Two more are
+   imprecise rather than silent (a rename reads as a removal; a constraint
+   tightened inside an existing `allOf` branch reads as "1 branch removed"). One
+   is neither — an unmodelled restriction keyword makes the gate *fail*, saying
+   it abstained. Still uncompared: the **contents** of a `securitySchemes` entry.
+3. **A `required` removal on a request-only schema reports**, which is a
+   deliberate false positive: a JSON pointer cannot tell request from response
+   and most schemas here are shared. The message names the direction so a
+   reviewer resolves it instead of the gate guessing.
+4. **The floor equals the current version today** (`1.6.0` both), so the live
+   comparison cannot fail on a version bump. Not vacuous — it still catches an
+   in-place removal under 1.6.0 — but its full value arrives when #11/#13 move
+   `info.version` above the floor.
+5. **`x-minimum-supported-version` is a one-line addition to a file two sibling
    branches are editing.** Small merge surface, but a real one.
+6. **Editing the YAML and running only `pytest tests/integration` gives no
+   signal.** Not fixed: `.github/workflows/contract.yml` runs `pytest
+   tests/contract` on every push and PR, and `testpaths` makes a bare `pytest -q`
+   cover it. Coupling unrelated suites would cost more than it buys.
+7. **Commit `a0063fd`'s message says "Thirteen breaking mutations"; there were
+   fourteen** at that commit and there are **21** now. The message is immutable;
+   the count is corrected here and nowhere else repeats it.
 
 ## Coordination with #11 and #13
 
@@ -151,14 +160,85 @@ Both bump `info.version` (1.7.0, 1.8.0) and add endpoints, and neither knows
 this machinery exists. On merge:
 
 - `test_published_contract_artifact.py` goes red until `scripts/publish_contract.py`
-  is run and `contract/` committed — the intended behaviour, and the message
-  names the command;
+  is run and `contract/` committed — the intended behaviour, and every failure
+  message now names the command rather than raising a bare `FileNotFoundError`
+  (walked end to end on a scratch copy);
 - `test_contract_compatibility.py` compares the new document against
-  `contract/1.6.0/`. Adding endpoints and optional fields is compatible and
-  passes; anything else fails with the pointer;
+  `contract/1.6.0/` — **0 findings for both branches, measured**;
 - `test_declared_examples_are_real.py` picks up any new unauthenticated GET and
   any new declared example automatically — nothing to edit.
 
-## Council
+**Do not make a red compatibility gate green by raising
+`x-minimum-supported-version`.** That silences it permanently;
+`test_raising_the_floor_past_a_published_version_is_written_down` now refuses it
+without a written reason.
 
-<!-- filled in below -->
+## Council — 2 rounds, `.docs/agents/council.md`
+
+Machine-readable records: `council-round-1.json`, `council-round-2.json` beside
+this file, both also registered with `governancekit council --record`.
+
+### Round 1 — lenses: sweep skeptic, claim auditor, second caller
+
+**26 raised · 26 survived §2 · 24 became tests · 4 questions left open.**
+
+Every finding arrived with trigger, wrong result, file:line and a reproduction,
+so all 26 survived §2. Four were declared duplicates across lenses (claim 5 =
+sweep 3, claim 6 = sweep 11, second 1 = sweep 1, second 3 = claim 3), leaving 22
+distinct defects.
+
+The one that mattered most: **the gate reported every purely additive release as
+breaking.** Measured against the real sibling branches, `feature/gh-11` produced
+**31** breaking findings and `feature/gh-13` **21**, and not one named a pointer
+a 1.6.0 client could address. OpenAPI forces `required: true` on every path
+parameter, so it would have fired on every endpoint carrying one, forever. Both
+are **0** now. The self-test that should have caught it added an endpoint with
+no parameters, no body and no response schema — the one shape that dodged the
+defect.
+
+Second worst: **a test certified a break as compatible.**
+`drop_a_required_request_field` was meant to prove a request-side relaxation
+safe; the schema it mutated was `Actor`, which is response-only.
+
+Seven further classes were silently green and are now caught, each with a
+mutation that fails without the fix: `servers` (never walked), path-item-level
+`parameters` (invisible in, phantom removals out), `components.requestBodies`,
+a changed or deleted `default`, which credential an operation accepts, a branch
+added to an `allOf`, and a `required` name removed from a response schema.
+Raising the floor — the cheapest way to disarm the whole gate — now needs a
+written reason. The example sweep reached 5 of 24 examples while two documents
+claimed every one; all 24 are checked. The undocumented-field check skipped
+every `$ref` and `allOf` response, which is every error shape in the contract.
+
+Questions left open (recorded, not closed): `securitySchemes` entry contents;
+the republish-under-the-same-version hole; the deliberate request-side false
+positive; and the floor being equal to the current version today.
+
+### Round 2 — verification, plus regression hunt on the round-1 fixes
+
+**6 raised · 6 survived §2 · 2 became tests · 4 questions left open** (the four
+carried from round 1, now all recorded as accepted risks above).
+
+Round 2 verified all 26 round-1 findings by reproduction: **23 fully closed**,
+3 partial or re-broken. It then found 6 problems in the fixes themselves:
+
+| # | what | classification | closed by |
+|---|---|---|---|
+| NEW-1 | an existing operation gaining a **required request body** passed in silence — 28 of 40 operations carry none today; round 1's suppression removed a signal that had existed by accident | `introduzido-pela-r1` | `demand_a_request_body_where_there_was_none` |
+| NEW-2 | pointing an existing operation at an already-**required component parameter** passed in silence; the `$ref` site assumed `required: False` and the component itself was unchanged. 41 of 90 operation parameters are `$ref`s | `pré-existente` | `point_an_operation_at_a_required_component_parameter` |
+| NEW-3 | the corrected `curl` recipe still 404s — the fix swapped one wrong branch name for another; **no branch carries `contract/`** | `introduzido-pela-r1` (the false claim); `aberto-da-r1` (the recipe not resolving) | both documents now say no branch carries it yet |
+| NEW-4 | this RESUME.md, added by the fix commit, reinstated the retired `deploy/incus/` citation and carried stale counts and an empty Council section | `introduzido-pela-r1` | rewritten; `test_the_contract_docs_do_not_deny_what_ships` now scans every `docs/issues/**/RESUME.md` too |
+| NEW-5 | the checker enforced three rules the **normative** README list did not contain, while claiming to transcribe it — the cry-wolf mechanism the design exists to avoid | `introduzido-pela-r1` | the five rules are now in §"What is a breaking change" |
+| NEW-6 | a dangling test id in the script docstring | `introduzido-pela-r1` | corrected |
+
+Round 2 also caught a cry-wolf trap before it could fire: the unmodelled-keyword
+tripwire yielded unconditionally, so the first `readOnly: true` anywhere in the
+contract would have made the build permanently red with no way to fix it. It now
+reports only on a *change*.
+
+Round 2's clean probes are worth recording: the new suppression does **not**
+hide a genuine break (existing endpoint + new required parameter, existing schema
++ new required property, optional-to-required flips all still report);
+`_declared_properties` is cycle-safe; and `servers` / path-item parameters /
+`requestBodies` introduce no phantom findings on either sibling branch (0 removed
+and 0 changed facts on both).

--- a/docs/issues/014-contract-integration-compat-tests/RESUME.md
+++ b/docs/issues/014-contract-integration-compat-tests/RESUME.md
@@ -1,0 +1,164 @@
+# RESUME — WK-20260826-gh14-contract-tests (issue #14, epic #1)
+
+- work_id: WK-20260826-gh14-contract-tests
+- data: 2026-08-26
+- branch: `feature/gh-14/contract-integration-compat-tests`
+
+## Next Step (DO THIS FIRST)
+
+Nothing is pushed and no PR exists. The branch is three (soon four) commits
+ahead of `development` and the full suite is green.
+
+**Before merging, and before merging #11 or #13:** whoever merges a branch that
+changed `docs/api/codex-bridge.openapi.yaml` must run
+
+```bash
+python3 scripts/publish_contract.py
+```
+
+and commit `contract/`. `tests/contract` fails until they do, and the failure
+message names the file — but the person seeing it will not have read this, so
+say it in the pull request.
+
+## Current state
+
+Committed on the branch, not pushed, not merged, not deployed. Nothing under
+`gateway/`, `agent/`, `shared/` or `migrations/` was touched
+(`git diff --stat 2e18820..HEAD -- gateway/ agent/ shared/ migrations/` is
+empty), no endpoint was added, and `info.version` /
+`probes.API_CONTRACT_VERSION` are both still `1.6.0` — #11 and #13 own the
+version bumps.
+
+The delivery is anti-drift **machinery**, and it iterates the contract's own
+paths dynamically. No test in it names an endpoint.
+
+## What issue #14 asked for, and where each half came from
+
+| acceptance criterion | already met before this work | added here |
+|---|---|---|
+| PRs fail when the implementation diverges from the contract | route-inventory drift, both directions: `tests/contract/test_openapi_document.py:290` (`test_no_public_route_is_missing_from_the_contract`) and `:298` (`test_no_contract_path_is_unimplemented`); run on every push/PR by `.github/workflows/contract.yml:29` | **response-body** divergence, which `docs/api/README.md` §"What the gate does not cover" named as the open half: `tests/contract/test_declared_examples_are_real.py` validates live bodies against the declared schemas and rejects a top-level field the contract omits |
+| representative success **and** failure examples tested | behaviour-level, in `tests/integration` — `test_probes.py:53,140,154` (health / ready / 503) and `test_api_conventions.py:151,164,173,186` (422 / HTTPException / 500 / 429 envelopes) — asserted against expectations **written in Python** | the same responses asserted against the **document**: every declared example validated against its own schema, every drivable success body against the declared schema, and failure bodies against `components/schemas/Error` |
+| a machine-consumable contract artifact / the mobile repo can pin a version | nothing. `docs/api/README.md` §"Getting the contract to the mobile repository" said so in as many words: *"Today there is none […] a consumer copies it by hand"* | `scripts/publish_contract.py` → `contract/<version>/{codex-bridge.openapi.yaml,manifest.json}` + `contract/index.json`, with `tests/contract/test_published_contract_artifact.py` |
+| breaking changes detected before merge | nothing. `info.version` was a number with no comparison behind it; `test_openapi_document.py:414` only asserts the runtime **reports** the same number | `x-minimum-supported-version` in the document + `scripts/check_contract_compatibility.py` + `tests/contract/test_contract_compatibility.py` |
+| CI output identifies the incompatible endpoint/schema | route drift already named `(path, method)` pairs | every compatibility finding is a JSON pointer, most-general-first, asserted by `test_the_gate_names_the_incompatible_endpoint_in_its_output` and by the whole mutation matrix (each mutation returns the pointer it broke and the finding must name it) |
+
+Building a second route-drift gate would have been duplicate coverage; it was
+not built.
+
+## The two mechanisms
+
+**Artifact publication.** `scripts/publish_contract.py` copies the document
+byte-for-byte into `contract/<info.version>/`, writes a `manifest.json` with its
+SHA-256, and refreshes `contract/index.json` (`latest` + every version). Nothing
+carries a timestamp, a hostname or a user name, because `--check` verifies by
+regenerating into a temp tree and comparing bytes — a field that moved between
+two runs would make the gate fire on itself. `--check` *also* re-hashes every
+previously published version against its own manifest, which is the check that
+makes a pin mean anything. Consumer-side commands: `docs/api/testing.md`.
+
+**Minimum supported version.** Declared as `x-minimum-supported-version` at the
+root of the OpenAPI document — in the document, not in a repo constant, so it
+travels with the published artifact and a consumer reads the floor without
+cloning this repository (the same argument `docs/api/README.md` makes for
+`x-contract-excluded-paths` living there).
+`scripts/check_contract_compatibility.py` flattens both documents into
+`pointer → (kind, value)` facts and diffs them in the direction that hurts a
+client.
+
+The baseline is the **published copy** `contract/<floor>/codex-bridge.openapi.yaml`,
+not a second snapshot under `tests/contract/baselines/`. That is a deliberate
+deviation from the plan: `contract/<floor>/` is already an immutable,
+digest-verified copy of exactly those bytes, and a byte-identical third copy
+would be one more thing to drift.
+
+## Changed files
+
+New: `scripts/publish_contract.py`, `scripts/check_contract_compatibility.py`,
+`contract/index.json`, `contract/1.6.0/{codex-bridge.openapi.yaml,manifest.json}`,
+`docs/api/testing.md`,
+`tests/contract/{test_published_contract_artifact,test_contract_compatibility,test_declared_examples_are_real}.py`,
+this file.
+
+Changed: `docs/api/codex-bridge.openapi.yaml` (only `x-minimum-supported-version`
+and one Conventions paragraph that had gone stale — no endpoint, no version
+move), `docs/api/README.md`, `docs/required-reading.md`,
+`tests/contract/test_docs_match_the_runtime.py`, `pyproject.toml`
+(`jsonschema` declared in the `test` extra rather than resting on a transitive
+dependency), `docs/codemap.md`.
+
+## Checks
+
+`PYTHONPATH=. .venv/bin/python -m pytest -q` from the worktree → **615 passed,
+3 skipped**. Baseline on the same worktree before this session's new tests: 561
+passed, 3 skipped — so +54 tests, no regression, same 3 skips.
+`pytest tests/contract -q` → 91 passed (26 before).
+
+The known `test_agent_ws_handshake.py` flake did not appear: `codex_bridge.db`
+was deleted before each full run.
+
+Not validated:
+
+- **Postgres, and any deployed environment.** Nothing here needs a database
+  beyond the SQLite file `TestClient` creates; `scripts/apply_migrations.py` was
+  never run.
+- **Authenticated endpoints' response bodies.** The body-conformance gate drives
+  only operations the document marks `security: []`; a session fixture lives in
+  `tests/integration` and reaching across suites would put the authorization
+  model's setup into the contract suite. Stated in the module docstring and in
+  `docs/api/README.md`, not implied away.
+- **`format` keywords.** `jsonschema` does not assert `format` by default and it
+  is left off, so `format: date-time` is unenforced — and the contract's actual
+  rule (RFC 3339 *with* `Z`) is not expressible in a schema at all, as the
+  document's own Conventions section says.
+- **The consumer-side recipe in `docs/api/testing.md`.** The `curl` +
+  digest-verify snippet was never run against `raw.githubusercontent.com`; the
+  branch is not pushed, so the URL it names does not resolve yet.
+- **The mock-server line** (`npx @stoplight/prism-cli`). Documented explicitly as
+  a pointer and not a supported path: not in CI, not in `pyproject.toml`, not
+  exercised by any test.
+- **End-to-end reachability** through the nginx edge in `deploy/incus/` —
+  unchanged and still unverified by this repository's tests.
+
+## Risks accepted
+
+1. **Republishing under the same `info.version` rewrites a pin.** `publish()`
+   overwrites the version directory and its manifest together, so the digest
+   agrees again and every gate goes green while the bytes behind a number a
+   client pinned have changed. Only the version-control history shows it.
+   Closing it in the publisher means enforcing "every change moves
+   `info.version`", which would have forced a version bump belonging to #11/#13.
+   Written into `docs/api/README.md` §"Getting the contract to the mobile
+   repository" with the mitigation: **review any diff that touches `contract/`
+   without adding a directory.**
+2. **The compatibility gate is honest about four blind spots**, three of them
+   from the README's own breaking list: a meaning change under an unchanged name
+   and type, default sort order / cursor identity and lifetime, a rename
+   reported as a removal, and a tightening inside an `allOf`/`anyOf`/`oneOf`
+   branch (members compared as a set, because positional comparison would report
+   two breaks on every harmless reorder). Enumerated in the module docstring and
+   in `docs/api/testing.md`.
+3. **The floor equals the current version today** (`1.6.0` both), so the live
+   compatibility comparison cannot fail on a version bump. It is not vacuous —
+   it compares the working document against an immutable published copy, so an
+   in-place removal under `1.6.0` fails it — but its full value arrives when
+   #11/#13 move `info.version` above the floor.
+4. **`x-minimum-supported-version` is a one-line addition to a file two sibling
+   branches are editing.** Small merge surface, but a real one.
+
+## Coordination with #11 and #13
+
+Both bump `info.version` (1.7.0, 1.8.0) and add endpoints, and neither knows
+this machinery exists. On merge:
+
+- `test_published_contract_artifact.py` goes red until `scripts/publish_contract.py`
+  is run and `contract/` committed — the intended behaviour, and the message
+  names the command;
+- `test_contract_compatibility.py` compares the new document against
+  `contract/1.6.0/`. Adding endpoints and optional fields is compatible and
+  passes; anything else fails with the pointer;
+- `test_declared_examples_are_real.py` picks up any new unauthenticated GET and
+  any new declared example automatically — nothing to edit.
+
+## Council
+
+<!-- filled in below -->

--- a/docs/issues/014-contract-integration-compat-tests/council-round-1.json
+++ b/docs/issues/014-contract-integration-compat-tests/council-round-1.json
@@ -1,0 +1,221 @@
+{
+  "round": 1,
+  "triggers": ["shared-contract", "adds-not-validated-claim"],
+  "lenses": ["sweep skeptic", "claim auditor", "second caller"],
+  "findings": [
+    {
+      "lens": "sweep skeptic",
+      "trigger": "add a new endpoint carrying a required query parameter with pattern/maxLength; add a new optional request field with maxLength+pattern; add a new optional response field with a pattern",
+      "wrong_outcome": "the gate fails all three, and README section \"What is not breaking\" lists all three by name. _additions keyed off pointer novelty and never asked whether the parent property/parameter/endpoint was also new",
+      "location": "scripts/check_contract_compatibility.py:345-368 (_additions); the self-test that missed it, tests/contract/test_contract_compatibility.py:400-407 add_an_endpoint",
+      "evidence": "reproduction /tmp/gh14/m6.py cases 12-14: REPORTED paths[/api/v1/widgets].get.parameters[projectId:query] a new *required* parameter; ...schema.maxLength; ...schema.pattern; ...responses[200]...required",
+      "closure": "scripts/check_contract_compatibility.py _new_addressables + the ancestor suppression in _additions; tests/contract/test_contract_compatibility.py::add_a_realistic_endpoint (path param + constrained query param + required body + response required). Verified 0 findings against the real feature/gh-11 and feature/gh-13 documents, down from 31 and 21"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "/ready answers 503 with an extra top-level field such as a server filesystem path",
+      "wrong_outcome": "skipped, not failed: schema.get('properties') is None for every {$ref} or {allOf} response, and the guard read that as 'not a described JSON object'. Every error shape in the contract is one of those two",
+      "location": "tests/contract/test_declared_examples_are_real.py:304-307",
+      "evidence": "reproduction /tmp/gh14/skipdemo.py: 'SKIPPED -> /ready 503 is not a described JSON object'; of 8 declared responses on the drivable operations only the 3 inline 200s ran",
+      "closure": "_declared_properties resolves $ref and unions allOf branches; test_the_undeclared_field_check_is_not_skipping_everything added as the third anti-vacuity guard"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "break components.schemas.Error.examples[0] to {\"code\":\"invented_code\",\"message\":123}",
+      "wrong_outcome": "green. _example_cases walked only paths.*.*.responses.*.content.*, reaching 5 of 24 declared example values, while README and testing.md both told the mobile team every example was checked",
+      "location": "tests/contract/test_declared_examples_are_real.py:120-142; claims at docs/api/README.md:92 and docs/api/testing.md:149-158",
+      "evidence": "reproduction /tmp/gh14/ex.py: 'EXAMPLE_CASES found by _example_cases(): 5' vs 'independent scan, every declared example VALUE: 24'; after breaking Error.examples[0]: 'broken value present? False'",
+      "closure": "_example_cases now walks the three shapes an example takes (media-type object, schema examples list, header/parameter example) across paths and components; 24 parametrized cases collected, 0 skipped"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "swap security: [{bearerAuth: []}] to [{oauth2: ['admin']}] on one operation, or add a scope to all 35 authenticated operations",
+      "wrong_outcome": "green in both. _operation reduced the whole security block to one boolean, operation.get('security') == []. Every existing bearer token stops working",
+      "location": "scripts/check_contract_compatibility.py:187-192",
+      "evidence": "reproduction /tmp/gh14/m1.py cases 2 and 2b: *** NO FINDINGS (gate green) ***, mutated ops: 35",
+      "closure": "a securityRequirements fact carrying the canonical requirement set; test swap_the_credential_an_operation_accepts"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "append {maxLength: 4} to components.schemas.ProjectId.allOf",
+      "wrong_outcome": "green. _changes reported only old - new for composition, so a set that only gains members never fired; every project identifier in the contract is silently truncated",
+      "location": "scripts/check_contract_compatibility.py:297-305 and :404-407",
+      "evidence": "reproduction /tmp/gh14/m4.py cases 7b and 7c: *** NO FINDINGS (gate green) ***. Control 7a (edit inside a branch) did report",
+      "closure": "additions to an allOf now report (allOf is an AND); oneOf/anyOf still widen. Test add_a_branch_to_an_all_of"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "components.parameters.Limit.schema.default: 50 -> 1, or delete it",
+      "wrong_outcome": "green in both. A client that omits limit silently gets a different page size; same invisible behavioural flip the README names for default sort order",
+      "location": "scripts/check_contract_compatibility.py:255-312, `default` never read",
+      "evidence": "reproduction /tmp/gh14/m1.py cases 5 and 5b: *** NO FINDINGS (gate green) ***; 5 default sites in the document",
+      "closure": "a default fact, reported on change and on removal; test change_a_default"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "rename the server variable host -> hostname, or delete servers entirely",
+      "wrong_outcome": "green in both, while README says 'renaming anything, in either direction' is breaking and every generated client embeds the server variable",
+      "location": "scripts/check_contract_compatibility.py:157-181, _document read only paths and components",
+      "evidence": "reproduction /tmp/gh14/m1.py cases 4 and 4b: *** NO FINDINGS (gate green) ***",
+      "closure": "_servers walks server urls and variables, keyed by url template so reordering is not a rename; test rename_a_server_variable"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "(a) add a required path-item-level parameter to /api/v1/projects; (b) hoist that path's five GET parameters up to the path item, a pure refactor",
+      "wrong_outcome": "(a) green on a new required parameter; (b) five phantom 'this parameter was removed or renamed' findings, after which those parameters are permanently outside the walker",
+      "location": "scripts/check_contract_compatibility.py:157-166",
+      "evidence": "reproduction /tmp/gh14/m1.py case 1 *** NO FINDINGS ***; case 1b reported 5 removals including parameters[#/components/parameters/Cursor]",
+      "closure": "path-item parameters are inherited into every operation under the path; tests add_a_required_parameter_to_a_path_item (breaking) and hoist_parameters_to_the_path_item (compatible)"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "hoist a request body into components.requestBodies and $ref it, then set maxLength: 8 on a field there",
+      "wrong_outcome": "the hoist reports 3 phantom removals and the tightening that follows is invisible; _document dispatched only schemas/parameters/responses/headers",
+      "location": "scripts/check_contract_compatibility.py:168-181",
+      "evidence": "reproduction /tmp/gh14/m4.py cases 9 and 9b printed identical output, with no mention of maxLength",
+      "closure": "components.requestBodies content is walked. Latent in this contract (no entry today), so covered by the walker rather than by a mutation of its own -- recorded as a residual in RESUME.md"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "components.schemas.Error gains dependentRequired: {code: [details]}; Error.properties.message gains readOnly: true",
+      "wrong_outcome": "green on both. Also never read: prefixItems, contains, uniqueItems, multipleOf, propertyNames, patternProperties, not, if/then/else, dependentSchemas, writeOnly, discriminator",
+      "location": "scripts/check_contract_compatibility.py:255-312",
+      "evidence": "reproduction /tmp/gh14/m4.py cases 10 and 10b: *** NO FINDINGS (gate green) ***",
+      "closure": "UNMODELLED_RESTRICTIONS tripwire: an unmodelled restriction keyword makes the gate fail saying it abstained rather than approving. Test use_a_restriction_keyword_the_gate_does_not_model"
+    },
+    {
+      "lens": "sweep skeptic",
+      "trigger": "read the two published limitation lists side by side",
+      "wrong_outcome": "the module docstring says 'Four classes' then lists five bullets, one of which is not a class that passes at all; testing.md repeats 'Four classes', lists four, and drops the securitySchemes bullet, so the mobile-facing document admits fewer gaps than the code does",
+      "location": "scripts/check_contract_compatibility.py:23-46; docs/api/testing.md:130-142",
+      "evidence": "bullet count 5 under a heading saying 4; grep -n 'Four classes|securitySchemes' docs/api/testing.md returns only line 133 with no securitySchemes bullet",
+      "closure": "both lists rewritten to the same shape and the same content: three silent classes, two imprecise-not-silent, one that fails loudly, plus the one still uncompared (securitySchemes contents)"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "a pull request removes a name from any response schema's required list, e.g. Actor.required loses id",
+      "wrong_outcome": "exit 0, 'No breaking change'. A generated client makes a required field non-nullable and reads it unconditionally. Worse, the COMPATIBLE fixture drop_a_required_request_field mutates Actor, which is response-only, so the matrix certified the break as compatible",
+      "location": "scripts/check_contract_compatibility.py:336-342 (_removals) and :400-403 (_changes); false certification at tests/contract/test_contract_compatibility.py:443-448 and :459",
+      "evidence": "'=== compat: response schema loses a required field (Actor.id) === No breaking change ... exit=0'; and 'FIRST schema with required: Actor -> [kind, id]', Actor appearing only at docs/api/codex-bridge.openapi.yaml:312 inside a 200 body",
+      "closure": "required removals are reported, with the direction named so a reviewer can say whether the schema is request-only; the bogus fixture is deleted and replaced by the breaking mutation stop_requiring_a_response_field"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "read section \"Getting the contract to the mobile repository\" to decide whether the document <-> mobile client pair is now guarded",
+      "wrong_outcome": "present indicative claim that the mobile repository fetches and verifies the digest, with the hand-copying in the past tense. Neither is true: CodexBridgeMobile has no contract/ directory, no manifest fetch, no digest verification",
+      "location": "docs/api/README.md:1224 and :1233; recipe at docs/api/testing.md:78-83",
+      "evidence": "grep -rIn 'contract/1\\.|x-minimum-supported-version' ~/Sync/Projects/AI/CodexBridgeMobile returns nothing; ls -d .../CodexBridgeMobile/contract absent; git ls-tree main -- contract | wc -l = 0",
+      "closure": "README now says the producing half is done and the consuming half is not, in as many words, and names what the mobile repository would have to do"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "edit the document, leave info.version at 1.6.0, run the command the failure message tells you to run",
+      "wrong_outcome": "contract/1.6.0/ -- a directory a client pinned by digest -- is silently rewritten together with its manifest, --check exits 0 and the suite is green, directly contradicting testing.md's unqualified immutability claim",
+      "location": "docs/api/testing.md:61-63; scripts/publish_contract.py:25-28 vs :139-148",
+      "evidence": "on a /tmp copy: BEFORE 1e229f26... / 'Published contract 1.6.0' / '--check ... exit=0' / AFTER 80071984...",
+      "closure": "testing.md carries the caveat in full, naming the mechanism, the remedy and the review rule. The hole itself is a written risk acceptance in RESUME.md: closing it needs a version bump that belongs to #11/#13"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "ask whether anything verifies that a contracted route survives the front door, and read the closing paragraph of testing.md",
+      "wrong_outcome": "told no, and pointed at deploy/incus/. test_proxy_routes.py asserts precisely that every contract path is routed by every terminating vhost; the live vhosts are in deploy/nginx/, and deploy/incus/ was retired 2026-08-10",
+      "location": "docs/api/testing.md:191-194; contradicted by tests/contract/test_proxy_routes.py:83-101 and deploy/incus/codexbridge_edge_proxy.py:1",
+      "evidence": "ls deploy/nginx -> three .conf files; head -1 deploy/incus/codexbridge_edge_proxy.py -> '\"\"\"RETIRED 2026-08-10 - the Incus edge proxy on the dom1 path.'",
+      "closure": "the paragraph now says the front door is checked statically from deploy/nginx/ and that no test sends a request to a real host; both denials pinned by test_the_contract_docs_do_not_deny_what_ships"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "follow testing.md to extract fixtures, or edit an example under components.schemas.<Name>.examples",
+      "wrong_outcome": "16 schema-level example values are never checked, including all four Error examples -- the envelope the delivery is built around -- and the stated extraction rule yields 5 fixtures out of 24",
+      "location": "tests/contract/test_declared_examples_are_real.py:111-142; claims at docs/api/testing.md:149-159",
+      "evidence": "'response media examples (covered): 5' vs 'schema-level examples lists (NOT covered): 8 -- Id(2) ProjectId(1) ExecutorId(1) Timestamp(1) Actor(2) Permission(3) PageInfo(2) Error(4)'",
+      "closure": "same fix as sweep skeptic finding 3; testing.md replaces the single-shape sentence with a table of the three shapes and says 24"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "use the 'what this cannot see' list as the exhaustive statement it presents itself as",
+      "wrong_outcome": "'Four classes' followed by five bullets in the script, and four in testing.md with securitySchemes dropped; commit a0063fd repeats the four. With the response-required finding the real number was at least six",
+      "location": "scripts/check_contract_compatibility.py:26 vs :29-46; docs/api/testing.md:132-143",
+      "evidence": "quoted heading 'Four classes of breaking change pass this gate, and three of them are in the README's own list:' followed by five bullets",
+      "closure": "same rewrite as sweep skeptic finding 11; the lists now also record which gaps round 1 closed rather than documented"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "read commit a0063fd as the record of what the mutation matrix proves",
+      "wrong_outcome": "it says 'Thirteen breaking mutations'; the BREAKING list held fourteen callables and fourteen cases ran",
+      "location": "commit a0063fd body; tests/contract/test_contract_compatibility.py:362-377",
+      "evidence": "pytest --collect-only | grep -c test_a_breaking_change_is_caught_and_named = 14 (the 'eight' compatible in the same sentence was correct)",
+      "closure": "not amendable without rewriting a published commit; recorded in RESUME.md as a known error in a0063fd's message, and the current counts are stated there instead"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "use testing.md's table as the enumeration it claims to be",
+      "wrong_outcome": "heading 'The four gates' above a five-row table, while tests/contract/ holds six files; README said five. The one missing from both is test_proxy_routes.py, which is the root of the denial finding above",
+      "location": "docs/api/testing.md:22-34; docs/api/README.md:1269",
+      "evidence": "ls tests/contract/*.py | wc -l = 6",
+      "closure": "heading and table name all six; test_the_testing_doc_counts_the_gates_that_exist derives the count from the directory so the next file added fails the doc"
+    },
+    {
+      "lens": "claim auditor",
+      "trigger": "match CI output against the sample in testing.md",
+      "wrong_outcome": "the sample shows paths[...] before components[...], which sorted() on the pointer cannot produce, and omits the '  - ' prefix the CLI writes",
+      "location": "docs/api/testing.md:119-124; scripts/check_contract_compatibility.py:463 and :536",
+      "evidence": "actual output with both documented mutations applied: header line then '  - components.schemas[Error]...' then '  - paths[/api/v1/auth/sign-in]...'",
+      "closure": "the sample is replaced with real output including the header line and the prefix, plus a sentence explaining the ordering"
+    },
+    {
+      "lens": "second caller",
+      "trigger": "issue #11 or #13 merges into development; both are purely additive releases",
+      "wrong_outcome": "the gate exits 1 with 31 breaking changes for #11 and 21 for #13, none touching anything a 1.6.0 client can address. Since OpenAPI requires in: path parameters to be required, every endpoint with a path parameter fires forever, and the remedy text on screen says 'needs a new namespace (/api/v2)' when the correct action is to ignore all 31",
+      "location": "scripts/check_contract_compatibility.py:345-368; the self-test at tests/contract/test_contract_compatibility.py:400-406",
+      "evidence": "real git merge of feature/gh-11 in a /tmp clone then pytest: 'E 31 breaking change(s)'; ancestry classification 'gh-11: 31 findings; 0 on a pointer whose ancestor exists in 1.6.0' and 'gh-13: 21 findings; 0'",
+      "closure": "same fix as sweep skeptic finding 1. Re-measured after the fix: 0 findings against both sibling documents"
+    },
+    {
+      "lens": "second caller",
+      "trigger": "a merger facing a red gate raises x-minimum-supported-version from 1.6.0 to the current info.version",
+      "wrong_outcome": "the gate then compares the document with a published copy of itself and can never fire again; the promise to every client pinned on the old version is dropped with no test, no warning and no reviewer prompt. test_the_minimum_supported_version_is_not_ahead_of_the_document asserts low <= high, so floor == current is explicitly permitted",
+      "location": "tests/contract/test_contract_compatibility.py:146; the floor at docs/api/codex-bridge.openapi.yaml:2313",
+      "evidence": "on the simulated gh-11 merge, raising the floor to 1.7.0 and republishing gave '91 passed' -- fully green",
+      "closure": "test_raising_the_floor_past_a_published_version_is_written_down: the floor must be the oldest published version unless x-minimum-supported-version-raised records why. Reproduced closed in /tmp/gh14sim3 -- raising the floor now fails with the reason demanded by name"
+    },
+    {
+      "lens": "second caller",
+      "trigger": "any contributor changes the document without moving info.version and follows the failure message",
+      "wrong_outcome": "publish() overwrites the pinned copy and its manifest together, so --check and test_every_published_version_hashes_to_its_manifest both agree again; testing.md, which docs/required-reading.md marks obrigatorio, asserts the opposite",
+      "location": "docs/api/testing.md:61-63; mechanism at scripts/publish_contract.py:149-161",
+      "evidence": "clean-slate run: 'pinned 1.6.0 sha BEFORE 1e229f26...' / 'Published contract 1.6.0' / 'AFTER 830c303d...' / '91 passed'",
+      "closure": "same as claim auditor finding 3 -- caveat written into testing.md and the hole recorded as an accepted risk"
+    },
+    {
+      "lens": "second caller",
+      "trigger": "the mobile team follows testing.md's consuming section today",
+      "wrong_outcome": "every curl 404s. origin/main contains no contract/ and no docs/api/ at all, and the doc asserts main 'moves' and carries the artifact",
+      "location": "docs/api/testing.md:73-83",
+      "evidence": "origin/main fad0cb2 2026-08-21; 'origin/main: docs/api ?' and 'origin/main: contract/ ?' both empty; development ahead of origin/main by 19",
+      "closure": "REF defaults to development, and the section opens by saying main carries neither directory and the recipe does not work until the API work reaches it"
+    },
+    {
+      "lens": "second caller",
+      "trigger": "any merge that moves info.version before contract/<new>/ exists, i.e. every release merge by construction",
+      "wrong_outcome": "three of seven failures are bare FileNotFoundError with no remedy, two of them tests of the publisher's own behaviour failing for an unrelated reason; and with the floor pointing at an unpublished version, 23 tests ERROR from an unguarded module fixture, burying the one actionable message",
+      "location": "tests/contract/test_published_contract_artifact.py:144, :169, :196; tests/contract/test_contract_compatibility.py:99-100",
+      "evidence": "'FileNotFoundError: .../contract/1.7.0/codex-bridge.openapi.yaml' in three tests; and '3 failed, 65 passed, 23 errors' with the floor unpublished",
+      "closure": "the baseline fixture and _isolated_tree fail with the publish command instead of opening a missing file, and the byte-identical test guards its read. Re-walked in /tmp/gh14sim2: 7 failures, every one carrying 'Run python3 scripts/publish_contract.py', 0 errors"
+    },
+    {
+      "lens": "second caller",
+      "trigger": "developer edits the OpenAPI document and runs only pytest tests/integration or tests/unit",
+      "wrong_outcome": "fully green; nothing hints that contract/ is stale or that the compatibility gate exists",
+      "location": "pyproject.toml:63 (testpaths = [\"tests\"]); no contract reference under tests/integration or tests/unit",
+      "evidence": "with an optional field added and no republish: 'tests/integration: 443 passed, 3 skipped' and 'tests/unit: 81 passed'",
+      "closure": "accepted, not fixed: .github/workflows/contract.yml runs pytest tests/contract on every push and pull request, and testpaths makes a bare pytest -q cover it. Recorded as a residual risk in RESUME.md rather than solved by coupling unrelated suites"
+    }
+  ],
+  "questions": [
+    "components.securitySchemes entry *contents* are still not compared -- its removal reports like any component, but a bearer-to-apiKey swap on the scheme itself does not. Every operation in this contract carries the same scheme, so there is no observable wrong result today; it is named in both honesty lists.",
+    "Republishing an edited document under the same info.version rewrites the copy and its manifest together, so every gate stays green while the bytes behind a pinned number change. Closing it means enforcing 'every change moves info.version' in the publisher, which would force a version bump belonging to the endpoint work in flight (#11, #13). Written into docs/api/README.md and accepted in RESUME.md.",
+    "A required-name removal on a request-only schema now reports, which is a deliberate false positive: the pointer cannot tell request from response and most schemas here are shared. The message names the direction so a reviewer can resolve it rather than the gate guessing.",
+    "The live compatibility comparison cannot fail on a version bump while the floor equals info.version (1.6.0 both today). It is not vacuous -- it still catches an in-place removal under 1.6.0 -- but its full value arrives when #11/#13 move info.version above the floor."
+  ]
+}

--- a/docs/issues/014-contract-integration-compat-tests/council-round-2.json
+++ b/docs/issues/014-contract-integration-compat-tests/council-round-2.json
@@ -1,0 +1,61 @@
+{
+  "round": 2,
+  "triggers": ["shared-contract", "adds-not-validated-claim"],
+  "lenses": ["verification of round 1", "regression hunt on the round-1 fixes"],
+  "findings": [
+    {
+      "lens": "regression hunt on the round-1 fixes",
+      "trigger": "add a required requestBody to GET /api/v1/auth/me, an operation that has none today",
+      "wrong_outcome": "exit 0, 'No breaking change'. Every existing caller sends no body and starts getting 4xx. 28 of the 40 operations in this contract carry no request body, so that is the surface. _additions had a branch for a required parameter and none for a required body, and round 1's ancestor suppression removed a signal that had previously existed by accident, because the new media type is ADDRESSABLE",
+      "location": "scripts/check_contract_compatibility.py _additions, the branch list around the parameter case; TIGHTENING_WHEN_ADDED omitted requestBody",
+      "evidence": "the same mutation through the pre-round-1 checker (git show bf6c7fe:scripts/check_contract_compatibility.py) reports '...requestBody.content[application/json].schema.required: [reason] became required where nothing was'; post-round-1 it returns []",
+      "closure": "an `elif kind == 'requestBody' and value` branch in _additions; test demand_a_request_body_where_there_was_none. Classification: introduzido-pela-r1"
+    },
+    {
+      "lens": "regression hunt on the round-1 fixes",
+      "trigger": "append {$ref: '#/components/parameters/IfMatch'} to GET /api/v1/projects; the component is required: true",
+      "wrong_outcome": "0 findings, while every existing caller of that operation now omits a required header. _parameter emitted required=False unconditionally for a $ref site, on the reasoning that required lives on the component -- true, but the component is unchanged, so nothing fires. 41 of the 90 operation parameters in the contract are $refs and all 40 operations are exposed",
+      "location": "scripts/check_contract_compatibility.py _parameter, the $ref branch",
+      "evidence": "a single document carrying both this and the requestBody mutation runs through the real CLI as 'No breaking change... exit=0'. Byte-identical code at bf6c7fe",
+      "closure": "_component_parameter_is_required resolves the component's required flag at the reference site; test point_an_operation_at_a_required_component_parameter. Classification: pre-existente"
+    },
+    {
+      "lens": "verification of round 1",
+      "trigger": "follow docs/api/testing.md section 'Consuming a pinned version' as rewritten by round 1, with REF=development",
+      "wrong_outcome": "every command still 404s. The round-1 fix replaced one wrong branch name (main) with another (development). testing.md asserted 'development is where the artifact lives today' and README said the same; both false",
+      "location": "docs/api/testing.md, the 'Not usable yet' paragraph and the REF assignment; docs/api/README.md section 'Getting the contract to the mobile repository'",
+      "evidence": "after git fetch origin: git ls-tree -r --name-only origin/development | grep -c '^contract/' -> 0; contract/ exists only on the unmerged feature/gh-14 branch; origin/development is at 2e18820, an ancestor of HEAD",
+      "closure": "both documents now say no branch carries contract/ yet and that it becomes fetchable when this work merges. Classification: introduzido-pela-r1 for the new false claim, aberto-da-r1 for the recipe not resolving"
+    },
+    {
+      "lens": "verification of round 1",
+      "trigger": "read docs/issues/014-contract-integration-compat-tests/RESUME.md, added by the round-1 fix commit itself",
+      "wrong_outcome": "four false statements in the delivery's own handoff: stale test counts (615/91 vs actual 650/126), the deploy/incus citation that claim-auditor finding 4 had just retired, 'four blind spots' contradicting the corrected lists, and an empty Council section. The denial gate added in the same commit iterated only README.md and testing.md, so a handoff note -- the first thing the next agent reads -- sat outside it",
+      "location": "docs/issues/014-contract-integration-compat-tests/RESUME.md; coverage gap in tests/contract/test_docs_match_the_runtime.py, the denial loop's document list",
+      "evidence": "grep -rn RESUME tests/ returns only unrelated TASK_RESUME hits, so no test read the file; counts measured in the same session as 650 passed / 3 skipped and 126 in tests/contract",
+      "closure": "RESUME.md rewritten with measured counts and the full two-round record; _contract_prose_documents now includes every docs/issues/**/RESUME.md, so the same denials are policed there. Classification: introduzido-pela-r1"
+    },
+    {
+      "lens": "verification of round 1",
+      "trigger": "a reviewer meets \"['x'] stopped being required\" and consults docs/api/README.md section 'What is a breaking change', as both the script and the README tell them to",
+      "wrong_outcome": "the rule is not there. The README listed six breaking rules and none covered a required name leaving a response schema, a schema default changing (the README says default *sort order*, a different thing), or which credential an operation accepts. 'Relaxing a constraint' in the not-breaking list reads as licence to dismiss the first. x-minimum-supported-version-raised, a key the build now requires, appeared nowhere. The script's docstring claims 'The rules are not invented here'",
+      "location": "scripts/check_contract_compatibility.py module docstring rule table vs docs/api/README.md sections 'Versioning' and 'What is a breaking change'",
+      "evidence": "greps against README: 'stops being required' 0 hits, 'x-minimum-supported-version-raised' 0 hits, 'changing a default' 0 hits, while all three rules were verified live in round 2's per-finding table",
+      "closure": "five rules added to the normative README list, marked as introduced by issue #14 alongside the gate, plus the raised-floor key in the Versioning section. Classification: introduzido-pela-r1"
+    },
+    {
+      "lens": "verification of round 1",
+      "trigger": "follow the test-id pointer in the ancestor-suppression comment",
+      "wrong_outcome": "test_a_compatible_change_is_left_alone[add_an_endpoint_with_a_required_constrained_parameter] does not exist; the fixture that keeps that branch honest is add_a_realistic_endpoint. Same genre of defect round 1 spent nine findings on",
+      "location": "scripts/check_contract_compatibility.py, the _additions ancestor-suppression comment",
+      "evidence": "grep -rn add_an_endpoint_with_a_required_constrained_parameter . returns one hit, the comment itself",
+      "closure": "comment corrected to name add_a_realistic_endpoint and what it carries. Classification: introduzido-pela-r1"
+    }
+  ],
+  "questions": [
+    "Verified closed by reproduction: 23 of the 26 round-1 findings. The decisive measurement was re-run -- the compatibility gate reports 0 breaking changes against the real feature/gh-11 and feature/gh-13 documents, down from 31 and 21, and a fact-level audit confirms it is right for the right reason (gh-11 +300 facts / 0 removed / 0 changed; gh-13 +217 / 0 / 0, with zero new addressables inside a pre-existing endpoint).",
+    "Round 2 also caught a cry-wolf trap before it fired: the unmodelled-keyword tripwire yielded unconditionally, so the first readOnly: true anywhere in the contract would have made the build permanently red with no way to make it green. It now reports only on a change. No such keyword is in the contract today.",
+    "Still open and accepted as risks in RESUME.md, carried from round 1: securitySchemes entry contents are not compared; republishing under the same info.version rewrites a pin; the request-side required-removal false positive; and the floor equalling info.version today.",
+    "Residual, not re-raised: the duplicated setup-error volume when info.version moves before publishing went 23 -> 32, because the guard is per-parametrized-case and the matrix grew. No bare exception survives -- every failure names the publish command."
+  ]
+}

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1022,3 +1022,42 @@ It expects `state_version`, `values`, and `refs`; a hand-written flat JSON with
 shared-contract kit refreshes, stage the real delivery first and record the
 council round against that staged diff, because the fingerprint binding is what
 actually clears the gate.
+
+## 2026-08-26 — #14: a contract gate's false positives decide whether it survives
+
+The compatibility gate for issue #14 shipped its first cut reporting **31**
+breaking changes against `feature/gh-11` and **21** against `feature/gh-13`,
+both purely additive releases, with not one finding naming a pointer a 1.6.0
+client could address. The cause is worth remembering because it is not obvious:
+a constraint is only a *tightening* when the thing it constrains already
+existed. OpenAPI forces `required: true` on every path parameter, so "a new
+required parameter appeared" fired on every endpoint with a path parameter,
+forever.
+
+The self-test that should have caught it added an endpoint with no parameters,
+no request body and no response schema — the one shape that dodges the defect.
+**A compatible-side fixture is only worth what its realism is worth.** The
+replacement carries a required path parameter, a constrained optional query
+parameter, a required request body and a response `required`, all at once.
+
+Two more of the same family, from the same delivery:
+
+- a fixture named `drop_a_required_request_field` actually mutated `Actor`,
+  which is response-only, so the matrix *certified* a real break as compatible.
+  A fixture's name is not evidence of what it does;
+- the fix for the false positives introduced a new blind spot — an existing
+  operation gaining a **required request body** went silent, because the
+  suppression's ancestor rule swallowed the new media type. A signal that had
+  existed by accident was removed by a deliberate change. Round 2 found it by
+  running the *old* checker against the same mutation.
+
+And a trap caught before it fired: a tripwire that reports "this gate does not
+model keyword X" must report on a **change**, not on presence. Reporting on
+presence would have made the first `readOnly: true` a permanently red build with
+no edit that could turn it green — and a gate you cannot satisfy gets deleted,
+not obeyed.
+
+Finally: the delivery's own `RESUME.md`, written by the commit that retired four
+false sentences from `docs/api/`, reinstated one of them and carried stale test
+counts. The prose gate scanned `README.md` and `testing.md` and not the handoff
+note the next agent reads first. It scans `docs/issues/**/RESUME.md` now.

--- a/docs/required-reading.md
+++ b/docs/required-reading.md
@@ -57,6 +57,11 @@ Leitura escopada: só quem for mexer na área precisa.
 - `docs/api/codex-bridge.openapi.yaml` — o contrato canônico da API móvel. Mudar
   endpoint significa mudar este arquivo **primeiro**; `tests/contract/` reprova a
   divergência.
+- `docs/api/testing.md` — **obrigatório** ao mexer no contrato: qual gate guarda
+  qual par, como publicar uma versão (`scripts/publish_contract.py`), como o repo
+  móvel fixa uma versão pelo digest, e o que o gate de breaking change
+  (`scripts/check_contract_compatibility.py`) **não** consegue ver. Mudou o YAML
+  e não republicou? A suíte reprova, e a mensagem diz o arquivo.
 - `migrations/` + `scripts/apply_migrations.py` — **obrigatório** ao alterar
   `gateway/app/models/entities.py`. Uma mudança de schema não está pronta quando o
   modelo muda: o `create_all` do startup só cria tabela nova, nunca adiciona coluna

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+  # tests/contract/test_declared_examples_are_real.py validates live response
+  # bodies against the schemas in the contract. It arrives transitively with
+  # openapi-spec-validator, and is declared anyway: a direct import resting on
+  # someone else's dependency breaks the day that dependency drops it, in a
+  # gate whose whole job is to not be silently absent.
+  "jsonschema>=4.20.0",
   "openapi-spec-validator>=0.9.0",
   "pytest>=9.0.0",
   "pytest-asyncio>=1.1.0",

--- a/scripts/check_contract_compatibility.py
+++ b/scripts/check_contract_compatibility.py
@@ -194,6 +194,9 @@ class _Facts:
 
     def __init__(self, document: dict) -> None:
         self.facts: dict[str, tuple[str, Any]] = {}
+        #: Kept so a `$ref` can be resolved where the *reference site* is what
+        #: changed. See `_parameter`.
+        self.root = document
         self._document(document)
 
     def _emit(self, pointer: str, kind: str, value: Any = None) -> None:
@@ -302,10 +305,19 @@ class _Facts:
         if keyed:
             reference = parameter.get("$ref")
             if isinstance(reference, str):
-                # A `$ref` parameter carries neither name nor `in` here; the
-                # reference string is its identity, and its `required` lives on
-                # the component, which is walked separately.
-                self._emit(f"{parent}.parameters[{reference}]", "parameter", False)
+                # A `$ref` parameter carries neither name nor `in` here, so the
+                # reference string is its identity. Its `required` is resolved
+                # from the component rather than assumed `False`: council round
+                # 2 showed that pointing an existing operation at an
+                # already-required component parameter — `IfMatch`, say —
+                # passed in silence, because the component itself had not
+                # changed and the reference site claimed nothing was required.
+                # 41 of the 90 operation parameters in this contract are `$ref`s.
+                self._emit(
+                    f"{parent}.parameters[{reference}]",
+                    "parameter",
+                    self._component_parameter_is_required(reference),
+                )
                 return
             name = parameter.get("name")
             location = parameter.get("in")
@@ -317,6 +329,16 @@ class _Facts:
             pointer = parent
         self._emit(pointer, "parameter", bool(parameter.get("required")))
         self._schema(parameter.get("schema"), f"{pointer}.schema")
+
+    def _component_parameter_is_required(self, reference: str) -> bool:
+        """`required` of the component a parameter `$ref` points at."""
+        prefix = "#/components/parameters/"
+        if not reference.startswith(prefix):
+            return False
+        component = (self.root.get("components") or {}).get("parameters", {}).get(
+            reference[len(prefix):]
+        )
+        return bool(isinstance(component, dict) and component.get("required"))
 
     def _header(self, header: Any, pointer: str) -> None:
         if not isinstance(header, dict):
@@ -501,10 +523,23 @@ def _additions(before: dict, after: dict) -> Iterator[Finding]:
             # Born inside something that is itself new: nothing existed to
             # tighten. Applies to a new *required parameter* too — required on
             # an endpoint no client has ever called constrains nobody.
-            # `test_a_compatible_change_is_left_alone[add_an_endpoint_with_a_required_constrained_parameter]`
-            # is what keeps this branch honest.
+            # `test_a_compatible_change_is_left_alone[add_a_realistic_endpoint]`
+            # is what keeps this branch honest: it carries a required path
+            # parameter, a constrained query parameter, a required request body
+            # and a response `required`, all at once.
             continue
-        if kind == "unmodelled":
+        if kind == "requestBody" and value:
+            # An existing operation that starts demanding a body. Council round
+            # 2: 28 of the 40 operations here carry none today, and every
+            # existing caller of one that gains a required body starts getting
+            # 4xx. The `required` *inside* its schema is suppressed above —
+            # the media type is new — so without this branch the whole change
+            # was silent.
+            yield pointer, (
+                "this operation now requires a request body where it accepted "
+                "none. Existing callers send nothing and start failing."
+            )
+        elif kind == "unmodelled":
             yield pointer, (
                 f"this schema uses restriction keyword(s) this gate does not "
                 f"model, so it abstained rather than approving: {value}. Review "
@@ -602,12 +637,19 @@ def _changes(before: dict, after: dict) -> Iterator[Finding]:
                     "omits this field silently gets different behaviour."
                 )
         elif kind == "unmodelled":
-            yield pointer, (
-                f"this schema uses restriction keyword(s) this gate does not "
-                f"model, so it abstained rather than approving: {new}. Review "
-                "the change against docs/api/README.md §\"What is a breaking "
-                "change\" by hand."
-            )
+            # Only on a *change*. Yielding unconditionally would make the first
+            # `readOnly: true` anywhere in the contract a permanent red build,
+            # since the keyword would still be there tomorrow — and a gate that
+            # cannot be made green by fixing the thing it complains about is a
+            # gate that gets deleted. Council round 2 flagged this before it
+            # could happen: no such keyword is in the contract today.
+            if old != new:
+                yield pointer, (
+                    f"this schema's unmodelled restriction keyword(s) changed, "
+                    f"and this gate does not compare them, so it abstained "
+                    f"rather than approving: {new}. Review by hand against "
+                    "docs/api/README.md §\"What is a breaking change\"."
+                )
         elif kind == "ceiling":
             if _lt(new, old):
                 yield pointer, f"ceiling lowered from {old!r} to {new!r}."

--- a/scripts/check_contract_compatibility.py
+++ b/scripts/check_contract_compatibility.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""Refuse a contract change that breaks the minimum API version mobile still supports.
+
+    python3 scripts/check_contract_compatibility.py     # exit 1 and name every break
+
+`scripts/publish_contract.py` makes a version *pinnable*. This makes the pin
+*worth something*: it compares the working document against the published copy
+of the version named by `x-minimum-supported-version`, and fails when the
+difference is one an existing, conforming client cannot survive.
+
+The rules are not invented here. They are `docs/api/README.md` §"What is a
+breaking change" and §"What is not breaking", transcribed into a comparison:
+
+    removing an endpoint, a field, an enum value, a response status      breaking
+    renaming anything                                                    breaking
+    narrowing a type, tightening a constraint, a new required field      breaking
+    an endpoint that stops being unauthenticated                         breaking
+    adding an endpoint / an optional field / a response field            fine
+    relaxing a constraint, widening a type                               fine
+    adding a value to `ErrorCode`                                        fine (see below)
+    editing `description` / `summary` text                               fine
+
+## What this cannot see, stated plainly
+
+Read a green run as *"no mechanically visible break"*, never as *"compatible"*.
+Four classes of breaking change pass this gate, and three of them are in the
+README's own list:
+
+- **A meaning change that keeps the name and the type.** `status` growing a new
+  interpretation, `limit` counting something else, a field that used to be
+  UTC becoming local. No schema diff catches this — the README says so where it
+  lists the rule ("the most dangerous kind"). Nothing here changes that.
+- **Default sort order, and the identity or lifetime of a pagination cursor.**
+  Neither is expressible in the schema.
+- **A rename is reported as a removal**, because that is what a rename looks
+  like from the outside: the verdict is right, the wording is imprecise.
+- **Inside `allOf` / `anyOf` / `oneOf`**, members are compared as a set and not
+  recursed into, so a constraint tightened *within* a composition branch is
+  invisible. Compared positionally instead, reordering two equivalent branches
+  would report two breaks — and a gate that cries wolf is a gate that gets
+  deleted rather than obeyed. Five such keywords exist in the document today.
+- **Inside a `securitySchemes` entry.** Its *removal* reports, like any
+  component; changing an existing one (bearer to apiKey, a different header
+  name) does not. Every operation in this contract carries the same scheme, so
+  the case has never arisen — teach `_Facts._document` about the group before it
+  does.
+
+## Two conservative calls, on purpose
+
+- A **type change is breaking unless the candidate is a strict superset** of the
+  baseline's type set (`string` → `[string, "null"]` is widening). Anything else
+  — including an exotic widening this rule does not model — reports.
+- **`ErrorCode` is the one enum that may grow.** That is not a courtesy to a
+  familiar name: the contract itself requires clients to degrade an unknown
+  `code` to its HTTP status class, which is what makes the addition safe, and
+  the README names it as the single exception. `test_the_error_code_exemption_still_has_a_schema`
+  fails if that schema is renamed or removed, so the exemption cannot outlive
+  the reason for it — the same rule `test_no_exclusion_outlives_its_route`
+  applies to `x-contract-excluded-paths`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterator
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DOCUMENT = REPO_ROOT / "docs" / "api" / "codex-bridge.openapi.yaml"
+DEFAULT_PUBLISHED = REPO_ROOT / "contract"
+DOCUMENT_NAME = "codex-bridge.openapi.yaml"
+
+#: Root extension naming the oldest published contract version this build still
+#: promises to serve. It lives in the document rather than in this file so it
+#: travels with the published artifact: a consumer that fetched
+#: `contract/<v>/codex-bridge.openapi.yaml` can read the floor without cloning
+#: this repository. Same reason `x-contract-excluded-paths` lives there.
+MINIMUM_VERSION_KEY = "x-minimum-supported-version"
+
+OPERATIONS = frozenset(
+    {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+)
+
+#: The one enum a minor release may grow. See the module docstring.
+ERROR_CODE_ENUM_POINTER = "components.schemas[ErrorCode].enum"
+
+#: Constraints whose *lower* value is the stricter one: shrinking a ceiling
+#: rejects input and truncates output a conforming client relies on.
+CEILINGS = ("maxLength", "maxItems", "maxProperties", "maximum", "exclusiveMaximum")
+
+#: Constraints whose *higher* value is the stricter one.
+FLOORS = ("minLength", "minItems", "minProperties", "minimum", "exclusiveMinimum")
+
+#: Fact kinds that describe something a client can address by name. Their
+#: disappearance is the removal the README's first rule is about. Every other
+#: kind describes a *restriction*, and a restriction that disappears is a
+#: relaxation — which is explicitly not breaking.
+ADDRESSABLE = frozenset(
+    {"endpoint", "operation", "response", "component", "property", "parameter",
+     "header", "media"}
+)
+
+#: Fact kinds that are a restriction, so *appearing* where the baseline had
+#: none is a tightening.
+TIGHTENING_WHEN_ADDED = frozenset(
+    {"required", "pattern", "format", "const", "ceiling", "floor",
+     "closedProperties"}
+)
+
+
+# --------------------------------------------------------------------------
+# Reading the document down to comparable facts
+# --------------------------------------------------------------------------
+
+
+def _canonical(node: Any) -> str:
+    """A stable string for an arbitrary sub-document.
+
+    Used only where members are compared as an unordered set (composition
+    keywords, enum values): two structurally identical members must produce one
+    string, or set arithmetic would report a phantom removal.
+    """
+    return json.dumps(node, sort_keys=True, default=str)
+
+
+def _type_set(value: Any) -> frozenset[str]:
+    """`type` normalised to a set, because OpenAPI 3.1 allows a list."""
+    if isinstance(value, list):
+        return frozenset(str(item) for item in value)
+    return frozenset({str(value)})
+
+
+class _Facts:
+    """Everything about a document that a client could break against.
+
+    A flat `pointer -> (kind, value)` mapping rather than a tree, so the
+    comparison is set arithmetic and every finding already carries the pointer
+    that names it. `$ref` is recorded, never followed: the target is walked
+    once at its own `components.…` pointer, so following it here would report a
+    single component change once per reference site.
+    """
+
+    def __init__(self, document: dict) -> None:
+        self.facts: dict[str, tuple[str, Any]] = {}
+        self._document(document)
+
+    def _emit(self, pointer: str, kind: str, value: Any = None) -> None:
+        self.facts[pointer] = (kind, value)
+
+    # -- document ----------------------------------------------------------
+
+    def _document(self, document: dict) -> None:
+        for path, item in (document.get("paths") or {}).items():
+            if not isinstance(item, dict):
+                continue
+            pointer = f"paths[{path}]"
+            self._emit(pointer, "endpoint")
+            for key, operation in item.items():
+                if key.lower() not in OPERATIONS or not isinstance(operation, dict):
+                    continue
+                self._operation(operation, f"{pointer}.{key.lower()}")
+
+        for group, entries in (document.get("components") or {}).items():
+            if not isinstance(entries, dict):
+                continue
+            for name, entry in entries.items():
+                pointer = f"components.{group}[{name}]"
+                self._emit(pointer, "component")
+                if group == "schemas":
+                    self._schema(entry, pointer)
+                elif group == "parameters":
+                    self._parameter(entry, pointer, keyed=False)
+                elif group == "responses":
+                    self._response(entry, pointer)
+                elif group == "headers":
+                    self._header(entry, pointer)
+
+    def _operation(self, operation: dict, pointer: str) -> None:
+        self._emit(pointer, "operation")
+        # An endpoint that stops being reachable without a credential breaks
+        # every client that reached it — the probes are the whole reason a
+        # client can decide anything before signing in.
+        self._emit(
+            f"{pointer}.security",
+            "unauthenticated",
+            operation.get("security") == [],
+        )
+        for parameter in operation.get("parameters") or []:
+            self._parameter(parameter, pointer)
+        body = operation.get("requestBody")
+        if isinstance(body, dict):
+            self._emit(f"{pointer}.requestBody", "requestBody", bool(body.get("required")))
+            self._content(body.get("content"), f"{pointer}.requestBody")
+        for status, response in (operation.get("responses") or {}).items():
+            self._response(response, f"{pointer}.responses[{status}]", kind="response")
+
+    def _parameter(self, parameter: Any, parent: str, keyed: bool = True) -> None:
+        if not isinstance(parameter, dict):
+            return
+        if keyed:
+            reference = parameter.get("$ref")
+            if isinstance(reference, str):
+                # A `$ref` parameter carries neither name nor `in` here; the
+                # reference string is its identity, and its `required` lives on
+                # the component, which is walked separately.
+                self._emit(f"{parent}.parameters[{reference}]", "parameter", False)
+                return
+            name = parameter.get("name")
+            location = parameter.get("in")
+            pointer = f"{parent}.parameters[{name}:{location}]"
+        else:
+            # A component parameter: `parent` already names it, and this
+            # deliberately overwrites the bare `component` fact so its
+            # `required` flag is compared too.
+            pointer = parent
+        self._emit(pointer, "parameter", bool(parameter.get("required")))
+        self._schema(parameter.get("schema"), f"{pointer}.schema")
+
+    def _header(self, header: Any, pointer: str) -> None:
+        if not isinstance(header, dict):
+            return
+        if isinstance(header.get("$ref"), str):
+            self._emit(f"{pointer}.$ref", "ref", header["$ref"])
+            return
+        self._schema(header.get("schema"), f"{pointer}.schema")
+
+    def _response(self, response: Any, pointer: str, kind: str = "component") -> None:
+        if not isinstance(response, dict):
+            return
+        if kind == "response":
+            self._emit(pointer, "response")
+        if isinstance(response.get("$ref"), str):
+            self._emit(f"{pointer}.$ref", "ref", response["$ref"])
+            return
+        for name, header in (response.get("headers") or {}).items():
+            header_pointer = f"{pointer}.headers[{name}]"
+            self._emit(header_pointer, "header")
+            self._header(header, header_pointer)
+        self._content(response.get("content"), pointer)
+
+    def _content(self, content: Any, pointer: str) -> None:
+        if not isinstance(content, dict):
+            return
+        for media_type, media in content.items():
+            media_pointer = f"{pointer}.content[{media_type}]"
+            self._emit(media_pointer, "media")
+            if isinstance(media, dict):
+                self._schema(media.get("schema"), f"{media_pointer}.schema")
+
+    def _schema(self, schema: Any, pointer: str) -> None:
+        if not isinstance(schema, dict):
+            return
+
+        reference = schema.get("$ref")
+        if isinstance(reference, str):
+            self._emit(f"{pointer}.$ref", "ref", reference)
+            return
+
+        if "type" in schema:
+            self._emit(f"{pointer}.type", "type", _type_set(schema["type"]))
+        if "format" in schema:
+            self._emit(f"{pointer}.format", "format", schema["format"])
+        if "pattern" in schema:
+            self._emit(f"{pointer}.pattern", "pattern", schema["pattern"])
+        if "const" in schema:
+            self._emit(f"{pointer}.const", "const", _canonical(schema["const"]))
+        if isinstance(schema.get("enum"), list):
+            self._emit(
+                f"{pointer}.enum",
+                "enum",
+                frozenset(_canonical(value) for value in schema["enum"]),
+            )
+        if isinstance(schema.get("required"), list):
+            self._emit(
+                f"{pointer}.required",
+                "required",
+                frozenset(str(name) for name in schema["required"]),
+            )
+        for name in CEILINGS:
+            if name in schema:
+                self._emit(f"{pointer}.{name}", "ceiling", schema[name])
+        for name in FLOORS:
+            if name in schema:
+                self._emit(f"{pointer}.{name}", "floor", schema[name])
+
+        extra = schema.get("additionalProperties")
+        if extra is False:
+            self._emit(f"{pointer}.additionalProperties", "closedProperties", True)
+        elif isinstance(extra, dict):
+            self._schema(extra, f"{pointer}.additionalProperties")
+
+        for keyword in ("allOf", "anyOf", "oneOf"):
+            members = schema.get(keyword)
+            if isinstance(members, list):
+                # Set, not sequence: see the module docstring.
+                self._emit(
+                    f"{pointer}.{keyword}",
+                    "composition",
+                    frozenset(_canonical(member) for member in members),
+                )
+
+        for name, sub in (schema.get("properties") or {}).items():
+            sub_pointer = f"{pointer}.properties[{name}]"
+            self._emit(sub_pointer, "property")
+            self._schema(sub, sub_pointer)
+
+        self._schema(schema.get("items"), f"{pointer}.items")
+
+
+def facts(document: dict) -> dict[str, tuple[str, Any]]:
+    """Comparable facts for one OpenAPI document."""
+    return _Facts(document).facts
+
+
+# --------------------------------------------------------------------------
+# Comparing two of them
+# --------------------------------------------------------------------------
+
+
+Finding = tuple[str, str]  # (pointer, what went wrong)
+
+
+def _removals(before: dict, after: dict) -> Iterator[Finding]:
+    """Facts the baseline had and the candidate does not.
+
+    Only `ADDRESSABLE` kinds count. Every other kind is a *restriction*, and a
+    restriction that disappears is a relaxation — a vanished `pattern`,
+    `maxLength` or `enum` widens what the API accepts and returns, which
+    §"What is not breaking" lists explicitly.
+    """
+    for pointer in sorted(set(before) - set(after)):
+        kind, _ = before[pointer]
+        if kind in ADDRESSABLE:
+            yield pointer, (
+                f"this {kind} was removed or renamed. A client that addresses "
+                "it by name stops working."
+            )
+
+
+def _additions(before: dict, after: dict) -> Iterator[Finding]:
+    """Facts the candidate gained. Only a *restriction* that appears is breaking."""
+    for pointer in sorted(set(after) - set(before)):
+        kind, value = after[pointer]
+        if kind == "parameter" and value:
+            yield pointer, "a new *required* parameter. Existing callers do not send it."
+        elif kind == "required":
+            yield pointer, (
+                f"{sorted(value)} became required where nothing was. A request "
+                "that omits them is now rejected."
+            )
+        elif kind == "enum":
+            # `type: string` -> `enum: [a, b]` closes an open field. The
+            # symmetric case (an `enum` disappearing) is a widening and is
+            # deliberately not reported; see `_removals`.
+            yield pointer, (
+                f"an enum where the value was previously unconstrained; only "
+                f"{sorted(value)} are accepted now."
+            )
+        elif kind in TIGHTENING_WHEN_ADDED:
+            yield pointer, (
+                f"a constraint that did not exist before ({kind}={value!r}). "
+                "Input a client sends today may now be rejected."
+            )
+
+
+def _changes(before: dict, after: dict) -> Iterator[Finding]:
+    """Facts present in both, compared in the direction that hurts a client."""
+    for pointer in sorted(set(before) & set(after)):
+        kind, old = before[pointer]
+        new_kind, new = after[pointer]
+        if kind != new_kind:
+            yield pointer, f"changed from {kind} to {new_kind}."
+            continue
+
+        if kind == "type":
+            # A strict superset is a widening (`string` -> `[string, "null"]`).
+            # Everything else reports, including a widening this rule does not
+            # model: over-reporting a rare relaxation beats missing a narrowing.
+            if old != new and not old < new:
+                yield pointer, f"type narrowed from {sorted(old)} to {sorted(new)}."
+        elif kind == "enum":
+            gone = sorted(old - new)
+            if gone:
+                yield pointer, (
+                    f"enum value(s) {gone} removed. A client that receives or "
+                    "sends them stops working."
+                )
+            arrived = sorted(new - old)
+            if arrived and not pointer.endswith(ERROR_CODE_ENUM_POINTER):
+                yield pointer, (
+                    f"enum value(s) {arrived} added. Only `ErrorCode` may grow, "
+                    "because the contract requires clients to degrade an unknown "
+                    "code to its HTTP status class."
+                )
+        elif kind == "required":
+            arrived = sorted(new - old)
+            if arrived:
+                yield pointer, f"{arrived} became required."
+        elif kind == "composition":
+            gone = sorted(old - new)
+            if gone:
+                yield pointer, f"{len(gone)} branch(es) removed from the composition."
+        elif kind == "ceiling":
+            if _lt(new, old):
+                yield pointer, f"ceiling lowered from {old!r} to {new!r}."
+        elif kind == "floor":
+            if _lt(old, new):
+                yield pointer, f"floor raised from {old!r} to {new!r}."
+        elif kind in ("pattern", "const", "format", "ref"):
+            if old != new:
+                yield pointer, f"{kind} changed from {old!r} to {new!r}."
+        elif kind == "unauthenticated":
+            if old and not new:
+                yield pointer, (
+                    "this operation no longer declares `security: []`. A client "
+                    "that reached it without a credential now cannot."
+                )
+        elif kind == "requestBody":
+            if new and not old:
+                yield pointer, "the request body became required."
+        elif kind == "parameter":
+            if new and not old:
+                yield pointer, "an optional parameter became required."
+
+
+def _lt(left: Any, right: Any) -> bool:
+    """`left < right` for constraint values, `False` when they are not comparable.
+
+    A constraint written as a string in one document and a number in the other
+    is a document bug, not a compatibility verdict; refusing to compare beats
+    raising `TypeError` out of a gate.
+    """
+    try:
+        return bool(left < right)
+    except TypeError:
+        return False
+
+
+def incompatibilities(baseline: dict, candidate: dict) -> list[str]:
+    """Every breaking change in `candidate` relative to `baseline`.
+
+    Pure: two parsed documents in, findings out. The CLI below is a thin shell
+    around it so a test can enumerate mutations without paying for a subprocess
+    each time, and so a caller can reuse the classifier.
+
+    Ordered **by pointer**, not by the rendered sentence. Removing one endpoint
+    reports the endpoint and everything under it; sorting the sentences put
+    `paths[/health].get.…properties[status]` above `paths[/health]`, because
+    `.` sorts below `:`. The first line of a CI failure is the one that gets
+    read, and it has to be the endpoint, not a leaf of it.
+    """
+    before = facts(baseline)
+    after = facts(candidate)
+    findings: list[Finding] = []
+    findings += _removals(before, after)
+    findings += _additions(before, after)
+    findings += _changes(before, after)
+    return [f"{pointer}: {text}" for pointer, text in sorted(findings)]
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _load(path: Path) -> dict:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise SystemExit(f"{path} is not a YAML mapping")
+    return document
+
+
+def minimum_supported_version(document: dict) -> str | None:
+    value = document.get(MINIMUM_VERSION_KEY)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def baseline_path(document: dict, published: Path) -> Path:
+    version = minimum_supported_version(document)
+    if version is None:
+        raise SystemExit(
+            f"the document declares no `{MINIMUM_VERSION_KEY}`, so there is no "
+            "floor to check compatibility against. Add it, naming a version "
+            "published under contract/."
+        )
+    return published / version / DOCUMENT_NAME
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--document", type=Path, default=DEFAULT_DOCUMENT)
+    parser.add_argument(
+        "--published",
+        type=Path,
+        default=DEFAULT_PUBLISHED,
+        help="Directory holding the published versions. Defaults to contract/.",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Compare against this document instead of the published minimum.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.document.is_file():
+        print(f"No such contract document: {args.document}", file=sys.stderr)
+        return 1
+    candidate = _load(args.document)
+
+    baseline_file = args.baseline or baseline_path(candidate, args.published)
+    if not baseline_file.is_file():
+        print(
+            f"the minimum supported version names {baseline_file}, which does not "
+            "exist. Publish it (`python3 scripts/publish_contract.py`) or point "
+            f"`{MINIMUM_VERSION_KEY}` at a version that is published.",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings = incompatibilities(_load(baseline_file), candidate)
+    if findings:
+        print(
+            f"{len(findings)} breaking change(s) against the minimum supported "
+            f"contract version ({baseline_file}):",
+            file=sys.stderr,
+        )
+        for finding in findings:
+            print(f"  - {finding}", file=sys.stderr)
+        print(
+            "\nA breaking change needs a new namespace (/api/v2) or a migration "
+            "the operator accepted — see docs/api/README.md §\"What is a "
+            "breaking change\". If the change is not breaking and this gate is "
+            "wrong, say so in the pull request rather than editing the baseline: "
+            "a published version is what a client pinned.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"No breaking change against {baseline_file}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_contract_compatibility.py
+++ b/scripts/check_contract_compatibility.py
@@ -14,36 +14,63 @@ breaking change" and §"What is not breaking", transcribed into a comparison:
     removing an endpoint, a field, an enum value, a response status      breaking
     renaming anything                                                    breaking
     narrowing a type, tightening a constraint, a new required field      breaking
+    a required field that stops being required (on a response)           breaking
+    changing a `default`, or which credential an operation accepts       breaking
     an endpoint that stops being unauthenticated                         breaking
     adding an endpoint / an optional field / a response field            fine
     relaxing a constraint, widening a type                               fine
     adding a value to `ErrorCode`                                        fine (see below)
     editing `description` / `summary` text                               fine
 
+A constraint counts as a *tightening* only when the thing it constrains already
+existed. A brand-new endpoint's `required: true` path parameter constrains
+nobody — and getting that wrong is not theoretical: before council round 1 this
+gate reported 31 breaking changes against `feature/gh-11` and 21 against
+`feature/gh-13`, both purely additive, and not one finding named a pointer a
+1.6.0 client could address.
+
 ## What this cannot see, stated plainly
 
 Read a green run as *"no mechanically visible break"*, never as *"compatible"*.
-Four classes of breaking change pass this gate, and three of them are in the
-README's own list:
+**Three** classes of breaking change pass this gate in silence, and all three
+are in the README's own list:
 
 - **A meaning change that keeps the name and the type.** `status` growing a new
   interpretation, `limit` counting something else, a field that used to be
   UTC becoming local. No schema diff catches this — the README says so where it
   lists the rule ("the most dangerous kind"). Nothing here changes that.
-- **Default sort order, and the identity or lifetime of a pagination cursor.**
-  Neither is expressible in the schema.
-- **A rename is reported as a removal**, because that is what a rename looks
-  like from the outside: the verdict is right, the wording is imprecise.
+- **Default sort order.** A `default` *value* is compared; the order rows come
+  back in is not expressible in the schema at all.
+- **The identity or lifetime of a pagination cursor.** Same reason.
+
+Two more are imprecise rather than silent, which is a different thing:
+
+- **A rename is reported as a removal.** The verdict is right and the pointer is
+  right; only the wording is imprecise.
 - **Inside `allOf` / `anyOf` / `oneOf`**, members are compared as a set and not
-  recursed into, so a constraint tightened *within* a composition branch is
-  invisible. Compared positionally instead, reordering two equivalent branches
-  would report two breaks — and a gate that cries wolf is a gate that gets
-  deleted rather than obeyed. Five such keywords exist in the document today.
-- **Inside a `securitySchemes` entry.** Its *removal* reports, like any
-  component; changing an existing one (bearer to apiKey, a different header
-  name) does not. Every operation in this contract carries the same scheme, so
-  the case has never arisen — teach `_Facts._document` about the group before it
-  does.
+  recursed into, so a constraint tightened *within* an existing branch reports
+  as "1 branch removed" rather than naming the constraint. Compared positionally
+  instead, reordering two equivalent branches would report two breaks — and a
+  gate that cries wolf is a gate that gets deleted rather than obeyed. A branch
+  *added* to an `allOf` is caught, because `allOf` is an AND. Five composition
+  keywords exist in the document today.
+
+And one is neither, because the gate says so out loud:
+
+- **A restriction keyword this walker does not model** (`dependentRequired`,
+  `readOnly`, `uniqueItems`, `if`/`then`, …) makes the gate **fail** with
+  "this gate does not model … so it abstained rather than approving". None
+  appears in the contract today. Silence over an unread keyword was the failure
+  mode; a red build asking for a human is the fix.
+
+Council round 1 found seven more gaps that are now closed rather than
+documented, and this list is what it looked like before: `servers`,
+path-item-level `parameters`, `components.requestBodies`, a `default` value,
+which credential an operation accepts, a branch added to an `allOf`, and a
+`required` name removed from a response schema — every one of them green.
+`components.securitySchemes` **contents** are still not compared (its removal
+is); every operation here carries the same scheme, so teach `_Facts._document`
+about the group before that changes.
 
 ## Two conservative calls, on purpose
 
@@ -82,6 +109,14 @@ DOCUMENT_NAME = "codex-bridge.openapi.yaml"
 #: this repository. Same reason `x-contract-excluded-paths` lives there.
 MINIMUM_VERSION_KEY = "x-minimum-supported-version"
 
+#: Written reason for a floor that is no longer the oldest published version.
+#: Raising the floor is a deprecation — it drops the promise to every client
+#: still on the old pin — and it is also the cheapest way to make a red
+#: compatibility gate green, which is why it may not be a silent one-line diff.
+#: `tests/contract/test_contract_compatibility.py::test_raising_the_floor_past_a_published_version_is_written_down`
+#: is what enforces it, the same shape as the `reason` on an excluded path.
+RAISED_FLOOR_KEY = "x-minimum-supported-version-raised"
+
 OPERATIONS = frozenset(
     {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
 )
@@ -102,7 +137,7 @@ FLOORS = ("minLength", "minItems", "minProperties", "minimum", "exclusiveMinimum
 #: relaxation — which is explicitly not breaking.
 ADDRESSABLE = frozenset(
     {"endpoint", "operation", "response", "component", "property", "parameter",
-     "header", "media"}
+     "header", "media", "server", "serverVariable"}
 )
 
 #: Fact kinds that are a restriction, so *appearing* where the baseline had
@@ -111,6 +146,18 @@ TIGHTENING_WHEN_ADDED = frozenset(
     {"required", "pattern", "format", "const", "ceiling", "floor",
      "closedProperties"}
 )
+
+#: JSON Schema keywords that *restrict* a value and that this walker does not
+#: model. It does not compare them; it reports that one is present so the
+#: reviewer knows the gate abstained, instead of the gate abstaining silently.
+#: None of them appears in the contract today — the tripwire is what makes the
+#: day one arrives a red build rather than an invisible one.
+UNMODELLED_RESTRICTIONS = frozenset({
+    "dependentRequired", "dependentSchemas", "propertyNames", "patternProperties",
+    "prefixItems", "contains", "minContains", "maxContains", "uniqueItems",
+    "multipleOf", "not", "if", "then", "else", "readOnly", "writeOnly",
+    "unevaluatedProperties", "unevaluatedItems", "discriminator",
+})
 
 
 # --------------------------------------------------------------------------
@@ -155,15 +202,22 @@ class _Facts:
     # -- document ----------------------------------------------------------
 
     def _document(self, document: dict) -> None:
+        self._servers(document.get("servers"))
+
         for path, item in (document.get("paths") or {}).items():
             if not isinstance(item, dict):
                 continue
             pointer = f"paths[{path}]"
             self._emit(pointer, "endpoint")
+            # OpenAPI lets a path item declare parameters that apply to *every*
+            # operation under it. Walking only the operation keys dropped them:
+            # a new required one landed invisibly, and hoisting existing ones up
+            # — a pure refactor — reported them all as removed.
+            inherited = [p for p in (item.get("parameters") or []) if isinstance(p, dict)]
             for key, operation in item.items():
                 if key.lower() not in OPERATIONS or not isinstance(operation, dict):
                     continue
-                self._operation(operation, f"{pointer}.{key.lower()}")
+                self._operation(operation, f"{pointer}.{key.lower()}", inherited)
 
         for group, entries in (document.get("components") or {}).items():
             if not isinstance(entries, dict):
@@ -179,8 +233,41 @@ class _Facts:
                     self._response(entry, pointer)
                 elif group == "headers":
                     self._header(entry, pointer)
+                elif group == "requestBodies" and isinstance(entry, dict):
+                    self._emit(pointer, "parameter", bool(entry.get("required")))
+                    self._content(entry.get("content"), pointer)
 
-    def _operation(self, operation: dict, pointer: str) -> None:
+    def _servers(self, servers: Any) -> None:
+        """`servers` is where a generated client gets its base URL.
+
+        Renaming a server variable renames it in every generated client, which
+        §"What is a breaking change" covers under "renaming anything, in either
+        direction". Keyed by URL template rather than by list position, so
+        reordering two servers is not a rename.
+        """
+        if not isinstance(servers, list):
+            return
+        for server in servers:
+            if not isinstance(server, dict):
+                continue
+            url = str(server.get("url", ""))
+            pointer = f"servers[{url}]"
+            self._emit(pointer, "server")
+            for name, variable in (server.get("variables") or {}).items():
+                variable_pointer = f"{pointer}.variables[{name}]"
+                self._emit(variable_pointer, "serverVariable")
+                if isinstance(variable, dict) and "enum" in variable:
+                    values = variable["enum"]
+                    if isinstance(values, list):
+                        self._emit(
+                            f"{variable_pointer}.enum",
+                            "enum",
+                            frozenset(_canonical(value) for value in values),
+                        )
+
+    def _operation(
+        self, operation: dict, pointer: str, inherited: list[dict] | None = None
+    ) -> None:
         self._emit(pointer, "operation")
         # An endpoint that stops being reachable without a credential breaks
         # every client that reached it — the probes are the whole reason a
@@ -190,7 +277,17 @@ class _Facts:
             "unauthenticated",
             operation.get("security") == [],
         )
-        for parameter in operation.get("parameters") or []:
+        # …and separately, *which* credential. Collapsing the whole block to
+        # that one boolean made a scheme swap or an added scope invisible on
+        # every authenticated operation in the contract.
+        security = operation.get("security")
+        if isinstance(security, list):
+            self._emit(
+                f"{pointer}.security.requirements",
+                "securityRequirements",
+                frozenset(_canonical(requirement) for requirement in security),
+            )
+        for parameter in [*(inherited or []), *(operation.get("parameters") or [])]:
             self._parameter(parameter, pointer)
         body = operation.get("requestBody")
         if isinstance(body, dict):
@@ -288,6 +385,25 @@ class _Facts:
             if name in schema:
                 self._emit(f"{pointer}.{name}", "floor", schema[name])
 
+        if "default" in schema:
+            # A client that omits the field gets the server's default. Moving it
+            # changes that client's behaviour with no code change on either
+            # side — the same invisible flip §"What is a breaking change" names
+            # for default sort order.
+            self._emit(f"{pointer}.default", "default", _canonical(schema["default"]))
+
+        # Tripwire. Every keyword above is modelled; a restriction keyword this
+        # walker does not know about would otherwise be dropped in silence, and
+        # the honesty list would keep claiming a completeness it lost. Reporting
+        # it as "reviewed by hand" is the fail-loud version of a blind spot.
+        unmodelled = sorted(UNMODELLED_RESTRICTIONS & set(schema))
+        if unmodelled:
+            self._emit(
+                f"{pointer}.<unmodelled>",
+                "unmodelled",
+                _canonical({name: schema[name] for name in unmodelled}),
+            )
+
         extra = schema.get("additionalProperties")
         if extra is False:
             self._emit(f"{pointer}.additionalProperties", "closedProperties", True)
@@ -340,18 +456,67 @@ def _removals(before: dict, after: dict) -> Iterator[Finding]:
                 f"this {kind} was removed or renamed. A client that addresses "
                 "it by name stops working."
             )
+        elif kind == "required":
+            # The whole `required` list vanished. On a *response* schema that is
+            # a break: a generated client makes a required field non-nullable
+            # and reads it unconditionally. It is a relaxation only on a
+            # request-only schema, which a pointer cannot tell — most schemas
+            # here are shared. Reported, with the direction named, so a
+            # reviewer can say which it is instead of the gate guessing.
+            yield pointer, (
+                "every field here stopped being required. On a response that "
+                "breaks a client reading them unconditionally; on a "
+                "request-only schema it is a relaxation — say which in review."
+            )
+        elif kind == "default":
+            yield pointer, (
+                "the default was removed. A client that omits this field no "
+                "longer gets the value it was written against."
+            )
+
+
+def _new_addressables(before: dict, after: dict) -> tuple[str, ...]:
+    """Pointers of things the candidate introduces wholesale.
+
+    A constraint is only a *tightening* when the thing it constrains already
+    existed. Without this, adding an endpoint whose new query parameter carries
+    a `pattern`, or adding an optional field with a `maxLength`, reported as
+    breaking — three of the changes §"What is not breaking" lists by name. Two
+    sibling branches are adding endpoints right now, so the gate would have gone
+    red on exactly the work it is supposed to wave through.
+    """
+    return tuple(
+        pointer
+        for pointer in sorted(set(after) - set(before))
+        if after[pointer][0] in ADDRESSABLE
+    )
 
 
 def _additions(before: dict, after: dict) -> Iterator[Finding]:
     """Facts the candidate gained. Only a *restriction* that appears is breaking."""
+    fresh = _new_addressables(before, after)
     for pointer in sorted(set(after) - set(before)):
         kind, value = after[pointer]
-        if kind == "parameter" and value:
+        if any(pointer.startswith(f"{ancestor}.") for ancestor in fresh):
+            # Born inside something that is itself new: nothing existed to
+            # tighten. Applies to a new *required parameter* too — required on
+            # an endpoint no client has ever called constrains nobody.
+            # `test_a_compatible_change_is_left_alone[add_an_endpoint_with_a_required_constrained_parameter]`
+            # is what keeps this branch honest.
+            continue
+        if kind == "unmodelled":
+            yield pointer, (
+                f"this schema uses restriction keyword(s) this gate does not "
+                f"model, so it abstained rather than approving: {value}. Review "
+                "the change against docs/api/README.md §\"What is a breaking "
+                "change\" by hand."
+            )
+        elif kind == "parameter" and value:
             yield pointer, "a new *required* parameter. Existing callers do not send it."
         elif kind == "required":
             yield pointer, (
-                f"{sorted(value)} became required where nothing was. A request "
-                "that omits them is now rejected."
+                f"{sorted(value)} became required where nothing was; a message "
+                "that omits them is now invalid."
             )
         elif kind == "enum":
             # `type: string` -> `enum: [a, b]` closes an open field. The
@@ -401,10 +566,48 @@ def _changes(before: dict, after: dict) -> Iterator[Finding]:
             arrived = sorted(new - old)
             if arrived:
                 yield pointer, f"{arrived} became required."
+            departed = sorted(old - new)
+            if departed:
+                # See `_removals` for why this is reported rather than waved
+                # through as a relaxation.
+                yield pointer, (
+                    f"{departed} stopped being required. On a response that "
+                    "breaks a client reading them unconditionally; on a "
+                    "request-only schema it is a relaxation — say which in review."
+                )
         elif kind == "composition":
             gone = sorted(old - new)
             if gone:
                 yield pointer, f"{len(gone)} branch(es) removed from the composition."
+            arrived = sorted(new - old)
+            if arrived and pointer.endswith(".allOf"):
+                # `allOf` is an AND: a new branch is a new constraint on every
+                # value that already validated. `oneOf`/`anyOf` are ORs, where
+                # a new branch widens, so only `allOf` reports here.
+                yield pointer, (
+                    f"{len(arrived)} branch(es) added to an `allOf`, which "
+                    "narrows every value that validated before."
+                )
+        elif kind == "securityRequirements":
+            lost = sorted(old - new)
+            if lost:
+                yield pointer, (
+                    "the credential this operation accepts changed; it no "
+                    f"longer accepts {lost}. A client holding one stops working."
+                )
+        elif kind == "default":
+            if old != new:
+                yield pointer, (
+                    f"the default changed from {old} to {new}. A client that "
+                    "omits this field silently gets different behaviour."
+                )
+        elif kind == "unmodelled":
+            yield pointer, (
+                f"this schema uses restriction keyword(s) this gate does not "
+                f"model, so it abstained rather than approving: {new}. Review "
+                "the change against docs/api/README.md §\"What is a breaking "
+                "change\" by hand."
+            )
         elif kind == "ceiling":
             if _lt(new, old):
                 yield pointer, f"ceiling lowered from {old!r} to {new!r}."

--- a/scripts/publish_contract.py
+++ b/scripts/publish_contract.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Publish the OpenAPI contract as a pinned, checksummed artifact.
+
+Run explicitly, by whoever changed the contract:
+
+    python3 scripts/publish_contract.py            # publish the current version
+    python3 scripts/publish_contract.py --check    # verify; exit 1 on drift
+
+Why this exists: `docs/api/README.md` §"Getting the contract to the mobile
+repository" recorded the gap this closes. The document lived in this repository
+and a consumer copied it by hand — nothing published it, nothing checksummed it,
+and nothing detected that a copy had diverged. The route-drift gate protected the
+*gateway ↔ document* pair and left the *document ↔ mobile client* pair, which is
+the pair epic #1 exists for, unguarded. `info.version` was decoration: a client
+could pin `1.6.0` and had no way to tell whether the bytes behind that number had
+changed underneath it.
+
+What it publishes, under `contract/`:
+
+    contract/<version>/codex-bridge.openapi.yaml   byte-identical copy
+    contract/<version>/manifest.json               version + sha256 of that copy
+    contract/index.json                            every published version, and the latest
+
+`EDortta/CodexBridgeMobile` pins a version by fetching that directory and
+checking the digest — see `docs/api/testing.md`. Once published, a version
+directory is **immutable**: `--check` recomputes every manifest digest, so
+editing a published copy in place fails rather than silently rewriting what a
+client already pinned.
+
+**Nothing here carries a timestamp, a hostname or a user name.** That is not
+tidiness: `--check` works by regenerating the artifact and comparing bytes, so a
+field that changes between two runs of the same input would make the gate fire
+on every run and be deleted within a week.
+
+Publishing a *new* version is the same command. It writes a new directory and
+leaves every previous one untouched, because a pin that can be rewritten is not
+a pin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE = REPO_ROOT / "docs" / "api" / "codex-bridge.openapi.yaml"
+DEFAULT_OUTPUT = REPO_ROOT / "contract"
+
+#: Name the document keeps inside a published version directory. Kept equal to
+#: the source filename so a consumer that already vendored the file by hand does
+#: not have to rename anything when it switches to the pin.
+DOCUMENT_NAME = "codex-bridge.openapi.yaml"
+
+MANIFEST_NAME = "manifest.json"
+INDEX_NAME = "index.json"
+
+#: Written into every manifest so a consumer reading one knows which producer
+#: shaped it. Bump it when the *layout* changes, never when the contract does.
+ARTIFACT_FORMAT = 1
+
+
+def sha256_of(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _version_key(version: str) -> tuple:
+    """Sort key for a semver-ish string, falling back to text.
+
+    A version that is not three integers sorts after every version that is,
+    rather than raising: `index.json` describing an odd version badly is
+    recoverable, refusing to publish it is not.
+    """
+    parts = version.split(".")
+    if len(parts) == 3 and all(part.isdigit() for part in parts):
+        return (0, tuple(int(part) for part in parts), "")
+    return (1, (), version)
+
+
+def contract_version(source: Path) -> str:
+    """`info.version` of the document at `source`.
+
+    Read with the YAML parser rather than by regex: the version is the identity
+    of the whole artifact, and a regex that matched `version:` inside a
+    description block would publish a directory named after prose.
+    """
+    document = yaml.safe_load(source.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise SystemExit(f"{source} is not a YAML mapping")
+    version = (document.get("info") or {}).get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise SystemExit(f"{source} has no info.version to publish")
+    return version
+
+
+def _published_versions(output: Path) -> list[str]:
+    if not output.is_dir():
+        return []
+    versions = [
+        entry.name
+        for entry in output.iterdir()
+        if entry.is_dir() and (entry / DOCUMENT_NAME).is_file()
+    ]
+    return sorted(versions, key=_version_key)
+
+
+def _render_manifest(version: str, digest: str) -> str:
+    return json.dumps(
+        {
+            "artifactFormat": ARTIFACT_FORMAT,
+            "contractVersion": version,
+            "document": DOCUMENT_NAME,
+            "sha256": digest,
+        },
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def _render_index(versions: list[str]) -> str:
+    return json.dumps(
+        {
+            "artifactFormat": ARTIFACT_FORMAT,
+            "latest": versions[-1] if versions else None,
+            "versions": versions,
+        },
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def publish(source: Path, output: Path) -> str:
+    """Write the version directory and refresh the index. Returns the version.
+
+    Writing is unconditional and byte-for-byte: an existing version directory is
+    overwritten with the current document. That is deliberate and is exactly why
+    `--check` also verifies **every** published version against its own manifest
+    — the immutability of a pin is enforced by the check, not by this function
+    refusing to write, because a refusal here would also block the legitimate
+    case of re-publishing after an interrupted run.
+    """
+    version = contract_version(source)
+    version_dir = output / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+
+    document = version_dir / DOCUMENT_NAME
+    shutil.copyfile(source, document)
+    (version_dir / MANIFEST_NAME).write_text(
+        _render_manifest(version, sha256_of(document)), encoding="utf-8"
+    )
+    (output / INDEX_NAME).write_text(
+        _render_index(_published_versions(output)), encoding="utf-8"
+    )
+    return version
+
+
+def _files_under(root: Path) -> set[Path]:
+    return {path.relative_to(root) for path in root.rglob("*") if path.is_file()}
+
+
+def check(source: Path, output: Path) -> list[str]:
+    """Everything wrong with the published artifact, in messages an operator can act on.
+
+    Two independent failures, reported separately because the remedies differ:
+
+    - the *current* version drifted from the document — regenerate;
+    - a *previously published* version no longer matches its own manifest digest
+      — that is a pinned artifact edited after the fact, and regenerating would
+      destroy the evidence rather than fix it.
+    """
+    problems: list[str] = []
+
+    if not output.is_dir():
+        return [
+            f"{output} does not exist: the contract has never been published. "
+            "Run `python3 scripts/publish_contract.py`."
+        ]
+
+    version = contract_version(source)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        expected_root = Path(tmp) / "contract"
+        # Seed with the published versions so the regenerated index lists the
+        # same set. Copying only the current version would make `index.json`
+        # differ for every repository that has published more than one, which
+        # is a gate firing on its own bookkeeping.
+        for published in _published_versions(output):
+            if published == version:
+                continue
+            shutil.copytree(output / published, expected_root / published)
+        publish(source, expected_root)
+
+        expected_files = _files_under(expected_root)
+        actual_files = _files_under(output)
+
+        for relative in sorted(expected_files - actual_files):
+            problems.append(f"missing from {output}/: {relative}")
+        for relative in sorted(actual_files - expected_files):
+            problems.append(f"unexpected file in {output}/: {relative}")
+        for relative in sorted(expected_files & actual_files):
+            expected_bytes = (expected_root / relative).read_bytes()
+            actual_bytes = (output / relative).read_bytes()
+            if expected_bytes != actual_bytes:
+                problems.append(f"stale: {relative} does not match the current document")
+
+    if problems:
+        problems.append(
+            "The published contract is out of step with "
+            f"{source.relative_to(REPO_ROOT) if source.is_relative_to(REPO_ROOT) else source}. "
+            "Run `python3 scripts/publish_contract.py` and commit the result."
+        )
+
+    problems.extend(_digest_problems(output))
+    return problems
+
+
+def _digest_problems(output: Path) -> list[str]:
+    """A published version whose bytes no longer match its recorded digest.
+
+    This is the check that makes a pin mean something. A consumer that pinned
+    `1.6.0` verified a digest once; if the file behind it can be edited while the
+    manifest keeps the old number — or edited together with the manifest, which
+    the version-control history still shows — the pin is decoration again.
+    """
+    problems: list[str] = []
+    for version in _published_versions(output):
+        manifest_path = output / version / MANIFEST_NAME
+        if not manifest_path.is_file():
+            problems.append(f"contract/{version}/ has no {MANIFEST_NAME}")
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            problems.append(f"contract/{version}/{MANIFEST_NAME} is not valid JSON: {exc}")
+            continue
+        recorded = manifest.get("sha256")
+        actual = sha256_of(output / version / DOCUMENT_NAME)
+        if recorded != actual:
+            problems.append(
+                f"contract/{version}/{DOCUMENT_NAME} was edited after publication: "
+                f"manifest records {recorded}, file hashes to {actual}. A published "
+                "version is what a client pinned; publish a new version instead of "
+                "rewriting one."
+            )
+        if manifest.get("contractVersion") != version:
+            problems.append(
+                f"contract/{version}/{MANIFEST_NAME} names contractVersion "
+                f"{manifest.get('contractVersion')!r}, but it lives in {version}/"
+            )
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=DEFAULT_SOURCE,
+        help="OpenAPI document to publish. Defaults to the canonical contract.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Directory the pinned artifact is written to. Defaults to contract/.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report drift between the document and the published artifact; do not write.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.source.is_file():
+        print(f"No such contract document: {args.source}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        problems = check(args.source, args.output)
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        if problems:
+            return 1
+        print(f"Published contract is in sync with {args.source}.")
+        return 0
+
+    version = publish(args.source, args.output)
+    print(f"Published contract {version} to {args.output}/{version}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/contract/test_contract_compatibility.py
+++ b/tests/contract/test_contract_compatibility.py
@@ -1,0 +1,480 @@
+"""The gate that fails a pull request before it breaks the pinned mobile client.
+
+`test_openapi_document.py` binds the gateway to the document. `test_published_contract_artifact.py`
+binds the document to the copy `EDortta/CodexBridgeMobile` downloads. Neither
+says anything about *what changed*: republishing after removing a field leaves
+both of them green, and the mobile build finds out at runtime.
+
+This file guards the third pair — **the document against the oldest version it
+still promises to serve**, declared as `x-minimum-supported-version` in the
+document itself and published under `contract/<version>/`. The rules are
+`docs/api/README.md` §"What is a breaking change" / §"What is not breaking";
+`scripts/check_contract_compatibility.py` is where they are transcribed.
+
+Two kinds of test here, deliberately separated:
+
+- the **mutation matrix**, which is where the classifier's teeth are proven. It
+  takes the real document, breaks it one way at a time, and asserts the gate
+  fires and names the right pointer — and, just as important, takes the changes
+  §"What is not breaking" allows and asserts the gate stays quiet. A gate that
+  cries wolf gets deleted rather than obeyed.
+- the **live check**, which runs the real pair.
+
+While the floor equals the current version the live pair is byte-identical and
+the live check cannot fail on a *version bump*. It is still not vacuous: it
+compares the working document against an immutable published copy, so editing
+`1.6.0` in place — removing a field without bumping anything — fails here, and
+fails differently from `--check` in the artifact test. That one fires on any
+byte change including a typo fix; this one fires only on a change a client
+cannot survive, and the remedies are different (republish vs. a new namespace).
+
+**What is not tested here, because it cannot be:** a change of *meaning* that
+keeps a field's name and type, a change of default sort order, and the identity
+or lifetime of a pagination cursor. All three are in the README's breaking list
+and none is visible to a schema diff — the README says so itself where it calls
+the first one "the most dangerous kind". A green run here means "no
+mechanically visible break", never "compatible".
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_contract_compatibility.py"
+SPEC_PATH = REPO_ROOT / "docs" / "api" / "codex-bridge.openapi.yaml"
+CONTRACT_DIR = REPO_ROOT / "contract"
+
+
+def _load_checker():
+    """Import the classifier from `scripts/`, which is not an importable package.
+
+    `tests/unit/test_apply_migrations.py` drives its script purely as a
+    subprocess, and the two live-pair tests below do the same so that the thing
+    CI runs is the thing under test, exit code included. The mutation matrix
+    does not: it is ~20 cases against a pure function over two parsed
+    documents, and a subprocess per case would buy nothing but a slower suite
+    and a stack trace one level further from the assertion.
+    """
+    spec = importlib.util.spec_from_file_location("check_contract_compatibility", SCRIPT)
+    assert spec and spec.loader, f"cannot import {SCRIPT}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_checker()
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict:
+    return yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def baseline(spec: dict) -> dict:
+    """The published copy of the minimum supported version.
+
+    Read from `contract/`, never re-derived from the working document: the
+    point of a baseline is that it is the bytes a client already holds.
+    """
+    path = checker.baseline_path(spec, CONTRACT_DIR)
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+# --------------------------------------------------------------------------
+# The floor is declared, and it names something a client can actually fetch
+# --------------------------------------------------------------------------
+
+
+def test_the_document_declares_a_minimum_supported_version(spec: dict) -> None:
+    """Without it there is no floor, and this whole file has nothing to compare against."""
+    version = checker.minimum_supported_version(spec)
+    assert version, (
+        "the contract declares no `x-minimum-supported-version`. The mobile "
+        "client has no way to learn which pinned version this build still "
+        "promises to serve, and the compatibility gate has no baseline."
+    )
+
+
+def test_the_minimum_supported_version_is_published(spec: dict) -> None:
+    """A floor naming an unpublished version is a floor over nothing."""
+    version = checker.minimum_supported_version(spec)
+    published = CONTRACT_DIR / version / "codex-bridge.openapi.yaml"
+    assert published.is_file(), (
+        f"`x-minimum-supported-version` names {version}, which is not published "
+        f"under contract/{version}/. Either publish it "
+        "(`python3 scripts/publish_contract.py`) or name a version that is."
+    )
+
+
+def test_the_minimum_supported_version_is_not_ahead_of_the_document(spec: dict) -> None:
+    """A floor above the ceiling means the build serves nothing it promises.
+
+    Compared as semver tuples where both are three integers, and skipped
+    otherwise rather than guessed at: a wrong verdict from a version scheme
+    this rule does not understand is worse than no verdict.
+    """
+    floor = checker.minimum_supported_version(spec)
+    current = spec["info"]["version"]
+
+    def parts(version: str):
+        pieces = version.split(".")
+        return tuple(int(p) for p in pieces) if len(pieces) == 3 and all(p.isdigit() for p in pieces) else None
+
+    low, high = parts(floor), parts(current)
+    if low is None or high is None:
+        pytest.skip(f"not both semver: floor={floor!r} current={current!r}")
+    assert low <= high, (
+        f"`x-minimum-supported-version` is {floor} while `info.version` is "
+        f"{current}: the floor is above the version this build implements."
+    )
+
+
+def test_the_error_code_exemption_still_has_a_schema(spec: dict) -> None:
+    """The one enum allowed to grow must still be the one the reason applies to.
+
+    `ErrorCode` may gain a value because the contract obliges clients to
+    degrade an unknown `code` to its HTTP status class. If that schema is
+    renamed or removed, the exemption in the classifier silently starts
+    applying to nothing — or, worse, keeps a name that now means something
+    else. Same rule as `test_no_exclusion_outlives_its_route`: an exemption may
+    not outlive its reason.
+    """
+    assert "ErrorCode" in (spec.get("components") or {}).get("schemas", {}), (
+        "the classifier exempts `ErrorCode` from the added-enum-value rule and "
+        "the contract no longer declares that schema; revisit "
+        "scripts/check_contract_compatibility.py::ERROR_CODE_ENUM_POINTER"
+    )
+    assert isinstance(spec["components"]["schemas"]["ErrorCode"].get("enum"), list)
+
+
+# --------------------------------------------------------------------------
+# The live pair
+# --------------------------------------------------------------------------
+
+
+def test_the_document_is_compatible_with_the_minimum_supported_version() -> None:
+    """The acceptance criterion: a breaking change is caught before merge.
+
+    Run as a subprocess so the exit code CI reads is what is asserted.
+    """
+    result = run()
+    assert result.returncode == 0, (
+        "the working contract breaks the minimum version mobile still "
+        f"supports:\n{result.stderr}{result.stdout}"
+    )
+
+
+def test_the_gate_names_the_incompatible_endpoint_in_its_output(tmp_path: Path) -> None:
+    """"CI output identifies the incompatible endpoint/schema" — asserted, not assumed.
+
+    A gate that exits 1 with "incompatible" and nothing else sends the reader
+    back to diff two 3,700-line documents by hand.
+    """
+    broken = tmp_path / "codex-bridge.openapi.yaml"
+    document = yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))
+    victim, _ = next(iter(document["paths"].items()))
+    document["paths"].pop(victim)
+    broken.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+    result = run("--document", str(broken), "--baseline", str(SPEC_PATH))
+    assert result.returncode == 1
+    assert f"paths[{victim}]" in result.stderr, result.stderr
+    assert "breaking change" in result.stderr
+
+
+def test_the_gate_refuses_a_floor_that_is_not_published(tmp_path: Path) -> None:
+    """Pointing the floor at a version nobody can download is not a green run."""
+    document = yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))
+    document[checker.MINIMUM_VERSION_KEY] = "0.0.1"
+    path = tmp_path / "codex-bridge.openapi.yaml"
+    path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+    result = run("--document", str(path))
+    assert result.returncode == 1
+    assert "0.0.1" in result.stderr
+    assert "publish" in result.stderr
+
+
+def test_a_document_with_no_declared_floor_is_an_error(tmp_path: Path) -> None:
+    document = yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))
+    document.pop(checker.MINIMUM_VERSION_KEY, None)
+    path = tmp_path / "codex-bridge.openapi.yaml"
+    path.write_text(yaml.safe_dump(document, sort_keys=False), encoding="utf-8")
+
+    result = run("--document", str(path))
+    assert result.returncode == 1
+    assert checker.MINIMUM_VERSION_KEY in result.stderr
+
+
+def test_a_document_compared_with_itself_reports_nothing(baseline: dict) -> None:
+    """The precondition every other case rests on.
+
+    A classifier that reported a break on an unchanged document would make the
+    matrix below pass for the wrong reason, and the live gate red forever.
+    """
+    assert checker.incompatibilities(baseline, copy.deepcopy(baseline)) == []
+
+
+# --------------------------------------------------------------------------
+# The mutation matrix — one break at a time, against the real document
+# --------------------------------------------------------------------------
+
+
+def _first_path(document: dict) -> str:
+    """Whatever endpoint the document happens to declare first.
+
+    Never a literal path. Two sibling branches are adding endpoints to this
+    document right now; a test naming `/api/v1/projects` would be a hidden
+    dependency on an endpoint set that is deliberately in flux, and the
+    machinery here is meant to be indifferent to it.
+    """
+    return next(iter(document["paths"]))
+
+
+def _error_schema(document: dict) -> dict:
+    """`Error` — the envelope §"One error envelope" makes every endpoint return.
+
+    Used as the mutation subject because it is the one schema the contract
+    guarantees exists for as long as the contract does, so the matrix does not
+    have to name an endpoint-specific shape.
+    """
+    return document["components"]["schemas"]["Error"]
+
+
+def remove_an_endpoint(document: dict) -> str:
+    victim = _first_path(document)
+    document["paths"].pop(victim)
+    return f"paths[{victim}]"
+
+
+def remove_an_operation(document: dict) -> str:
+    victim = _first_path(document)
+    method = next(k for k in document["paths"][victim] if k in checker.OPERATIONS)
+    document["paths"][victim].pop(method)
+    return f"paths[{victim}].{method}"
+
+
+def remove_a_response_status(document: dict) -> str:
+    victim = _first_path(document)
+    method = next(k for k in document["paths"][victim] if k in checker.OPERATIONS)
+    responses = document["paths"][victim][method]["responses"]
+    status = sorted(responses)[-1]
+    responses.pop(status)
+    return f"paths[{victim}].{method}.responses[{status}]"
+
+
+def remove_a_response_field(document: dict) -> str:
+    _error_schema(document)["properties"].pop("retryable")
+    return "components.schemas[Error].properties[retryable]"
+
+
+def rename_a_response_field(document: dict) -> str:
+    properties = _error_schema(document)["properties"]
+    properties["isRetryable"] = properties.pop("retryable")
+    return "components.schemas[Error].properties[retryable]"
+
+
+def remove_an_enum_value(document: dict) -> str:
+    document["components"]["schemas"]["ErrorCode"]["enum"].pop()
+    return "components.schemas[ErrorCode].enum"
+
+
+def _some_other_enum(document: dict) -> tuple[str, dict]:
+    """A component schema carrying an `enum` that is not `ErrorCode`.
+
+    Found rather than named: `ErrorCode` is the one enum a minor release may
+    grow, and the rule under test is that *every other* enum is closed. A test
+    naming one by hand would go vacuous the day that schema is renamed.
+    """
+    for name, schema in document["components"]["schemas"].items():
+        if name != "ErrorCode" and isinstance(schema, dict) and isinstance(schema.get("enum"), list):
+            return name, schema
+    pytest.skip("the contract declares no closed enum other than `ErrorCode`")
+
+
+def add_a_value_to_another_enum(document: dict) -> str:
+    name, schema = _some_other_enum(document)
+    schema["enum"] = [*schema["enum"], "a-value-no-client-expects"]
+    return f"components.schemas[{name}].enum"
+
+
+def close_an_open_field_with_an_enum(document: dict) -> str:
+    """`type: string` -> `enum: [...]`: yesterday's valid value may be rejected today."""
+    _error_schema(document)["properties"]["message"]["enum"] = ["only", "these"]
+    return "components.schemas[Error].properties[message].enum"
+
+
+def narrow_a_type(document: dict) -> str:
+    _error_schema(document)["properties"]["message"]["type"] = "integer"
+    return "components.schemas[Error].properties[message].type"
+
+
+def tighten_a_ceiling(document: dict) -> str:
+    _error_schema(document)["properties"]["message"]["maxLength"] = 8
+    return "components.schemas[Error].properties[message].maxLength"
+
+
+def add_a_pattern(document: dict) -> str:
+    _error_schema(document)["properties"]["message"]["pattern"] = "^only-this$"
+    return "components.schemas[Error].properties[message].pattern"
+
+
+def make_a_field_required(document: dict) -> str:
+    _error_schema(document)["properties"]["hint"] = {"type": "string"}
+    _error_schema(document)["required"].append("hint")
+    return "components.schemas[Error].required"
+
+
+def change_a_reference(document: dict) -> str:
+    _error_schema(document)["properties"]["code"]["$ref"] = "#/components/schemas/Id"
+    return "components.schemas[Error].properties[code].$ref"
+
+
+def require_authentication_on_an_open_endpoint(document: dict) -> str:
+    for path, item in document["paths"].items():
+        for method, operation in item.items():
+            if method in checker.OPERATIONS and operation.get("security") == []:
+                operation.pop("security")
+                return f"paths[{path}].{method}.security"
+    pytest.skip("the contract declares no unauthenticated operation to close")
+
+
+BREAKING: list[Callable[[dict], str]] = [
+    remove_an_endpoint,
+    remove_an_operation,
+    remove_a_response_status,
+    remove_a_response_field,
+    rename_a_response_field,
+    remove_an_enum_value,
+    add_a_value_to_another_enum,
+    close_an_open_field_with_an_enum,
+    narrow_a_type,
+    tighten_a_ceiling,
+    add_a_pattern,
+    make_a_field_required,
+    change_a_reference,
+    require_authentication_on_an_open_endpoint,
+]
+
+
+@pytest.mark.parametrize("mutate", BREAKING, ids=lambda fn: fn.__name__)
+def test_a_breaking_change_is_caught_and_named(
+    baseline: dict, mutate: Callable[[dict], str]
+) -> None:
+    """Every rule in §"What is a breaking change" that a schema diff can see.
+
+    The mutation returns the pointer it broke, and the finding must name it:
+    "the gate went red" is worth much less to whoever reads the CI log than
+    "the gate went red at this pointer".
+    """
+    candidate = copy.deepcopy(baseline)
+    pointer = mutate(candidate)
+    findings = checker.incompatibilities(baseline, candidate)
+
+    assert findings, f"{mutate.__name__} is a breaking change and the gate stayed green"
+    assert any(finding.startswith(f"{pointer}:") for finding in findings), (
+        f"the gate fired but never named {pointer}. It said: {findings}"
+    )
+
+
+def add_an_endpoint(document: dict) -> None:
+    document["paths"]["/api/v1/something-new"] = {
+        "get": {
+            "operationId": "getSomethingNew",
+            "responses": {"200": {"description": "New."}},
+        }
+    }
+
+
+def add_an_optional_response_field(document: dict) -> None:
+    _error_schema(document)["properties"]["hint"] = {"type": "string"}
+
+
+def add_a_value_to_error_code(document: dict) -> None:
+    document["components"]["schemas"]["ErrorCode"]["enum"].append("brand_new_code")
+
+
+def relax_a_ceiling(document: dict) -> None:
+    _error_schema(document)["properties"]["message"]["maxLength"] = 65536
+
+
+def drop_a_pattern(document: dict) -> None:
+    for schema in document["components"]["schemas"].values():
+        if isinstance(schema, dict) and "pattern" in schema:
+            schema.pop("pattern")
+            return
+    pytest.skip("no schema in the contract carries a `pattern` to relax")
+
+
+def widen_a_type(document: dict) -> None:
+    _error_schema(document)["properties"]["message"]["type"] = ["string", "null"]
+
+
+def rewrite_prose(document: dict) -> None:
+    _error_schema(document)["description"] = "Completely different explanatory text."
+    document["info"]["description"] = "Also rewritten."
+    for item in document["paths"].values():
+        for method, operation in item.items():
+            if method in checker.OPERATIONS:
+                operation["summary"] = "Reworded."
+                operation["description"] = "Reworded, at length."
+
+
+def drop_a_required_request_field(document: dict) -> None:
+    for schema in document["components"]["schemas"].values():
+        if isinstance(schema, dict) and schema.get("required"):
+            schema["required"] = schema["required"][:-1]
+            return
+    pytest.skip("no schema in the contract declares `required`")
+
+
+COMPATIBLE: list[Callable[[dict], None]] = [
+    add_an_endpoint,
+    add_an_optional_response_field,
+    add_a_value_to_error_code,
+    relax_a_ceiling,
+    drop_a_pattern,
+    widen_a_type,
+    rewrite_prose,
+    drop_a_required_request_field,
+]
+
+
+@pytest.mark.parametrize("mutate", COMPATIBLE, ids=lambda fn: fn.__name__)
+def test_a_compatible_change_is_left_alone(
+    baseline: dict, mutate: Callable[[dict], None]
+) -> None:
+    """§"What is not breaking", asserted as loudly as its opposite.
+
+    This half is not decoration. A classifier that flags an added optional
+    field blocks every ordinary pull request, and the first person who needs to
+    ship on a Friday deletes the gate rather than argues with it. The
+    false-positive side is what decides whether this survives.
+    """
+    candidate = copy.deepcopy(baseline)
+    mutate(candidate)
+    findings = checker.incompatibilities(baseline, candidate)
+    assert findings == [], (
+        f"{mutate.__name__} is listed under §\"What is not breaking\" and the "
+        f"gate flagged it: {findings}"
+    )

--- a/tests/contract/test_contract_compatibility.py
+++ b/tests/contract/test_contract_compatibility.py
@@ -95,8 +95,20 @@ def baseline(spec: dict) -> dict:
 
     Read from `contract/`, never re-derived from the working document: the
     point of a baseline is that it is the bytes a client already holds.
+
+    Guarded, because an unguarded module fixture is how one missing file
+    becomes twenty-three identical `FileNotFoundError` tracebacks with the one
+    actionable sentence buried under them. Council round 1 walked the merge of
+    a sibling branch and counted exactly that.
     """
     path = checker.baseline_path(spec, CONTRACT_DIR)
+    if not path.is_file():
+        pytest.fail(
+            f"the contract's `{checker.MINIMUM_VERSION_KEY}` names "
+            f"{checker.minimum_supported_version(spec)}, and {path} does not "
+            "exist. Run `python3 scripts/publish_contract.py` and commit "
+            "contract/, or point the floor at a version that is published."
+        )
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
@@ -147,6 +159,51 @@ def test_the_minimum_supported_version_is_not_ahead_of_the_document(spec: dict) 
         f"`x-minimum-supported-version` is {floor} while `info.version` is "
         f"{current}: the floor is above the version this build implements."
     )
+
+
+def test_raising_the_floor_past_a_published_version_is_written_down(spec: dict) -> None:
+    """The one edit that silently disarms this whole file.
+
+    Council round 1: faced with a red compatibility gate, the cheapest green is
+    not to fix the break — it is to move `x-minimum-supported-version` up to
+    `info.version`. The gate then compares the document against a published copy
+    of itself and can never fire again, and the promise to every client still on
+    the old pin is dropped with no test, no warning, and a one-line diff nobody
+    reads as a policy change.
+
+    So the floor must be the **oldest** published version. Raising it is
+    legitimate — but it is a deprecation, and this contract's own rule for a
+    deliberate exception is that it is written down where the machine can see
+    it: the same shape as `x-contract-excluded-paths`, which
+    `test_every_exclusion_is_well_formed` refuses without a `reason`.
+    """
+    floor = checker.minimum_supported_version(spec)
+    published = sorted(
+        (path.name for path in CONTRACT_DIR.iterdir() if path.is_dir()),
+        key=_version_key,
+    )
+    assert published, "nothing is published, so there is no floor to check"
+    oldest = published[0]
+    if floor == oldest:
+        return
+
+    waiver = spec.get(checker.RAISED_FLOOR_KEY)
+    assert isinstance(waiver, str) and waiver.strip(), (
+        f"`x-minimum-supported-version` is {floor} while contract/{oldest}/ is "
+        "still published, so this build has stopped promising to serve a "
+        "version a client may have pinned. That is a deprecation, not "
+        f"housekeeping: record why in `{checker.RAISED_FLOOR_KEY}`, naming the "
+        "mobile release that stopped using it. If the floor was raised to get "
+        "past a red compatibility gate, fix the break instead — that is the "
+        "one thing this gate exists to prevent."
+    )
+
+
+def _version_key(version: str) -> tuple:
+    parts = version.split(".")
+    if len(parts) == 3 and all(part.isdigit() for part in parts):
+        return (0, tuple(int(part) for part in parts), "")
+    return (1, (), version)
 
 
 def test_the_error_code_exemption_still_has_a_schema(spec: dict) -> None:
@@ -359,6 +416,89 @@ def require_authentication_on_an_open_endpoint(document: dict) -> str:
     pytest.skip("the contract declares no unauthenticated operation to close")
 
 
+def stop_requiring_a_response_field(document: dict) -> str:
+    """A response field that becomes optional is a break, not a relaxation.
+
+    Council round 1: the first cut treated every `required` removal as a
+    relaxation, and the "compatible" fixture that was supposed to prove the
+    request-side case safe actually mutated `Actor` — a response-only schema —
+    so the matrix *certified* this break as compatible. A generated client
+    makes a required field non-nullable and reads it unconditionally.
+    """
+    schema = _error_schema(document)
+    schema["required"] = [name for name in schema["required"] if name != "retryable"]
+    return "components.schemas[Error].required"
+
+
+def swap_the_credential_an_operation_accepts(document: dict) -> str:
+    """Collapsing `security` to "is it empty" hid every scheme and scope change."""
+    for path, item in document["paths"].items():
+        for method, operation in item.items():
+            if method in checker.OPERATIONS and operation.get("security"):
+                operation["security"] = [{"someOtherScheme": ["admin"]}]
+                return f"paths[{path}].{method}.security.requirements"
+    pytest.skip("the contract declares no authenticated operation")
+
+
+def add_a_branch_to_an_all_of(document: dict) -> str:
+    """`allOf` is an AND: a new branch narrows every value that validated before.
+
+    Only removals were compared, so appending `maxLength: 4` to `ProjectId`
+    truncated every project identifier in the contract with the gate green.
+    """
+    for name, schema in document["components"]["schemas"].items():
+        if isinstance(schema, dict) and isinstance(schema.get("allOf"), list):
+            schema["allOf"] = [*schema["allOf"], {"maxLength": 4}]
+            return f"components.schemas[{name}].allOf"
+    pytest.skip("the contract uses no `allOf`")
+
+
+def change_a_default(document: dict) -> str:
+    """A client that omits the field gets different behaviour and no error."""
+    for name, parameter in document["components"]["parameters"].items():
+        schema = parameter.get("schema")
+        if isinstance(schema, dict) and "default" in schema:
+            schema["default"] = "a-value-nobody-was-written-against"
+            return f"components.parameters[{name}].schema.default"
+    pytest.skip("no component parameter declares a `default`")
+
+
+def rename_a_server_variable(document: dict) -> str:
+    """`servers` was not walked at all; every generated client embeds it."""
+    for server in document.get("servers") or []:
+        variables = server.get("variables") or {}
+        for name in list(variables):
+            variables[f"{name}Renamed"] = variables.pop(name)
+            return f"servers[{server.get('url', '')}].variables[{name}]"
+    pytest.skip("the contract declares no server variable")
+
+
+def add_a_required_parameter_to_a_path_item(document: dict) -> str:
+    """Path-item parameters apply to every operation under the path.
+
+    The walker looked only at operation keys, so this landed invisibly — and
+    hoisting existing parameters up here, a pure refactor, reported them all as
+    removed.
+    """
+    path = _first_path(document)
+    document["paths"][path]["parameters"] = [
+        {"name": "tenantId", "in": "query", "required": True, "schema": {"type": "string"}}
+    ]
+    method = next(k for k in document["paths"][path] if k in checker.OPERATIONS)
+    return f"paths[{path}].{method}.parameters[tenantId:query]"
+
+
+def use_a_restriction_keyword_the_gate_does_not_model(document: dict) -> str:
+    """The tripwire: abstaining loudly beats abstaining silently.
+
+    `dependentRequired` rejects requests a conforming client sends today. The
+    gate does not model it — so it says so and fails, rather than printing "no
+    breaking change" over a keyword it never read.
+    """
+    _error_schema(document)["dependentRequired"] = {"code": ["message"]}
+    return "components.schemas[Error].<unmodelled>"
+
+
 BREAKING: list[Callable[[dict], str]] = [
     remove_an_endpoint,
     remove_an_operation,
@@ -374,6 +514,14 @@ BREAKING: list[Callable[[dict], str]] = [
     make_a_field_required,
     change_a_reference,
     require_authentication_on_an_open_endpoint,
+    # Added in council round 1; every one of these was green before.
+    stop_requiring_a_response_field,
+    swap_the_credential_an_operation_accepts,
+    add_a_branch_to_an_all_of,
+    change_a_default,
+    rename_a_server_variable,
+    add_a_required_parameter_to_a_path_item,
+    use_a_restriction_keyword_the_gate_does_not_model,
 ]
 
 
@@ -404,6 +552,97 @@ def add_an_endpoint(document: dict) -> None:
             "responses": {"200": {"description": "New."}},
         }
     }
+
+
+def add_a_realistic_endpoint(document: dict) -> None:
+    """An endpoint shaped like one someone would actually add.
+
+    Council round 1, and the single worst defect this delivery had. The fixture
+    above adds an operation with no parameters, no request body and no response
+    schema — the one shape that dodges `_additions`. Against the *real*
+    `feature/gh-11` and `feature/gh-13` branches, both purely additive, the gate
+    reported **31** and **21** breaking changes; not one touched a pointer a
+    1.6.0 client can address.
+
+    A path parameter is `required: true` by OpenAPI rule, so the defect fired on
+    every endpoint with one, forever. This fixture carries a path parameter, a
+    constrained optional query parameter, a required request body and a response
+    schema with its own `required` — every trigger at once.
+    """
+    document["paths"]["/api/v1/widgets/{widgetId}"] = {
+        "get": {
+            "operationId": "getWidget",
+            "security": [{"bearerAuth": []}],
+            "parameters": [
+                {
+                    "name": "widgetId",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string", "maxLength": 64, "pattern": "^[a-z-]+$"},
+                },
+                {
+                    "name": "fields",
+                    "in": "query",
+                    "required": False,
+                    "schema": {"type": "string", "enum": ["short", "full"]},
+                },
+            ],
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {"name": {"type": "string", "maxLength": 40}},
+                        }
+                    }
+                },
+            },
+            "responses": {
+                "200": {
+                    "description": "A widget.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["id", "createdAt"],
+                                "properties": {
+                                    "id": {"$ref": "#/components/schemas/Id"},
+                                    "createdAt": {"$ref": "#/components/schemas/Timestamp"},
+                                },
+                            }
+                        }
+                    },
+                }
+            },
+        }
+    }
+
+
+def add_a_component_schema(document: dict) -> None:
+    """A new schema arrives with its own `required` and constraints, and is referenced."""
+    document["components"]["schemas"]["WidgetSummary"] = {
+        "type": "object",
+        "required": ["id", "label"],
+        "properties": {
+            "id": {"$ref": "#/components/schemas/Id"},
+            "label": {"type": "string", "maxLength": 80, "pattern": "^[A-Za-z ]+$"},
+        },
+    }
+
+
+def hoist_parameters_to_the_path_item(document: dict) -> None:
+    """A pure refactor: path-item parameters apply to every operation under it.
+
+    Reported five phantom removals before the walker learned to inherit them.
+    """
+    for path, item in document["paths"].items():
+        for method, operation in item.items():
+            if method in checker.OPERATIONS and operation.get("parameters"):
+                item["parameters"] = operation.pop("parameters")
+                return
+    pytest.skip("no operation in the contract declares parameters to hoist")
 
 
 def add_an_optional_response_field(document: dict) -> None:
@@ -440,23 +679,17 @@ def rewrite_prose(document: dict) -> None:
                 operation["description"] = "Reworded, at length."
 
 
-def drop_a_required_request_field(document: dict) -> None:
-    for schema in document["components"]["schemas"].values():
-        if isinstance(schema, dict) and schema.get("required"):
-            schema["required"] = schema["required"][:-1]
-            return
-    pytest.skip("no schema in the contract declares `required`")
-
-
 COMPATIBLE: list[Callable[[dict], None]] = [
     add_an_endpoint,
+    add_a_realistic_endpoint,
+    add_a_component_schema,
+    hoist_parameters_to_the_path_item,
     add_an_optional_response_field,
     add_a_value_to_error_code,
     relax_a_ceiling,
     drop_a_pattern,
     widen_a_type,
     rewrite_prose,
-    drop_a_required_request_field,
 ]
 
 

--- a/tests/contract/test_contract_compatibility.py
+++ b/tests/contract/test_contract_compatibility.py
@@ -488,6 +488,64 @@ def add_a_required_parameter_to_a_path_item(document: dict) -> str:
     return f"paths[{path}].{method}.parameters[tenantId:query]"
 
 
+def demand_a_request_body_where_there_was_none(document: dict) -> str:
+    """An operation that starts requiring a body every existing caller omits.
+
+    Council round 2. 28 of the 40 operations in this contract carry no request
+    body, and the `required` *inside* a newly added body is correctly suppressed
+    — the media type is new — so without a rule for the body itself the whole
+    change was silent.
+    """
+    for path, item in document["paths"].items():
+        for method, operation in item.items():
+            if method in checker.OPERATIONS and "requestBody" not in operation:
+                operation["requestBody"] = {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["reason"],
+                                "properties": {"reason": {"type": "string"}},
+                            }
+                        }
+                    },
+                }
+                return f"paths[{path}].{method}.requestBody"
+    pytest.skip("every operation in the contract already has a request body")
+
+
+def point_an_operation_at_a_required_component_parameter(document: dict) -> str:
+    """A `$ref` to an already-required component parameter, added to an operation.
+
+    Council round 2: the reference site claimed nothing was required and the
+    component itself had not changed, so nothing fired — while every existing
+    caller of that operation now omits a required header. 41 of the 90 operation
+    parameters in this contract are `$ref`s.
+    """
+    required = next(
+        (
+            name
+            for name, entry in document["components"]["parameters"].items()
+            if isinstance(entry, dict) and entry.get("required")
+        ),
+        None,
+    )
+    if required is None:
+        pytest.skip("no component parameter is declared required")
+    reference = f"#/components/parameters/{required}"
+    for path, item in document["paths"].items():
+        for method, operation in item.items():
+            if method not in checker.OPERATIONS:
+                continue
+            existing = operation.get("parameters") or []
+            if any(p.get("$ref") == reference for p in existing if isinstance(p, dict)):
+                continue
+            operation["parameters"] = [*existing, {"$ref": reference}]
+            return f"paths[{path}].{method}.parameters[{reference}]"
+    pytest.skip("every operation already references that parameter")
+
+
 def use_a_restriction_keyword_the_gate_does_not_model(document: dict) -> str:
     """The tripwire: abstaining loudly beats abstaining silently.
 
@@ -522,6 +580,9 @@ BREAKING: list[Callable[[dict], str]] = [
     rename_a_server_variable,
     add_a_required_parameter_to_a_path_item,
     use_a_restriction_keyword_the_gate_does_not_model,
+    # Added in council round 2; both were green after round 1.
+    demand_a_request_body_where_there_was_none,
+    point_an_operation_at_a_required_component_parameter,
 ]
 
 

--- a/tests/contract/test_declared_examples_are_real.py
+++ b/tests/contract/test_declared_examples_are_real.py
@@ -1,0 +1,370 @@
+"""Response **bodies**, checked against the contract — the half the route gate skips.
+
+`docs/api/README.md` §"What the gate does not cover" is explicit about the hole
+this file fills:
+
+> It compares **route inventories**: `(path, method)` on both sides. It does not
+> read a single `requestBody` or `responses` block. […] Body-level conformance
+> is issue #14's scope.
+
+Three claims are checked, and each fails for its own reason:
+
+1. **A declared example must satisfy the schema it illustrates.** The mobile
+   team codes against the example long before it codes against the schema; an
+   example that lies costs more than a missing one, because it is trusted.
+2. **A response the gateway actually returns must satisfy the declared schema**,
+   and must carry no top-level field the contract does not describe. That is
+   the body-level mirror of the route-drift gate: an undocumented field is an
+   undocumented public surface.
+3. **A failure response must be the declared `Error` envelope** — the contract
+   calls it "the single error envelope returned by every endpoint in this
+   contract for every non-2xx response. An endpoint that returns anything else
+   is a contract violation, not a variant."
+
+### Why this is not the coverage `tests/integration` already has
+
+`tests/integration/test_probes.py` and `test_api_conventions.py` assert
+behaviour against expectations **written in Python** — `body["status"] ==
+"degraded"`, `body["code"] == "not_found"`. Those are a second, independent
+statement of the contract, and two independent statements drift: the YAML can
+gain a required field, or lose one, and every one of those tests stays green.
+Nothing in this repository validated a live response against the schema in the
+document until this file. The assertion here is deliberately *not* a restatement
+of the expected fields — it is `the document says so`.
+
+### What is driven, and what is not
+
+Operations are discovered from the document, never listed here: two sibling
+branches are adding endpoints right now, and a hardcoded list would be a hidden
+dependency on an endpoint set in flux. The filter is a property the document
+states about itself — `security: []`, a GET, no path parameters — so an
+unauthenticated probe added tomorrow is covered without editing this file.
+
+**not validated: authenticated endpoints.** Driving them needs the sign-in
+fixtures that live in `tests/integration`, and reaching across suites to build a
+session here would put the authorization model's setup in the contract suite.
+Their success and failure bodies are exercised in `tests/integration` against
+hand-written expectations, which is the weaker form described above. Closing
+that is a follow-up, not something this file quietly pretends to do.
+
+**not validated: `format` keywords.** `jsonschema` does not assert `format` by
+default and it is left off here, so `format: date-time` on a `Timestamp` is not
+enforced by these tests. The stricter rule the contract actually wants — RFC
+3339 *with* an explicit `Z` — is not expressible in the schema at all, as the
+document's own Conventions section says.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+from jsonschema import Draft202012Validator
+
+from gateway.app.main import app
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC_PATH = REPO_ROOT / "docs" / "api" / "codex-bridge.openapi.yaml"
+
+OPERATIONS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
+
+SPEC: dict = yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))
+
+
+def _validator(fragment: dict) -> Draft202012Validator:
+    """A validator for one schema fragment that can still follow the document's `$ref`s.
+
+    The fragment is republished as the root of a synthetic document that keeps
+    the real `components`, so `#/components/schemas/Id` resolves to the same
+    place it resolves to in the contract. Handing the bare fragment to the
+    validator instead would make every internal pointer dangle — and a
+    validator that cannot resolve a `$ref` raises rather than passing, so the
+    failure would at least be loud; this makes it correct.
+    """
+    return Draft202012Validator({**fragment, "components": SPEC["components"]})
+
+
+def _resolve_response(response: Any) -> dict | None:
+    """A response object, following a `#/components/responses/…` reference.
+
+    Reusable error responses are declared once and `$ref`-ed from dozens of
+    operations. Skipping them would leave `InternalError` — the shape a client
+    meets on the worst day — unchecked.
+    """
+    if not isinstance(response, dict):
+        return None
+    reference = response.get("$ref")
+    if isinstance(reference, str):
+        prefix = "#/components/responses/"
+        if not reference.startswith(prefix):
+            return None
+        return (SPEC.get("components") or {}).get("responses", {}).get(
+            reference[len(prefix):]
+        )
+    return response
+
+
+def _declared_examples(media: dict) -> Iterator[tuple[str, Any]]:
+    """Every example in one media-type object, `example` and `examples` alike."""
+    if "example" in media:
+        yield "example", media["example"]
+    for name, entry in (media.get("examples") or {}).items():
+        if isinstance(entry, dict) and "value" in entry:
+            yield f"examples[{name}]", entry["value"]
+
+
+def _example_cases() -> list[tuple[str, dict, Any]]:
+    """(label, schema, example) for every response example the document declares."""
+    cases: list[tuple[str, dict, Any]] = []
+    for path, item in (SPEC.get("paths") or {}).items():
+        if not isinstance(item, dict):
+            continue
+        for method, operation in item.items():
+            if method.lower() not in OPERATIONS or not isinstance(operation, dict):
+                continue
+            for status, raw in (operation.get("responses") or {}).items():
+                response = _resolve_response(raw)
+                if not response:
+                    continue
+                for media_type, media in (response.get("content") or {}).items():
+                    schema = (media or {}).get("schema")
+                    if not isinstance(schema, dict):
+                        continue
+                    for label, value in _declared_examples(media):
+                        cases.append(
+                            (f"{method.upper()} {path} {status} {media_type} {label}",
+                             schema, value)
+                        )
+    return cases
+
+
+EXAMPLE_CASES = _example_cases()
+
+
+def _drivable_operations() -> list[tuple[str, str, dict]]:
+    """Operations this suite can call with no credential and no path parameter.
+
+    Discovered from a property the document states about itself (`security: []`),
+    so a probe added later is covered without editing this file, and an endpoint
+    that stops being unauthenticated drops out here — where
+    `test_contract_compatibility.py` will have already failed the change.
+    """
+    found: list[tuple[str, str, dict]] = []
+    for path, item in (SPEC.get("paths") or {}).items():
+        if "{" in path or not isinstance(item, dict):
+            continue
+        for method, operation in item.items():
+            if method.lower() != "get" or not isinstance(operation, dict):
+                continue
+            if operation.get("security") == []:
+                found.append((path, method.lower(), operation))
+    return found
+
+
+DRIVABLE = _drivable_operations()
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# --------------------------------------------------------------------------
+# 1. A declared example satisfies the schema it illustrates
+# --------------------------------------------------------------------------
+
+
+def test_the_document_declares_response_examples_at_all() -> None:
+    """Anti-vacuity: the parametrized test below is empty if discovery breaks.
+
+    A helper that silently returns `[]` turns a parametrized suite into zero
+    tests and a green run — the loudest kind of false coverage there is.
+    """
+    assert EXAMPLE_CASES, (
+        "no response example was discovered in the contract. Either the "
+        "document declares none, or `_example_cases` stopped finding them."
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "why"),
+    [
+        ({}, "every required field missing"),
+        (
+            {"code": "not_found", "message": "x", "requestId": "not valid!!", "retryable": False},
+            "`requestId` violating the `Id` pattern, which lives behind a `$ref`",
+        ),
+        (
+            {"code": "invented_code", "message": "x", "requestId": "req-1", "retryable": False},
+            "a `code` outside `ErrorCode`, also behind a `$ref`",
+        ),
+    ],
+    ids=["missing-required", "bad-ref-pattern", "bad-ref-enum"],
+)
+def test_the_validator_rejects_what_the_schema_forbids(body: dict, why: str) -> None:
+    """Everything below is worthless if `_validator` accepts anything.
+
+    Two of the three cases are only caught by following a `$ref` into
+    `components`, which is the part of the wiring that would fail silently: a
+    validator built on the bare fragment cannot resolve those pointers, and
+    "no errors" is indistinguishable from "conforms".
+    """
+    schema = SPEC["components"]["schemas"]["Error"]
+    assert list(_validator(schema).iter_errors(body)), (
+        f"the validator accepted a body with {why}; it is not checking anything"
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "schema", "example"), EXAMPLE_CASES, ids=[case[0] for case in EXAMPLE_CASES]
+)
+def test_a_declared_example_satisfies_its_own_schema(
+    label: str, schema: dict, example: Any
+) -> None:
+    """An example that contradicts its schema misleads the reader who trusts it most."""
+    errors = sorted(_validator(schema).iter_errors(example), key=lambda e: list(e.path))
+    assert not errors, (
+        f"the example for {label} does not satisfy the schema it illustrates: "
+        + "; ".join(f"{list(error.path) or '<root>'}: {error.message}" for error in errors[:5])
+    )
+
+
+# --------------------------------------------------------------------------
+# 2. The gateway returns what the document says it returns
+# --------------------------------------------------------------------------
+
+
+def test_at_least_one_operation_can_be_driven() -> None:
+    """Anti-vacuity, again: `security: []` disappearing must not read as green."""
+    assert DRIVABLE, (
+        "no unauthenticated GET without path parameters was found in the "
+        "contract, so nothing below actually calls the gateway."
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "operation"), DRIVABLE, ids=[f"{p}" for p, _, _ in DRIVABLE]
+)
+def test_the_gateway_returns_the_declared_shape(
+    client: TestClient, path: str, method: str, operation: dict
+) -> None:
+    """The success half of "representative examples are tested".
+
+    Asserted against the document, not against a field list written here: that
+    is the whole difference between this and the probe tests in
+    `tests/integration`, which restate the contract in Python and therefore
+    cannot notice the document changing.
+    """
+    response = client.request(method.upper(), path)
+    status = str(response.status_code)
+
+    declared = _resolve_response((operation.get("responses") or {}).get(status))
+    assert declared is not None, (
+        f"{method.upper()} {path} answered {status} and the contract declares no "
+        f"{status} response for it. Declared: {sorted(operation.get('responses') or {})}"
+    )
+
+    media = (declared.get("content") or {}).get("application/json")
+    assert media, f"the contract declares no application/json body for {path} {status}"
+
+    body = response.json()
+    errors = sorted(_validator(media["schema"]).iter_errors(body), key=lambda e: list(e.path))
+    assert not errors, (
+        f"the body {method.upper()} {path} returned does not satisfy the schema "
+        f"the contract declares for {status}: "
+        + "; ".join(f"{list(error.path) or '<root>'}: {error.message}" for error in errors[:5])
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "method", "operation"), DRIVABLE, ids=[f"{p}" for p, _, _ in DRIVABLE]
+)
+def test_the_gateway_returns_no_field_the_contract_omits(
+    client: TestClient, path: str, method: str, operation: dict
+) -> None:
+    """The body-level mirror of the undocumented-route check.
+
+    Schema validation alone cannot see this: none of these objects sets
+    `additionalProperties: false`, so an extra top-level field is valid and
+    invisible. It is still an undocumented part of the public surface, and a
+    client written from the contract will never read it — which is how a field
+    ships, gets depended on by one consumer, and is then impossible to remove.
+
+    Top level only, on purpose. Recursing would demand a `properties` block for
+    every nested object including the deliberately open ones (`capabilities` is
+    `additionalProperties: {type: boolean}` by design), and a gate that fires on
+    a documented design decision is a gate that gets deleted.
+    """
+    response = client.request(method.upper(), path)
+    declared = _resolve_response((operation.get("responses") or {}).get(str(response.status_code)))
+    schema = ((declared or {}).get("content") or {}).get("application/json", {}).get("schema", {})
+    body = response.json()
+    if not isinstance(body, dict) or not isinstance(schema.get("properties"), dict):
+        pytest.skip(f"{path} {response.status_code} is not a described JSON object")
+
+    undeclared = sorted(set(body) - set(schema["properties"]))
+    assert not undeclared, (
+        f"{method.upper()} {path} returns top-level field(s) {undeclared} that "
+        f"{SPEC_PATH.name} does not describe. Add them to the schema or stop "
+        "returning them; an undocumented field is an undocumented public surface."
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. The failure half: every non-2xx is the declared envelope
+# --------------------------------------------------------------------------
+
+
+def _unmatched_api_path(client: TestClient):
+    """A path under the public namespace that no route claims."""
+    return client.get("/api/v1/no-such-resource-exists-here")
+
+
+def _wrong_method_on_a_contracted_path(client: TestClient):
+    """A method the contract does not declare for a path it does declare.
+
+    The path is taken from the document rather than named here, for the same
+    reason as everywhere else in this file.
+    """
+    path, _, _ = DRIVABLE[0]
+    return client.post(path)
+
+
+FAILURE_TRIGGERS = [
+    ("unmatched path under /api/v1", _unmatched_api_path),
+    ("method not allowed on a contracted path", _wrong_method_on_a_contracted_path),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "trigger"), FAILURE_TRIGGERS, ids=[label for label, _ in FAILURE_TRIGGERS]
+)
+def test_a_failure_response_is_the_declared_error_envelope(
+    client: TestClient, label: str, trigger
+) -> None:
+    """`Error` is a promise about *every* non-2xx, so it is checked against the schema.
+
+    `tests/integration/test_api_conventions.py` already asserts these two
+    triggers return a sane envelope — by checking fields it names in Python.
+    This asserts the same responses against `components.schemas.Error` as the
+    document declares it, which is the assertion that notices the document
+    gaining a required field the gateway does not send.
+    """
+    response = trigger(client)
+    assert 400 <= response.status_code < 600, (
+        f"{label} did not fail: HTTP {response.status_code}"
+    )
+
+    errors = sorted(
+        _validator(SPEC["components"]["schemas"]["Error"]).iter_errors(response.json()),
+        key=lambda e: list(e.path),
+    )
+    assert not errors, (
+        f"the body returned for {label} (HTTP {response.status_code}) is not the "
+        "`Error` envelope the contract promises for every non-2xx response: "
+        + "; ".join(f"{list(error.path) or '<root>'}: {error.message}" for error in errors[:5])
+    )

--- a/tests/contract/test_declared_examples_are_real.py
+++ b/tests/contract/test_declared_examples_are_real.py
@@ -108,6 +108,53 @@ def _resolve_response(response: Any) -> dict | None:
     return response
 
 
+def _declared_properties(schema: Any, seen: frozenset[str] = frozenset()) -> set[str] | None:
+    """Top-level property names a schema describes, following `$ref` and `allOf`.
+
+    `None` means "this schema genuinely describes no named properties" — a
+    free-form object, or a non-object — which is the only case that may be
+    skipped.
+
+    Council round 1: reading `schema["properties"]` directly returned `None` for
+    every `{"$ref": …}` and `{"allOf": […]}` response, and the test read that as
+    "not a described JSON object" and skipped. It *is* described. Every error
+    shape in this contract is one of those two, so a response could carry an
+    undeclared field — a server filesystem path, say, which
+    `docs/api/README.md` §"Fields that must never ship" calls the canonical trap
+    — and the check would step over it in silence.
+    """
+    if not isinstance(schema, dict):
+        return None
+
+    reference = schema.get("$ref")
+    if isinstance(reference, str):
+        if reference in seen:
+            return None  # a cycle; refuse rather than recurse forever
+        prefix = "#/components/schemas/"
+        if not reference.startswith(prefix):
+            return None
+        target = (SPEC.get("components") or {}).get("schemas", {}).get(
+            reference[len(prefix):]
+        )
+        return _declared_properties(target, seen | {reference})
+
+    names: set[str] = set()
+    found = False
+    if isinstance(schema.get("properties"), dict):
+        names |= set(schema["properties"])
+        found = True
+    # `allOf` is an AND: the object may carry the properties of every branch.
+    # `oneOf`/`anyOf` are deliberately not unioned — which branch applies
+    # depends on the value, so a union would silently permit fields from a
+    # branch this response is not.
+    for branch in schema.get("allOf") or []:
+        branch_names = _declared_properties(branch, seen)
+        if branch_names is not None:
+            names |= branch_names
+            found = True
+    return names if found else None
+
+
 def _declared_examples(media: dict) -> Iterator[tuple[str, Any]]:
     """Every example in one media-type object, `example` and `examples` alike."""
     if "example" in media:
@@ -118,28 +165,84 @@ def _declared_examples(media: dict) -> Iterator[tuple[str, Any]]:
 
 
 def _example_cases() -> list[tuple[str, dict, Any]]:
-    """(label, schema, example) for every response example the document declares."""
+    """(label, schema, example) for **every** example the document declares.
+
+    Council round 1: the first cut walked `paths.*.*.responses.*.content.*` and
+    nothing else, reaching 5 of the 24 example values in the document while both
+    `README.md` and `testing.md` told the mobile team it checked every one. The
+    19 it missed are the identifier and envelope examples — `Id`, `Timestamp`,
+    `Actor`, `Permission`, `PageInfo`, `Error` — which is precisely the set a
+    client author lifts as fixtures first.
+
+    Three shapes carry an example, and each validates against a different
+    schema: a media-type object's `example`/`examples` against the media type's
+    own schema; a schema's `examples` **list** against that schema; a
+    header's or parameter's `example` against its `schema`.
+    """
     cases: list[tuple[str, dict, Any]] = []
+
     for path, item in (SPEC.get("paths") or {}).items():
         if not isinstance(item, dict):
             continue
         for method, operation in item.items():
             if method.lower() not in OPERATIONS or not isinstance(operation, dict):
                 continue
+            where = f"{method.upper()} {path}"
+            body = operation.get("requestBody")
+            if isinstance(body, dict):
+                cases += _content_cases(body.get("content"), f"{where} requestBody")
+            for parameter in operation.get("parameters") or []:
+                cases += _keyed_example_cases(parameter, f"{where} parameter")
             for status, raw in (operation.get("responses") or {}).items():
                 response = _resolve_response(raw)
                 if not response:
                     continue
-                for media_type, media in (response.get("content") or {}).items():
-                    schema = (media or {}).get("schema")
-                    if not isinstance(schema, dict):
-                        continue
-                    for label, value in _declared_examples(media):
-                        cases.append(
-                            (f"{method.upper()} {path} {status} {media_type} {label}",
-                             schema, value)
-                        )
+                cases += _content_cases(response.get("content"), f"{where} {status}")
+                for name, header in (response.get("headers") or {}).items():
+                    cases += _keyed_example_cases(header, f"{where} {status} header {name}")
+
+    components = SPEC.get("components") or {}
+    for name, schema in (components.get("schemas") or {}).items():
+        # A *schema* `examples` is a plain list of values, not a map of example
+        # objects — a different shape from the media-type keyword of the same
+        # name, and the reason a single helper missed it.
+        if isinstance(schema, dict) and isinstance(schema.get("examples"), list):
+            for index, value in enumerate(schema["examples"]):
+                cases.append((f"components.schemas.{name} examples[{index}]", schema, value))
+    for group in ("headers", "parameters"):
+        for name, entry in (components.get(group) or {}).items():
+            cases += _keyed_example_cases(entry, f"components.{group}.{name}")
+    for name, body in (components.get("requestBodies") or {}).items():
+        if isinstance(body, dict):
+            cases += _content_cases(body.get("content"), f"components.requestBodies.{name}")
+
     return cases
+
+
+def _content_cases(content: Any, where: str) -> list[tuple[str, dict, Any]]:
+    """Examples on a media-type object, validated against that media type's schema."""
+    cases: list[tuple[str, dict, Any]] = []
+    if not isinstance(content, dict):
+        return cases
+    for media_type, media in content.items():
+        schema = (media or {}).get("schema")
+        if not isinstance(schema, dict) or not isinstance(media, dict):
+            continue
+        for label, value in _declared_examples(media):
+            cases.append((f"{where} {media_type} {label}", schema, value))
+    return cases
+
+
+def _keyed_example_cases(entry: Any, where: str) -> list[tuple[str, dict, Any]]:
+    """Examples on a header or parameter, validated against its own `schema`."""
+    if not isinstance(entry, dict):
+        return []
+    schema = entry.get("schema")
+    if not isinstance(schema, dict):
+        return []
+    return [
+        (f"{where} {label}", schema, value) for label, value in _declared_examples(entry)
+    ]
 
 
 EXAMPLE_CASES = _example_cases()
@@ -246,6 +349,33 @@ def test_at_least_one_operation_can_be_driven() -> None:
     )
 
 
+def test_the_undeclared_field_check_is_not_skipping_everything(client: TestClient) -> None:
+    """The third anti-vacuity guard, and the one that was missing.
+
+    `test_the_gateway_returns_no_field_the_contract_omits` ends in
+    `pytest.skip` when it cannot find the declared property names. A skip is
+    green, and a parametrized suite that skips every case looks exactly like one
+    that passed — which is how, in council round 1, the check turned out to be
+    stepping over every `$ref` and `allOf` response in the contract while
+    reporting no skips at all (pytest counts a skip inside a passed run quietly).
+    This asserts that at least one case really compared something.
+    """
+    compared = 0
+    for path, method, operation in DRIVABLE:
+        response = client.request(method.upper(), path)
+        declared = _resolve_response(
+            (operation.get("responses") or {}).get(str(response.status_code))
+        )
+        schema = ((declared or {}).get("content") or {}).get("application/json", {}).get("schema", {})
+        if isinstance(response.json(), dict) and _declared_properties(schema) is not None:
+            compared += 1
+    assert compared, (
+        "every drivable operation skipped the undeclared-field check, so it "
+        "compared nothing. Either no response is a described JSON object, or "
+        "`_declared_properties` stopped resolving the contract's schemas."
+    )
+
+
 @pytest.mark.parametrize(
     ("path", "method", "operation"), DRIVABLE, ids=[f"{p}" for p, _, _ in DRIVABLE]
 )
@@ -303,10 +433,11 @@ def test_the_gateway_returns_no_field_the_contract_omits(
     declared = _resolve_response((operation.get("responses") or {}).get(str(response.status_code)))
     schema = ((declared or {}).get("content") or {}).get("application/json", {}).get("schema", {})
     body = response.json()
-    if not isinstance(body, dict) or not isinstance(schema.get("properties"), dict):
+    properties = _declared_properties(schema)
+    if not isinstance(body, dict) or properties is None:
         pytest.skip(f"{path} {response.status_code} is not a described JSON object")
 
-    undeclared = sorted(set(body) - set(schema["properties"]))
+    undeclared = sorted(set(body) - properties)
     assert not undeclared, (
         f"{method.upper()} {path} returns top-level field(s) {undeclared} that "
         f"{SPEC_PATH.name} does not describe. Add them to the schema or stop "

--- a/tests/contract/test_docs_match_the_runtime.py
+++ b/tests/contract/test_docs_match_the_runtime.py
@@ -25,6 +25,7 @@ from gateway.app.main import app
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 API_README = REPO_ROOT / "docs" / "api" / "README.md"
+API_TESTING = REPO_ROOT / "docs" / "api" / "testing.md"
 CODEMAP = REPO_ROOT / "docs" / "codemap.md"
 
 
@@ -205,3 +206,87 @@ def test_the_api_readme_does_not_deny_the_publication_machinery_that_ships(denia
         f"docs/api/README.md still says {denial!r}, while contract/ publishes "
         f"{published} and both contract scripts exist"
     )
+
+
+def _contract_test_files() -> list[str]:
+    return sorted(
+        path.name for path in (REPO_ROOT / "tests" / "contract").glob("test_*.py")
+    )
+
+
+def test_the_testing_doc_counts_the_gates_that_exist() -> None:
+    """`docs/api/testing.md` enumerates the gates; the enumeration must be true.
+
+    Council round 1: the heading said "The four gates" over a five-row table
+    while `tests/contract/` held six files, and the one missing from both it and
+    `README.md` was `test_proxy_routes.py` — which is also the gate the same
+    document went on to deny existed. A count is the cheapest thing in a
+    document to leave behind, and this file is `docs/required-reading.md`'s
+    **obrigatório** reading for anyone touching the contract.
+    """
+    files = _contract_test_files()
+    prose = " ".join(API_TESTING.read_text(encoding="utf-8").split())
+    spelled = {4: "four", 5: "five", 6: "six", 7: "seven", 8: "eight"}[len(files)]
+
+    assert f"## The {spelled} gates" in prose, (
+        f"tests/contract/ holds {len(files)} gate files {files}, and "
+        f"docs/api/testing.md does not say \"The {spelled} gates\". Update the "
+        "heading and the table together."
+    )
+    missing = [name for name in files if name not in prose]
+    assert not missing, (
+        f"docs/api/testing.md's gate table does not name {missing}. A reader "
+        "uses it as the enumeration it claims to be."
+    )
+
+
+@pytest.mark.parametrize(
+    "denial",
+    [
+        # Said while `test_proxy_routes.py` asserted precisely the opposite.
+        "end-to-end reachability of a contracted route is not verified by this repository's tests.**",
+        # Cited the Incus edge, retired 2026-08-10, as the live front door.
+        "the nginx edge in `deploy/incus/` decides separately what it forwards",
+        # Claimed an immutability `publish()` does not provide.
+        "editing `contract/1.6.0/…` in place fails rather than quietly rewriting what a client already pinned. Ship a new version instead.",
+        # Claimed the mobile repository already consumes the artifact.
+        "`EDortta/CodexBridgeMobile` fetches that directory and verifies the digest",
+    ],
+)
+def test_the_contract_docs_do_not_deny_what_ships(denial: str) -> None:
+    """Sentences that were false when written, pinned so they cannot come back.
+
+    Same mechanism as the rate-limiter denials above and the same reason: each
+    of these was a statement about machinery, in the document a contract author
+    or the mobile team reaches for first, that the code contradicted.
+
+    Preconditions asserted, not assumed — a denial is only stale while the thing
+    it denies is really there.
+    """
+    assert (REPO_ROOT / "tests" / "contract" / "test_proxy_routes.py").is_file()
+    assert (REPO_ROOT / "deploy" / "nginx").is_dir(), "the live vhosts moved"
+    assert "RETIRED" in (
+        REPO_ROOT / "deploy" / "incus" / "codexbridge_edge_proxy.py"
+    ).read_text(encoding="utf-8")[:200]
+
+    for document in _contract_prose_documents():
+        prose = " ".join(document.read_text(encoding="utf-8").split())
+        assert denial not in prose, (
+            f"{document.relative_to(REPO_ROOT)} still says {denial!r}, and it is "
+            "not true of the code in this commit."
+        )
+
+
+def _contract_prose_documents() -> list[Path]:
+    """Every document that describes the contract machinery in prose.
+
+    Council round 2: the denial loop covered `README.md` and `testing.md`, and
+    the issue's own `RESUME.md` — added by the same commit that retired those
+    sentences — reinstated one of them (`deploy/incus/`) plus stale test counts.
+    A handoff note is the first thing the next agent reads; leaving it outside
+    the gate that polices the other two is the asymmetric-robustness shape
+    `design-standards.md` §3 warns about.
+    """
+    documents = [API_README, API_TESTING]
+    documents += sorted((REPO_ROOT / "docs" / "issues").rglob("RESUME.md"))
+    return documents

--- a/tests/contract/test_docs_match_the_runtime.py
+++ b/tests/contract/test_docs_match_the_runtime.py
@@ -165,3 +165,43 @@ def test_the_api_readme_does_not_deny_the_limiter_that_ships(denial: str) -> Non
         f"docs/api/README.md still says {denial!r}, while {len(limited)} served "
         "/api routes carry RateLimitDependency"
     )
+
+
+@pytest.mark.parametrize(
+    "denial",
+    [
+        # §"Getting the contract to the mobile repository", before issue #14.
+        "Today there is none",
+        "Nothing publishes it, nothing checksums it",
+        # §Versioning.
+        "Nothing enforces this today",
+        # §"What the gate does not cover".
+        "Body-level conformance is issue #14's scope. Until it lands",
+        "nobody reads the `info.version` field as a working pin before #14 lands",
+    ],
+)
+def test_the_api_readme_does_not_deny_the_publication_machinery_that_ships(denial: str) -> None:
+    """§"Getting the contract to the mobile repository" described its own absence.
+
+    It was written when "a consumer copies it by hand" was true, and it is the
+    section a mobile developer reads *first* when asking how to get the
+    contract. Left alone after issue #14, it would send that reader to copy the
+    file by hand while a published, checksummed, pinnable artifact sat in
+    `contract/` — the exact failure §"Rate limiting" already had once, in the
+    document a client author reaches for.
+
+    The precondition is asserted, not assumed: these sentences are only stale if
+    the machinery that makes them false is really there.
+    """
+    published = sorted(
+        path.name for path in (REPO_ROOT / "contract").glob("*") if path.is_dir()
+    )
+    assert published, "nothing is published under contract/; the denials are not stale yet"
+    for script in ("publish_contract.py", "check_contract_compatibility.py"):
+        assert (REPO_ROOT / "scripts" / script).is_file(), f"scripts/{script} is missing"
+
+    prose = " ".join(API_README.read_text(encoding="utf-8").split())
+    assert denial not in prose, (
+        f"docs/api/README.md still says {denial!r}, while contract/ publishes "
+        f"{published} and both contract scripts exist"
+    )

--- a/tests/contract/test_published_contract_artifact.py
+++ b/tests/contract/test_published_contract_artifact.py
@@ -1,0 +1,238 @@
+"""The pinned contract artifact `EDortta/CodexBridgeMobile` consumes.
+
+`test_openapi_document.py` guards the *gateway ↔ document* pair. This file
+guards the *document ↔ published artifact* pair, which is the half
+`docs/api/README.md` §"Getting the contract to the mobile repository" recorded as
+unguarded: the document lived here, a consumer copied it by hand, nothing
+checksummed it, and `info.version` was a number a client could pin without any
+guarantee that the bytes behind it would still be the same tomorrow.
+
+Two failures, deliberately kept apart because the remedies are opposite:
+
+- the published copy is **behind** the document — regenerate it
+  (`python3 scripts/publish_contract.py`);
+- a **previously published** version no longer hashes to its own manifest — a
+  pinned artifact was edited after the fact, and regenerating would erase the
+  evidence rather than fix anything.
+
+The script is exercised as a subprocess, the same way
+`tests/unit/test_apply_migrations.py` exercises the migration runner: the thing
+CI runs is the thing under test, argument parsing and exit code included.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "publish_contract.py"
+SPEC_PATH = REPO_ROOT / "docs" / "api" / "codex-bridge.openapi.yaml"
+CONTRACT_DIR = REPO_ROOT / "contract"
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict:
+    return yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))
+
+
+def test_the_publisher_exists_and_runs() -> None:
+    """If the script moves, every other test here would pass vacuously."""
+    assert SCRIPT.is_file(), f"the contract publisher is missing: {SCRIPT}"
+    assert run("--help").returncode == 0
+
+
+def test_the_published_artifact_matches_the_current_document() -> None:
+    """A merged contract change that never reached `contract/` is drift.
+
+    This is the acceptance criterion "pull requests fail when implementation
+    diverges from the published contract", on the publication side: the gateway
+    and the document are already bound to each other, and this binds the
+    document to the copy the mobile repository actually downloads.
+    """
+    result = run("--check")
+    assert result.returncode == 0, (
+        "the published contract is out of step with the document:\n"
+        f"{result.stderr}{result.stdout}"
+    )
+
+
+def test_the_current_version_is_published(spec: dict) -> None:
+    """`info.version` must name a directory a client can fetch.
+
+    Asserted separately from `--check` so that a publisher which silently
+    stopped writing version directories fails here by name rather than as a
+    confusing byte diff.
+    """
+    version = spec["info"]["version"]
+    published = CONTRACT_DIR / version / "codex-bridge.openapi.yaml"
+    assert published.is_file(), (
+        f"the contract is at {version} and nothing is published under "
+        f"contract/{version}/. Run `python3 scripts/publish_contract.py`."
+    )
+
+
+def test_the_index_names_the_current_version_as_latest(spec: dict) -> None:
+    """The pointer a consumer follows when it has not pinned yet."""
+    index = json.loads((CONTRACT_DIR / "index.json").read_text(encoding="utf-8"))
+    assert index["latest"] == spec["info"]["version"]
+    assert spec["info"]["version"] in index["versions"]
+
+
+def test_a_published_version_is_byte_identical_to_the_document(spec: dict) -> None:
+    """Not "equivalent YAML" — identical bytes.
+
+    A consumer verifies a SHA-256. Re-serialising the document on the way out
+    would produce a file that parses the same and hashes differently on every
+    PyYAML upgrade, so the digest would stop identifying the content and start
+    identifying the toolchain.
+    """
+    version = spec["info"]["version"]
+    published = CONTRACT_DIR / version / "codex-bridge.openapi.yaml"
+    assert published.read_bytes() == SPEC_PATH.read_bytes()
+
+
+def test_every_published_version_hashes_to_its_manifest() -> None:
+    """The property that makes a pin worth pinning.
+
+    Re-implemented here rather than delegated to `--check`, because a bug in the
+    script's own digest comparison would make `--check` green and this test is
+    what says so independently.
+    """
+    import hashlib
+
+    versions = sorted(path for path in CONTRACT_DIR.iterdir() if path.is_dir())
+    assert versions, "no contract version is published at all"
+    for version_dir in versions:
+        manifest = json.loads((version_dir / "manifest.json").read_text(encoding="utf-8"))
+        document = version_dir / "codex-bridge.openapi.yaml"
+        digest = hashlib.sha256(document.read_bytes()).hexdigest()
+        assert manifest["sha256"] == digest, (
+            f"contract/{version_dir.name}/ was edited after publication: the "
+            f"manifest records {manifest['sha256']}, the file hashes to {digest}. "
+            "Publish a new version rather than rewriting one a client has pinned."
+        )
+        assert manifest["contractVersion"] == version_dir.name
+
+
+# --------------------------------------------------------------------------
+# The gate has to be able to fail, or it is decoration
+# --------------------------------------------------------------------------
+
+
+def _isolated_tree(tmp_path: Path) -> tuple[Path, Path]:
+    """A copy of the document and the published artifact, safe to corrupt."""
+    source = tmp_path / "codex-bridge.openapi.yaml"
+    shutil.copyfile(SPEC_PATH, source)
+    output = tmp_path / "contract"
+    shutil.copytree(CONTRACT_DIR, output)
+    return source, output
+
+
+def test_check_reports_a_document_that_moved_ahead_of_the_artifact(tmp_path: Path) -> None:
+    """Change the document, do not republish: the check must name the stale file."""
+    source, output = _isolated_tree(tmp_path)
+    source.write_text(
+        source.read_text(encoding="utf-8").replace(
+            "summary: Contract-first HTTP API consumed by CodexBridgeMobile.",
+            "summary: Something else entirely.",
+        ),
+        encoding="utf-8",
+    )
+
+    result = run("--check", "--source", str(source), "--output", str(output))
+    assert result.returncode == 1
+    assert "stale" in result.stderr
+    assert "codex-bridge.openapi.yaml" in result.stderr
+    assert "scripts/publish_contract.py" in result.stderr
+
+
+def test_check_reports_a_published_version_edited_after_the_fact(tmp_path: Path) -> None:
+    """Rewriting a pinned version is the failure the digest exists to catch."""
+    source, output = _isolated_tree(tmp_path)
+    version = yaml.safe_load(source.read_text(encoding="utf-8"))["info"]["version"]
+    published = output / version / "codex-bridge.openapi.yaml"
+    published.write_text(published.read_text(encoding="utf-8") + "\n# tampered\n", encoding="utf-8")
+
+    result = run("--check", "--source", str(source), "--output", str(output))
+    assert result.returncode == 1
+    assert "edited after publication" in result.stderr
+    assert version in result.stderr
+
+
+def test_check_reports_a_contract_that_was_never_published(tmp_path: Path) -> None:
+    source = tmp_path / "codex-bridge.openapi.yaml"
+    shutil.copyfile(SPEC_PATH, source)
+
+    result = run("--check", "--source", str(source), "--output", str(tmp_path / "nowhere"))
+    assert result.returncode == 1
+    assert "never been published" in result.stderr
+
+
+def test_publishing_a_new_version_leaves_the_old_one_untouched(tmp_path: Path) -> None:
+    """A pin survives the next release, or it was never a pin.
+
+    Publishing `9.9.9` must add a directory and change nothing inside the
+    version a client already downloaded — including its digest.
+    """
+    source, output = _isolated_tree(tmp_path)
+    current = yaml.safe_load(source.read_text(encoding="utf-8"))["info"]["version"]
+    before = (output / current / "codex-bridge.openapi.yaml").read_bytes()
+    before_manifest = (output / current / "manifest.json").read_bytes()
+
+    source.write_text(
+        source.read_text(encoding="utf-8").replace(f"version: {current}", "version: 9.9.9", 1),
+        encoding="utf-8",
+    )
+    result = run("--source", str(source), "--output", str(output))
+    assert result.returncode == 0, result.stderr
+
+    assert (output / current / "codex-bridge.openapi.yaml").read_bytes() == before
+    assert (output / current / "manifest.json").read_bytes() == before_manifest
+    assert (output / "9.9.9" / "codex-bridge.openapi.yaml").is_file()
+
+    index = json.loads((output / "index.json").read_text(encoding="utf-8"))
+    assert index["latest"] == "9.9.9"
+    assert current in index["versions"]
+
+    # And the whole artifact is self-consistent again afterwards.
+    assert run("--check", "--source", str(source), "--output", str(output)).returncode == 0
+
+
+def test_publishing_is_deterministic(tmp_path: Path) -> None:
+    """Two runs over one input produce identical bytes.
+
+    `--check` compares a regenerated artifact against the committed one, so a
+    timestamp, a hostname or a dict iteration order in the output would make the
+    gate fire on every run — and a gate that cries wolf is a gate that gets
+    deleted rather than obeyed.
+    """
+    source = tmp_path / "codex-bridge.openapi.yaml"
+    shutil.copyfile(SPEC_PATH, source)
+    first, second = tmp_path / "a", tmp_path / "b"
+
+    assert run("--source", str(source), "--output", str(first)).returncode == 0
+    assert run("--source", str(source), "--output", str(second)).returncode == 0
+
+    files = sorted(path.relative_to(first) for path in first.rglob("*") if path.is_file())
+    assert files
+    for relative in files:
+        assert (first / relative).read_bytes() == (second / relative).read_bytes(), (
+            f"{relative} differs between two runs over the same document"
+        )

--- a/tests/contract/test_published_contract_artifact.py
+++ b/tests/contract/test_published_contract_artifact.py
@@ -105,6 +105,13 @@ def test_a_published_version_is_byte_identical_to_the_document(spec: dict) -> No
     """
     version = spec["info"]["version"]
     published = CONTRACT_DIR / version / "codex-bridge.openapi.yaml"
+    # Guarded rather than read straight: on a release commit that moved
+    # `info.version` before running the publisher, reading it raised a bare
+    # `FileNotFoundError` with no remedy in it.
+    assert published.is_file(), (
+        f"contract/{version}/ does not exist. Run "
+        "`python3 scripts/publish_contract.py` and commit the result."
+    )
     assert published.read_bytes() == SPEC_PATH.read_bytes()
 
 
@@ -137,9 +144,24 @@ def test_every_published_version_hashes_to_its_manifest() -> None:
 
 
 def _isolated_tree(tmp_path: Path) -> tuple[Path, Path]:
-    """A copy of the document and the published artifact, safe to corrupt."""
+    """A copy of the document and the published artifact, safe to corrupt.
+
+    Fails with the remedy when the current version is not published yet.
+    Without this, a release commit that moved `info.version` before running the
+    publisher made three tests here die with a bare `FileNotFoundError` naming a
+    path under `/tmp` — two of them tests of the *publisher's own* behaviour,
+    failing for a reason that has nothing to do with what they assert. Council
+    round 1 walked a sibling merge and read exactly that output.
+    """
     source = tmp_path / "codex-bridge.openapi.yaml"
     shutil.copyfile(SPEC_PATH, source)
+    version = yaml.safe_load(SPEC_PATH.read_text(encoding="utf-8"))["info"]["version"]
+    if not (CONTRACT_DIR / version / "codex-bridge.openapi.yaml").is_file():
+        pytest.fail(
+            f"the contract is at {version} and contract/{version}/ does not "
+            "exist, so this test has nothing to work from. Run "
+            "`python3 scripts/publish_contract.py` and commit the result."
+        )
     output = tmp_path / "contract"
     shutil.copytree(CONTRACT_DIR, output)
     return source, output


### PR DESCRIPTION
Closes the anti-drift machinery issue #4's own `docs/api/README.md` §"Getting the contract to the mobile repository" named as #14's scope. **No runtime code touched; `info.version` and `API_CONTRACT_VERSION` left at 1.6.0** so this rides alongside the #11/#13 branches without a version collision.

## What was already met vs added

- **PRs fail on divergence** — route-inventory drift already existed (`test_openapi_document.py`); this adds **body-level** conformance: the 24 declared examples vs their schemas, live response bodies vs declared schemas, failures vs `components/schemas/Error`.
- **Machine-consumable pinned artifact** — new `scripts/publish_contract.py` emits a byte-identical copy + SHA-256 manifest per version under `contract/<version>/`; `--check` regenerates in tmp and diffs (fails on drift).
- **Breaking-change gate** — `x-minimum-supported-version` in the document + `scripts/check_contract_compatibility.py`; every finding is a JSON pointer.
- **Mock/fixture docs** — `docs/api/testing.md`.

## Council (two rounds, recorded in `docs/issues/014-.../`)

- R1: 26 raised / 26 survived §2 / 24 became tests / 4 questions
- R2: 6 / 6 / 2 / 4

Headline fix: the compatibility gate reported 31 false "breaking" changes against `feature/gh-11` and 21 against `feature/gh-13` (a new-but-constrained field read as a tightening; OpenAPI forcing `required:true` on path params). **Both are 0 now, measured against the real branches.**

## Checks

Full suite **652 passed, 3 skipped** (up from 561/3); `tests/contract` 128 (up from 26).

## Merge note for the operator

Whoever merges **#11 or #13** must run `python3 scripts/publish_contract.py` and commit `contract/`, and must **not** silence a red compatibility gate by raising the floor — a test now refuses that without a written reason. Not validated: Postgres; any deployment; authenticated-endpoint bodies; the `prism` mock line.

Do not merge / do not close #14 — operator merges and closes.
