### PR TITLE
feat(gh-13): mobile event stream (SSE) and notification preferences (contract 1.8.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,24 @@ CODEX_BRIDGE_MCP_AUTH_MODE=oauth
 CODEX_BRIDGE_MCP_BEARER_TOKEN=replace-with-strong-random-token
 CODEX_BRIDGE_OAUTH_ALLOWED_CLIENT_IDS=chatgpt-codexbridge
 CODEX_BRIDGE_OAUTH_ALLOWED_REDIRECT_URI_PREFIXES=https://chatgpt.com,https://chat.openai.com,https://auth.openai.com
-CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES=codexbridge.read codexbridge.task.submit codexbridge.task.cancel
+# The server-side scope allowlist. Sign-in issues `user.scopes & this`, so a
+# scope missing here can never be granted, however `users.json` is edited — the
+# endpoint that needs it answers 403 for every non-admin, permanently.
+#
+# Setting this variable REPLACES the default in `gateway/app/core/config.py`
+# wholesale; it does not merge. That is why the full list is spelled out rather
+# than the three the first version of this file carried: issues #8, #10 and #13
+# each added a scope to `config.py` and not to this template, so a deployment
+# built from it had `issues.write`, `conversations.write` and
+# `notifications.manage` silently ungrantable. Keep this line and
+# `Settings.oauth_default_scopes` in step —
+# `tests/integration/test_events.py::test_the_env_template_can_grant_every_scope_the_catalogue_needs`
+# fails when they drift.
+#
+# `codexbridge.task.approve` is deliberately absent: approving a sensitive
+# session is a capability an operator adds here on purpose, not one every
+# signed-in phone receives.
+CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES=codexbridge.read codexbridge.task.submit codexbridge.task.cancel codexbridge.issues.write codexbridge.conversations.write codexbridge.notifications.manage
 CODEX_BRIDGE_OAUTH_ACCESS_TOKEN_TTL_SECONDS=3600
 CODEX_BRIDGE_OAUTH_AUTHORIZATION_CODE_TTL_SECONDS=600
 # Absolute lifetime of a mobile sign-in (POST /api/v1/auth/sign-in). Rotation

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -995,6 +995,205 @@ messages the issue's own test coverage requirement names.
 
 ---
 
+## Events and notifications (issue #13)
+
+`GET /api/v1/events/stream` (Server-Sent Events), `GET /api/v1/events` (the
+same events as an ordinary paged read), and `GET`/`PUT
+/api/v1/notifications/preferences`.
+
+### Why SSE, and why the polling endpoint is not a consolation prize
+
+SSE rather than WebSocket for three reasons, none of them "we had no
+WebSocket" — the gateway already speaks one at `/agent/ws`:
+
+- **Authentication.** Everything on this contract authenticates with
+  `Authorization: Bearer`. A browser or mobile WebSocket cannot set that
+  header on the handshake, so a WebSocket stream would need a second
+  authentication scheme: a token in the URL (forbidden — see
+  `.docs/agents/security-standards.md`) or a bespoke post-handshake auth
+  frame. SSE rides the scheme that already exists.
+- **Resume is in the transport.** `Last-Event-ID` is part of SSE. Issue #13's
+  "resume from the last acknowledged event" is the mechanism SSE was designed
+  around, with no application protocol on top.
+- **One direction is all this needs.** Nothing here asks the client to send
+  anything on the channel.
+
+`GET /api/v1/events` delivers the *same* events with the *same* ids. A client
+on a network that kills long-lived connections, or one in a background state
+where the platform will not hold a socket open, polls it and loses nothing.
+Both transports are first-class, and a client may move between them mid-stream
+because the position means the same thing on both.
+
+### The resume position is a public integer, not a cursor
+
+Every other collection here pages with an opaque signed cursor. This one does
+not, and that is deliberate rather than an oversight: the position is
+`Last-Event-ID`, which SSE puts on the wire and the client sends back
+verbatim. Wrapping the same position in an opaque cursor for the polling
+endpoint would publish two names for one place and make the two transports
+incompatible — a client could not hand a stream position to the fallback. The
+same reasoning `GET /api/v1/sessions/{sessionId}/logs` already applies to an
+append-only log.
+
+The id is monotonic but **not contiguous**: the underlying log also holds
+records that are never delivered as events. A skipped number is not a lost
+event. Loss is reported explicitly, and only explicitly — see below.
+
+`page.nextAfter` is the last id the page **loaded**, not the last id it
+returned. With a `type` filter the two differ, and reporting the last returned
+id would make the next request re-scan rows the filter already rejected —
+forever, when nothing in the tail matches.
+
+### No silent loss, in both directions
+
+Resume is `id > position`, so an event cannot be delivered twice or skipped
+while its record exists. The only way to lose one is for the record itself to
+be gone, and that is announced rather than papered over: the stream emits a
+`stream.gap` frame **before** delivering anything, and `GET /api/v1/events`
+returns a `gap` object beside its items. Delivering first and mentioning the
+gap afterwards would let a client act on a partial view believing it was
+continuous.
+
+Two reasons, and the second one matters as much as the first:
+
+- `beyond_retention` — the position's record is gone and the log moved past
+  it. `oldestAvailableId` says where to restart, because "you lost some" with
+  no position leaves a client guessing.
+- `cursor_ahead` — the position is beyond anything this log has ever held: a
+  position from another deployment, or a database restored from a backup older
+  than the client. Unsignalled, the stream would simply never deliver again,
+  which is the same silence in the other direction and much harder to diagnose
+  from a phone.
+
+Note what this build's retention actually does:
+`store.purge_expired_audit_events` deletes authentication rows and nothing
+else, so no domain event has ever been purged here and `beyond_retention`
+cannot be reached today. The signal exists so that a future retention policy
+over domain rows — an operator's decision, not this code's — cannot cause a
+silent loss the day it is switched on.
+
+### Authorization is by project, and it is re-checked while the stream runs
+
+A stream opened at 09:00 and still open at 17:00 authorized once, and
+everything after that was delivered on an eight-hour-old decision. This one
+re-resolves the bearer token on **every poll**: a revoked token, an expired
+token, a disabled account and a project removed from the actor's
+`allowedProjects` all take effect within one poll interval. The first three end
+the stream with `stream.closed` and `reason: unauthenticated`; the fourth
+simply stops delivering that project. **A client must not treat an open
+connection as proof it is still authorized.**
+
+Project scope is enforced on the query, like everywhere else here, so a page is
+never a filtered-down view of rows the caller was allowed to load. `?project=`
+only ever *narrows*: naming a project outside `allowedProjects` matches
+nothing.
+
+An event whose project cannot be derived is delivered to **nobody**,
+administrators included. `audit_events` has no project column — a row's project
+comes from the entity it names — and an event that belongs to no project cannot
+honestly be shown as belonging to one. Fail closed: an entity type nothing
+teaches the derivation about is invisible until someone does.
+
+### Authentication and security events are not on this surface at all
+
+Sign-in, failed sign-in and credential revocation are recorded in the same
+audit log these events are derived from. They are **excluded by construction**,
+not by a filter someone has to remember: they carry a user id where a project
+would be, so they are outside the set of entity types this surface can deliver.
+Streaming them would tell any token holder — including one belonging to a
+different person — when the operator signs in. Notification-preference changes
+are excluded the same way.
+
+### The summary is a whitelist; the stored payload never ships
+
+The internal audit payload is written by eleven call sites that were never
+audited for what they may contain: `actor_email`, `requested_by_email`,
+free-text `reason` and `error` strings from an executor, `context` blobs.
+§"Fields that must never ship" applies to every byte of it and no existing
+sanitizer covers a response body.
+
+So it is never passed through. Each event type names the handful of payload
+keys it may read, free text goes through the same `redact` the session-log
+endpoint uses and is truncated to a notification line, and a key nobody
+whitelisted does not leave the process. Adding a field to an audit payload
+therefore cannot leak it — the default is exclusion. Treat `summary` as a
+notification line, never as data: fetch the entity for authoritative state.
+
+### One change is one event, not three
+
+A session, a mission and a decision are three vocabularies over the same
+underlying row (§"Missions (issue #7)"). This surface does not triple every
+event to match. It emits one, with `entity.kind` naming the vocabulary that
+fits what happened — `decision` for the approval lifecycle, `session` for the
+run's own — and the id is the same id, so `GET /api/v1/sessions/{id}` and
+`GET /api/v1/missions/{id}` both accept it.
+
+One audit record forks on its content: a submission held for approval is a
+`decision.requested`, and every other submission is a `session.created`. Both
+are the same recorded row, so the fork lives in one place rather than in a
+second writer nobody would remember to call.
+
+### `MobileEventType` is closed, and already declares what #11 will emit
+
+A client may switch over it exhaustively, which makes adding a value a
+breaking change under §"What is a breaking change". `artifact.created`,
+`artifact.updated` and `androidBuild.status_changed` are therefore declared
+**now**, by a build that produces none of them — there is no artifact or
+Android build record until issue #11. Declaring them costs a client nothing
+(they never arrive) and saves a `v2` when they do. A `?type=` filter naming one
+is accepted and matches nothing, rather than answering `400`; rejecting it
+would make the declared values unusable, which is the opposite of why they were
+declared.
+
+### Notification preferences are a hook, not a filter
+
+`GET`/`PUT /api/v1/notifications/preferences` is one document per actor,
+always the caller's own — there is no `userId` parameter and no administrator
+override, because a preference document is personal data and an endpoint that
+could read another account's would be a disclosure with no product behind it.
+
+**There is no push transport in this build.** `pushDeliveryAvailable` is
+`false` and nothing reads these rows to decide delivery. They are stored so the
+choice survives a reinstall and so a later push integration has something to
+read.
+
+**They do not filter `GET /api/v1/events/stream`.** A client that opened the
+stream asked for the stream; withholding events from it because of a preference
+set on another device is how a phone silently misses the decision its operator
+was waiting for — and the failure would be indistinguishable from a quiet
+system. Narrow a live connection with that endpoint's `?type=` instead, which
+is per-connection state and cannot change underneath it.
+
+`PUT` is a whole-document replacement, so it is idempotent by construction:
+there is no `Idempotency-Key` (nothing to duplicate) and no `ETag`/`If-Match`
+(the only writer of a row is the actor it belongs to, so there is no concurrent
+third party for an optimistic check to protect against — the same reasoning
+§"No `revision`, no `ETag`, no `If-Match`" gives for conversations). Reading
+needs only `codexbridge.read`; writing needs
+`codexbridge.notifications.manage`, separate on purpose so an operator can
+grant a phone the stream without granting it the ability to rewrite what the
+account is notified about.
+
+### Limits, and what the rate limiter does not bound
+
+The limiter counts requests per window. One accepted request to
+`/events/stream` becomes a connection held open for minutes that takes a
+database session on every poll, so the endpoint that is cheapest per request is
+the one that can exhaust the pool the rest of the API shares. The gateway
+therefore bounds how many streams it holds open at once and answers `503` with
+`Retry-After` at that ceiling — refusing rather than queueing, because a
+refused client reconnects with its `Last-Event-ID` and loses nothing while a
+queued one holds the connection it was refused for. Each stream's lifetime is
+bounded too, and ends with `stream.closed` and `reason: max_duration`; every
+ending is a reconnect, and every reconnect is exact.
+
+`?type=` is validated before the first byte. Once a `text/event-stream` body
+has started there is no status code left to change, and a client that
+misspelled a filter would otherwise see an open, empty, permanently silent
+connection instead of a `400`.
+
+---
+
 ## Cross-cutting rules every endpoint inherits
 
 Implemented in `gateway/app/api/` (issue #12). An endpoint does not re-invent

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1106,7 +1106,7 @@ are excluded the same way.
 
 ### The summary is a whitelist; the stored payload never ships
 
-The internal audit payload is written by eleven call sites that were never
+The internal audit payload is written by thirty-one call sites that were never
 audited for what they may contain: `actor_email`, `requested_by_email`,
 free-text `reason` and `error` strings from an executor, `context` blobs.
 §"Fields that must never ship" applies to every byte of it and no existing
@@ -1163,6 +1163,20 @@ set on another device is how a phone silently misses the decision its operator
 was waiting for — and the failure would be indistinguishable from a quiet
 system. Narrow a live connection with that endpoint's `?type=` instead, which
 is per-connection state and cannot change underneath it.
+
+**A session that predates the scope grant keeps a token that cannot write.** A
+principal's scopes are snapshotted into the token row at sign-in, and
+`POST /api/v1/auth/refresh` rotates with `granted & user.scopes &
+server_allowlist` — an intersection, so it can only ever narrow. Adding
+`codexbridge.notifications.manage` to an account therefore does **not** reach a
+phone that is already signed in: it keeps answering `403` on this endpoint,
+through every refresh, until the absolute session lifetime expires or the user
+signs in again. That is the deliberate behaviour of a rotation that never
+escalates — a stolen refresh token must not be able to widen itself — and the
+cost is stated here rather than discovered. An operator granting a new scope to
+an existing user should expect to tell them to sign in again; a client seeing
+`403` on an action `GET /api/v1/auth/me` also reports as not allowed should
+offer re-authentication, not an error.
 
 `PUT` is a whole-document replacement, so it is idempotent by construction:
 there is no `Idempotency-Key` (nothing to duplicate) and no `ETag`/`If-Match`

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -2144,6 +2144,7 @@ paths:
         '400': {$ref: '#/components/responses/ValidationFailed'}
         '401': {$ref: '#/components/responses/Unauthenticated'}
         '403': {$ref: '#/components/responses/PermissionDenied'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
 
@@ -2177,9 +2178,16 @@ paths:
         ```
 
         `stream.closed` carries a `reason`: `max_duration` (the server bounds
-        how long one connection lives — reconnect), `unauthenticated` (the
-        credential stopped being usable) or `disconnected`. Every ending is a
-        reconnect with `Last-Event-ID`, which is exact.
+        how long one connection lives — reconnect) or `unauthenticated` (the
+        credential stopped being usable while the stream was open). Those are
+        the only two, and both are a reconnect with `Last-Event-ID`, which is
+        exact.
+
+        A stream that ends because the **client** went away sends no frame at
+        all — there is nothing listening to send it to. A client must therefore
+        treat a body that simply ends as an ordinary ending and reconnect from
+        its last id, exactly as it would after `stream.closed`; it must not wait
+        for a closing frame that is not coming.
 
         ## Resume
 
@@ -2294,12 +2302,13 @@ paths:
         '400': {$ref: '#/components/responses/ValidationFailed'}
         '401': {$ref: '#/components/responses/Unauthenticated'}
         '403': {$ref: '#/components/responses/PermissionDenied'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
         '503':
           description: |
             The gateway is already holding as many event streams open as it
-            will. Retry after the interval in `Retry-After`, with
+            will, or this account already has as many open as it may. Retry after the interval in `Retry-After`, with
             `Last-Event-ID`; nothing is lost by waiting.
           headers:
             X-Request-Id:
@@ -2599,7 +2608,7 @@ paths:
                 application: codex-bridge-gateway
                 applicationVersion: '0.1.0'
                 apiVersions: [v1]
-                contractVersion: '1.3.0'
+                contractVersion: '1.8.0'
                 buildRevision: b76a391
                 capabilities:
                   errorEnvelope: true
@@ -4338,9 +4347,10 @@ components:
           description: |
             On `stream.gap`, an `EventGap.reason`. On `stream.closed`, why the
             server ended the stream: `max_duration` (the server bounds how long
-            one connection lives), `unauthenticated` (the credential stopped
-            being usable while the stream was open) or `disconnected`. Every
-            one of them is a reconnect with `Last-Event-ID`.
+            one connection lives) or `unauthenticated` (the credential stopped
+            being usable while the stream was open). Both are a reconnect with
+            `Last-Event-ID`. A stream the client itself dropped produces no
+            frame — see `GET /api/v1/events/stream`.
         oldestAvailableId:
           type: [integer, 'null']
           format: int64

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.6.0
+  version: 1.8.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -2079,6 +2079,330 @@ paths:
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
 
+  /api/v1/events:
+    get:
+      operationId: listEvents
+      tags: [events]
+      summary: Events the caller may see, oldest first, after a given id
+      description: |
+        The backlog behind `GET /api/v1/events/stream`, and the documented
+        **polling fallback** for it. Not a second-class path: the same events,
+        with the same ids, translated by the same code. A client on a network
+        that breaks long-lived connections, or one in a background state where
+        the platform will not keep a socket open, polls this and loses nothing.
+
+        **Addressed by `after`, not by a cursor.** Every other collection in
+        this contract pages with an opaque `cursor`; this one does not, because
+        its position is *public by necessity* — `id` is the SSE resume token
+        the stream puts in `id:` and the client sends back as
+        `Last-Event-ID`. Wrapping it in an opaque cursor as well would publish
+        two names for one position and make the two transports incompatible.
+        The same reasoning `GET /api/v1/sessions/{sessionId}/logs` already
+        applies to an append-only log.
+
+        Oldest first, like `GET /api/v1/missions/{missionId}/timeline`: a
+        client on this endpoint is catching up, and catching up reads forward.
+
+        `page.nextAfter` is the last id this page **loaded**, which is not
+        necessarily the last id it returned — with a `type` filter the two
+        differ. Pass it back as `after`; passing the last returned `id`
+        instead makes the next request re-scan rows the filter already
+        rejected.
+
+        `gap` is present only when `after` names a position the log can no
+        longer continue from — the polling form of the stream's `stream.gap`
+        frame. See `EventGap`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/EventsAfter'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/EventProject'
+        - $ref: '#/components/parameters/EventType'
+      responses:
+        '200':
+          description: A page of events, oldest first.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MobileEvent'
+                  page:
+                    $ref: '#/components/schemas/EventPageInfo'
+                  gap:
+                    $ref: '#/components/schemas/EventGap'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/events/stream:
+    get:
+      operationId: streamEvents
+      tags: [events]
+      summary: Live event stream (Server-Sent Events)
+      description: |
+        A `text/event-stream` body that stays open and delivers events as they
+        are recorded. SSE rather than WebSocket for three reasons, stated so a
+        client author does not have to guess: it rides the `Authorization:
+        Bearer` scheme every other endpoint here uses (a browser or mobile
+        WebSocket cannot set that header on the handshake, and a token in the
+        URL is forbidden); `Last-Event-ID` puts exact resume in the transport
+        rather than in an application protocol on top; and nothing in this
+        feature needs a reverse channel.
+
+        ## Frames
+
+        Only entity events carry `id:`. A control frame deliberately does not,
+        because `Last-Event-ID` must never advance past an event the client
+        actually received.
+
+        ```
+        event: stream.open        (no id) the stream is open, from this position
+        event: stream.gap         (no id) resume is not continuous — re-read
+        event: <MobileEventType>  id: <n>  the events themselves, data is MobileEvent
+        : keep-alive              a comment, so a proxy does not time out an idle stream
+        event: stream.closed      (no id) why the server ended it
+        ```
+
+        `stream.closed` carries a `reason`: `max_duration` (the server bounds
+        how long one connection lives — reconnect), `unauthenticated` (the
+        credential stopped being usable) or `disconnected`. Every ending is a
+        reconnect with `Last-Event-ID`, which is exact.
+
+        ## Resume
+
+        Send `Last-Event-ID` (an `EventSource` does this by itself) or `after`.
+        The header wins when both are present: it is what a reconnecting client
+        sends automatically and it is the more recent of the two by
+        construction. A malformed `Last-Event-ID` is treated as absent rather
+        than rejected — the user agent sets it, not the application.
+
+        Resume is `id > position`, so an event cannot be delivered twice or
+        skipped. If the position can no longer be continued from, the stream
+        opens with `stream.gap` **before** delivering anything, so a client
+        never acts on a partial view believing it was continuous.
+
+        ## Authorization is re-checked while the stream runs
+
+        A stream opened this morning and still open this afternoon authorized
+        once. This one re-resolves the bearer token on every poll: a revoked
+        token, an expired token, a disabled account and a project removed from
+        the actor's `allowedProjects` all take effect within one poll interval,
+        and the stream ends with `stream.closed` and `reason:
+        unauthenticated`. A client must not treat an open connection as proof
+        it is still authorized.
+
+        ## What never appears here
+
+        Authentication and security events. Sign-in, sign-in failure and
+        credential revocation are recorded in the same audit log these events
+        are derived from, and they are excluded by construction — streaming
+        them would tell any token holder when an operator signs in. Neither do
+        events whose project cannot be determined: they are delivered to
+        nobody, administrators included.
+
+        Preferences set through `PUT /api/v1/notifications/preferences` do
+        **not** filter this stream. Narrow a connection with `?type=` instead.
+
+        ## Limits
+
+        The gateway bounds how many streams it holds open at once and answers
+        `503` with `Retry-After` when it is at that ceiling; reconnect with
+        `Last-Event-ID` and nothing is lost. `?type=` is validated before the
+        first byte, because once an event-stream body has started there is no
+        status code left to change.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/EventsAfter'
+        - $ref: '#/components/parameters/EventProject'
+        - $ref: '#/components/parameters/EventType'
+        - name: Last-Event-ID
+          in: header
+          required: false
+          description: |
+            The last event id this client received, sent automatically by an
+            `EventSource` on reconnect. Wins over `after` when both are given.
+            A value that is not a non-negative integer is ignored.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            An open event stream. The body is `text/event-stream` and does not
+            end until the server closes it; it is not JSON and must be read
+            frame by frame.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: |
+                  A sequence of SSE frames. The `data:` field of an entity
+                  frame is a `MobileEvent`; the `data:` field of a control
+                  frame is a `StreamControlFrame`. Described as a string
+                  because OpenAPI has no way to type a frame sequence — the
+                  two schemas named in `x-frame-payloads` are what a client
+                  parses each `data:` into.
+              # OpenAPI's content model types a *body*, and this body is a
+              # sequence of framed payloads of two different shapes. There is no
+              # standard place to say that, so the mapping is a vendor
+              # extension rather than prose: a generator can read it, and the
+              # contract gate sees the two schemas as referenced instead of
+              # reporting them as declared-and-unused, which is what they would
+              # be if this said the same thing in a sentence.
+              x-frame-payloads:
+                entity:
+                  description: The `data:` of a frame whose `event:` is a `MobileEventType`.
+                  schema:
+                    $ref: '#/components/schemas/MobileEvent'
+                control:
+                  description: The `data:` of a `stream.open`, `stream.gap` or `stream.closed` frame.
+                  schema:
+                    $ref: '#/components/schemas/StreamControlFrame'
+              examples:
+                openThenOneEvent:
+                  summary: Opening, then one decision event
+                  value: |
+                    event: stream.open
+                    data: {"type":"stream.open","from":0,"at":"2026-08-26T14:32:07Z"}
+
+                    id: 41
+                    event: decision.requested
+                    data: {"id":41,"type":"decision.requested","projectId":"codexbridge-demo","entity":{"kind":"decision","id":"9f0d6b2c-2f5a-4c2b-9d5e-1a7c3f8e4b10"},"action":"requested","at":"2026-08-26T14:32:09Z","summary":"A sensitive session is waiting for a decision.","state":"awaiting_approval"}
+
+                    : keep-alive
+
+                    event: stream.closed
+                    data: {"type":"stream.closed","reason":"max_duration","at":"2026-08-26T14:47:07Z"}
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+        '503':
+          description: |
+            The gateway is already holding as many event streams open as it
+            will. Retry after the interval in `Retry-After`, with
+            `Last-Event-ID`; nothing is lost by waiting.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Retry-After:
+              $ref: '#/components/headers/RetryAfter'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                code: dependency_unavailable
+                message: Too many event streams are open on this gateway. Retry shortly.
+                requestId: '5a3f1c88-90b1-4e2a-8a6f-2f9c0d1e7b43'
+                retryable: true
+
+  /api/v1/notifications/preferences:
+    get:
+      operationId: getNotificationPreferences
+      tags: [notifications]
+      summary: This actor's notification-subscription preferences
+      description: |
+        Always the calling actor's own. There is no `userId` parameter and no
+        administrator override: a preference document is personal data and an
+        endpoint that could read another account's would be a disclosure with
+        no product behind it.
+
+        Returns the defaults — an empty `eventTypes` and `pushEnabled: false`,
+        with `updatedAt: null` — when the actor has never saved preferences, so
+        a client can tell "never touched" from "explicitly set to the
+        defaults".
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: The actor's preferences.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferences'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    put:
+      operationId: putNotificationPreferences
+      tags: [notifications]
+      summary: Replace this actor's notification-subscription preferences
+      description: |
+        A whole-document replacement, idempotent by construction: the same body
+        sent twice produces the same document, which is why there is no
+        `Idempotency-Key` and no `If-Match` here. The only writer of a row is
+        the actor it belongs to, so there is no concurrent third party for an
+        optimistic check to protect against.
+
+        **These preferences are a hook for a push transport this build does not
+        have.** `pushDeliveryAvailable` is `false` and nothing reads these rows
+        to decide delivery. They are stored so the choice survives a reinstall
+        and so a later push integration has something to read.
+
+        **They do not filter `GET /api/v1/events/stream`.** A client that
+        opened the stream asked for the stream; withholding events from it
+        because of a preference set on another device is how a phone silently
+        misses the decision its operator was waiting for. Narrow a live
+        connection with that endpoint's `?type=` instead.
+
+        Requires the `notifications.manage` permission
+        (`codexbridge.notifications.manage`), which is separate from the read
+        scope on purpose: an operator may want a phone that watches the event
+        stream without being able to rewrite what the account is notified
+        about.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationPreferencesRequest'
+      responses:
+        '200':
+          description: The stored preferences.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            Cache-Control:
+              $ref: '#/components/headers/CacheControl'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationPreferences'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '422': {$ref: '#/components/responses/ValidationFailed'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
   /health:
     get:
       operationId: getHealth
@@ -2287,7 +2611,7 @@ paths:
                   tokenRevocation: true
                   effectivePermissions: true
                   deviceAuthorization: false
-                  eventStream: false
+                  eventStream: true
                   artifactDownloads: false
                 time: '2026-08-10T14:32:07Z'
         '429':
@@ -2489,6 +2813,52 @@ components:
         type: string
         minLength: 1
         maxLength: 255
+
+    EventsAfter:
+      name: after
+      in: query
+      required: false
+      description: |
+        Deliver only events with an `id` strictly greater than this. The
+        resume position for both event transports, and deliberately the same
+        integer the stream puts in `id:` — see `GET /api/v1/events`.
+
+        On the stream, `Last-Event-ID` wins over this when both are sent.
+      schema:
+        type: integer
+        format: int64
+        minimum: 0
+      examples:
+        resumeFromFortyOne:
+          value: 41
+
+    EventProject:
+      name: project
+      in: query
+      required: false
+      description: |
+        Repeatable. Restricts to these projects, **intersected** with what the
+        caller may see — naming a project outside the actor's
+        `allowedProjects` narrows to nothing rather than widening.
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/ProjectId'
+
+    EventType:
+      name: type
+      in: query
+      required: false
+      description: |
+        Repeatable. Restricts to these event types. A value outside
+        `MobileEventType` is a `400`; a value that is a declared type this
+        build never emits (`artifact.*`, `androidBuild.*`) is accepted and
+        matches nothing, which is what makes those values usable by a client
+        written ahead of the build that emits them.
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/MobileEventType'
 
   responses:
 
@@ -3731,3 +4101,304 @@ components:
           message: 'Unexpected server error. Report the requestId to the operator.'
           requestId: 'b4c5d6e7-f809-4a1b-8c2d-3e4f50617283'
           retryable: true
+
+
+    MobileEventType:
+      type: string
+      description: |
+        What kind of change an event reports. A closed vocabulary: a client may
+        switch over it exhaustively, and adding a value is a breaking change
+        under `docs/api/README.md` §"What is a breaking change" — which is why
+        the artifact and Android build values are already here.
+
+        **Declared and never emitted by this build:** `artifact.created`,
+        `artifact.updated` and `androidBuild.status_changed`. There is no
+        artifact or Android build record in this build (issue #11), so no event
+        of these types can arrive. They are declared now so that the build
+        which produces them is additive rather than a new major version.
+
+        A session, a mission and a decision are three vocabularies over the same
+        underlying row — see `docs/api/README.md` §"Missions (issue #7)". One
+        change produces **one** event, not three: `entity.kind` names the
+        vocabulary that fits what happened (`decision` for the approval
+        lifecycle, `session` for the run's own lifecycle), and the id is the
+        same id, so `GET /api/v1/sessions/{id}` and `GET /api/v1/missions/{id}`
+        both accept it.
+      enum:
+        - androidBuild.status_changed
+        - artifact.created
+        - artifact.updated
+        - conversation.created
+        - conversation.message_created
+        - decision.requested
+        - decision.resolved
+        - decision.resolved_by_actor
+        - epic.created
+        - issue.created
+        - issue.linked_to_epic
+        - issue.updated
+        - session.completed
+        - session.control_acknowledged
+        - session.control_refused
+        - session.control_requested
+        - session.created
+        - session.recovered
+        - session.restarted
+        - session.state_changed
+        - session.stop_acknowledged
+        - session.stopped
+
+    MobileEventEntityKind:
+      type: string
+      description: |
+        Which resource a client fetches to see the whole thing behind an event.
+        `artifact` and `androidBuild` appear only on the declared-but-unemitted
+        types above.
+      enum:
+        - session
+        - decision
+        - epic
+        - issue
+        - conversation
+        - artifact
+        - androidBuild
+
+    MobileEventEntity:
+      type: object
+      description: The resource this event is about.
+      required: [kind, id]
+      properties:
+        kind:
+          $ref: '#/components/schemas/MobileEventEntityKind'
+        id:
+          $ref: '#/components/schemas/Id'
+
+    MobileEvent:
+      type: object
+      description: |
+        One change, in the shape both event transports deliver.
+
+        **The summary is a whitelist, never the stored record.** The gateway's
+        internal audit payload is not passed through: each event type names the
+        few values it may read, free text is redacted and truncated on the way
+        out, and anything nobody whitelisted does not leave the server. Treat
+        `summary` as a notification line, not as data — fetch the entity for
+        the authoritative state.
+      required: [id, type, projectId, entity, action, at, summary]
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: |
+            Monotonically increasing position in the event log, and the resume
+            token: send it back as `Last-Event-ID` or `after`. Increasing but
+            **not contiguous** — the log also holds records that are never
+            delivered as events — so a client must not treat a skipped number
+            as a lost event. Loss is reported explicitly by `EventGap`.
+        type:
+          $ref: '#/components/schemas/MobileEventType'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        entity:
+          $ref: '#/components/schemas/MobileEventEntity'
+        action:
+          type: string
+          description: |
+            The part of `type` after the dot (`created`, `state_changed`, …),
+            so a client can branch coarsely without parsing the type string.
+            Derived, never stored, so the two cannot disagree.
+          examples:
+            - state_changed
+        at:
+          $ref: '#/components/schemas/Timestamp'
+        summary:
+          type: string
+          maxLength: 300
+          description: One short human-readable line. See the note above.
+          examples:
+            - 'State changed to running.'
+        state:
+          type: string
+          description: |
+            The entity's state at the moment of the event, when the event has
+            one. Omitted — not null — when it does not.
+          examples:
+            - running
+        actorId:
+          allOf:
+            - $ref: '#/components/schemas/Id'
+          description: |
+            Opaque id of the actor who caused the change, when the event
+            records one. Omitted when the change was not attributable to an
+            actor (an executor result, an expiry sweep). Never an email
+            address: the audit record holds one for several event kinds and it
+            is deliberately not read here.
+      examples:
+        - id: 41
+          type: session.state_changed
+          projectId: codexbridge-demo
+          entity:
+            kind: session
+            id: 9f0d6b2c-2f5a-4c2b-9d5e-1a7c3f8e4b10
+          action: state_changed
+          at: '2026-08-26T14:32:09Z'
+          summary: 'State changed to running.'
+          state: running
+
+    EventPageInfo:
+      type: object
+      description: |
+        Paging for the event backlog. Deliberately **not** `PageInfo`: this
+        collection is addressed by the same public integer id the stream
+        resumes from, so it has no opaque cursor. See `GET /api/v1/events`.
+      required: [hasMore]
+      properties:
+        hasMore:
+          type: boolean
+          description: |
+            Whether more events exist after this page. Authoritative: computed
+            from an over-fetch, so a page shortened by authorization or by a
+            `type` filter still reports the truth.
+        nextAfter:
+          type: [integer, 'null']
+          format: int64
+          description: |
+            Pass as `after` to fetch the next page. The last id this page
+            **loaded**, which is not necessarily the last id it returned when a
+            `type` filter dropped the tail. `null` when `hasMore` is `false`.
+
+    EventGap:
+      type: object
+      description: |
+        Sent when the requested resume position can no longer be continued from
+        — as this field on `GET /api/v1/events`, and as the `stream.gap` frame
+        on the stream, **before** any event is delivered.
+
+        Its whole purpose is that loss is never silent. Resume is
+        `id > position`, so the only way to miss an event is for its record to
+        be gone; a client that receives this must re-read the affected
+        resources rather than assume the events it now receives continue from
+        where it left off.
+      required: [reason, from]
+      properties:
+        reason:
+          type: string
+          description: |
+            `beyond_retention`: the position's record is gone and the log has
+            moved past it — events between the client's position and
+            `oldestAvailableId` were removed.
+
+            `cursor_ahead`: the position is beyond anything this log has ever
+            held. The position came from a different deployment, or this
+            database was restored from a backup older than the client. Left
+            unsignalled, the stream would simply never deliver again — the same
+            silence in the other direction.
+          enum:
+            - beyond_retention
+            - cursor_ahead
+        from:
+          type: integer
+          format: int64
+          description: The position the client asked to resume from.
+        oldestAvailableId:
+          type: [integer, 'null']
+          format: int64
+          description: |
+            The lowest position still held, so a client that fell behind knows
+            where to restart from instead of guessing. `null` when the log is
+            empty.
+
+    StreamControlFrame:
+      type: object
+      description: |
+        The `data:` payload of a `stream.open`, `stream.gap` or `stream.closed`
+        frame on `GET /api/v1/events/stream`.
+
+        These are **not** `MobileEventType` values and never will be: they carry
+        no entity, no project and no resume position, and a client that switches
+        exhaustively over the entity enum must not have to know them to compile.
+        Control frames also carry no SSE `id:`, so they cannot advance
+        `Last-Event-ID` past an event the client never received.
+      required: [type]
+      properties:
+        type:
+          type: string
+          enum:
+            - stream.open
+            - stream.gap
+            - stream.closed
+        at:
+          $ref: '#/components/schemas/Timestamp'
+        from:
+          type: integer
+          format: int64
+          description: On `stream.open` and `stream.gap`, the position the stream resumed from.
+        reason:
+          type: string
+          description: |
+            On `stream.gap`, an `EventGap.reason`. On `stream.closed`, why the
+            server ended the stream: `max_duration` (the server bounds how long
+            one connection lives), `unauthenticated` (the credential stopped
+            being usable while the stream was open) or `disconnected`. Every
+            one of them is a reconnect with `Last-Event-ID`.
+        oldestAvailableId:
+          type: [integer, 'null']
+          format: int64
+          description: On `stream.gap`, as `EventGap.oldestAvailableId`.
+
+    NotificationPreferences:
+      type: object
+      description: |
+        What one actor asked to be notified about. Recorded intent, not
+        delivery — see `PUT /api/v1/notifications/preferences`.
+      required: [eventTypes, pushEnabled, pushDeliveryAvailable]
+      properties:
+        eventTypes:
+          type: array
+          description: |
+            The event types the actor subscribed to, sorted and de-duplicated.
+            Empty means "nothing chosen", not "everything".
+          items:
+            $ref: '#/components/schemas/MobileEventType'
+        pushEnabled:
+          type: boolean
+          description: Whether the actor wants push delivery, once there is any.
+        updatedAt:
+          oneOf:
+            - $ref: '#/components/schemas/Timestamp'
+            - type: 'null'
+          description: |
+            When these preferences were last saved, or `null` when the actor
+            has never saved any — which lets a client tell "defaults, never
+            touched" from "explicitly set to the defaults".
+        pushDeliveryAvailable:
+          type: boolean
+          description: |
+            Whether this build can actually deliver a push notification.
+            `false` in this build. Stated in the payload rather than only in
+            prose so a client rendering the switch can say so at the moment it
+            renders it.
+
+    NotificationPreferencesRequest:
+      type: object
+      description: |
+        A whole-document replacement. Absent fields take their defaults rather
+        than keeping the stored value — this is a `PUT`, not a `PATCH`.
+      properties:
+        eventTypes:
+          type: array
+          maxItems: 64
+          description: |
+            Event types to subscribe to. A value outside `MobileEventType` is
+            rejected with `validation_failed` naming `eventTypes`. Duplicates
+            are accepted and collapsed.
+          items:
+            $ref: '#/components/schemas/MobileEventType'
+        pushEnabled:
+          type: boolean
+          default: false
+      examples:
+        - eventTypes:
+            - decision.requested
+            - session.completed
+          pushEnabled: true

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-08-22 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge map`
+> Generated: 2026-08-26 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--gh-13`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--gh-13 map`
 
 ## Summary
 
-- 95 file(s) · 876 symbol(s) indexed
-- Languages: config (2), python (91), shell (2)
+- 99 file(s) · 968 symbol(s) indexed
+- Languages: config (2), python (95), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -20,7 +20,7 @@
 ## Ignored Paths
 
 - Built-in: `.docs-migration-bak`, `.git`, `.idea`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`, `.tox`, `.venv`, `.vscode`, `__pycache__`, `build`, `dist`, `env`, `node_modules`, `venv`
-- `.gitignore`: `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, `.coverage`, `codex_bridge.db`, `dist/`, `build/`, `*.egg-info/`, `.venv/`, `venv/`, `AGENTS.md`, `.cursorrules`, `CLAUDE.md`, `.windsurfrules`, `GEMINI.md`, `.github/copilot-instructions.md`, `.amazonq/rules/ai-agents.md`, `.credentials`, `handoff.md`, `new-tag.sh`, `scripts/install-agents-kit.sh`, `scripts/agent-worktree.sh`, `.docs-migration-bak/`, `.gk/operator.json`, `.gk/secrets.json`, `.gk/context-telemetry.jsonl`, `.gk/overwritten/`, `.env`, `.env.*`, `.envrc`, `.npmrc`, `.pypirc`, `.netrc`, `*.pem`, `*.key`, `.credentials/*`, `!.env.example`, `!.env.sample`, `!.env.template`, `!.env.dist`, `!.env-example`, `!.env.missing`, `!.credentials/.gitignore`, `!.credentials/.keep`, `!.credentials/README*`, `!.credentials/*.example`, `!.credentials/*.sample`, `!.credentials/*.template`, `!.credentials/*.dist`
+- `.gitignore`: `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, `.coverage`, `codex_bridge.db`, `dist/`, `build/`, `*.egg-info/`, `.venv/`, `venv/`, `.governancekit-identity.json`, `AGENTS.md`, `.cursorrules`, `CLAUDE.md`, `.windsurfrules`, `GEMINI.md`, `.github/copilot-instructions.md`, `.amazonq/rules/ai-agents.md`, `handoff.md`, `new-tag.sh`, `scripts/install-agents-kit.sh`, `scripts/agent-worktree.sh`, `.docs-migration-bak/`, `.gk/operator.json`, `.gk/secrets.json`, `.gk/context-telemetry.jsonl`, `.gk/overwritten/`, `.gk/pre-upgrade/`, `.gk/pre-migrate/`, `.gk/remove-agents-backup/`, `.gk/remove-agents-plan.json`, `.gk/context-proposal/`, `*.kit-new`, `*.pre-draft`, `.env`, `.env.*`, `.envrc`, `.npmrc`, `.pypirc`, `.netrc`, `*.pem`, `*.key`, `.credentials/*`, `!.env.example`, `!.env.sample`, `!.env.template`, `!.env.dist`, `!.env-example`, `!.env.missing`, `!.credentials/.gitignore`, `!.credentials/.keep`, `!.credentials/README*`, `!.credentials/*.example`, `!.credentials/*.sample`, `!.credentials/*.template`, `!.credentials/*.dist`
 
 ## Entry Points
 
@@ -62,8 +62,10 @@ gateway/
         conversations.py  — "Conversations and contextual messaging — issue #10."
         decisions.py  — "Operational decisions: sensitive tasks held for a human to resolve — issue #6."
         epics.py  — "Epics — issue #8."
+        events.py  — "Near-real-time delivery of what changed, and the backlog behind it — issue #13."
         issues.py  — "Issues — issue #8."
         missions.py  — "Missions: the mission-control view of the same run Sessions exposes — issue #7."
+        notifications.py  — "What this actor wants to be notified about — issue #13."
         probes.py  — "Liveness, readiness and version — what a client asks before anything else."
         projects.py  — "Projects and the project operational dashboard — issue #5."
         sessions.py  — "Agent sessions, their logs, and lifecycle control."
@@ -93,6 +95,7 @@ gateway/
       agent_hub.py
       audit.py
       conversation_types.py  — "Closed vocabulary for conversation context references, and their error."
+      event_types.py  — "Which audit rows become mobile events, and what those events may say — issue #13."
       issue_types.py  — "Closed vocabularies for epics and issues, and the error they fail with."
       metrics.py
       store.py
@@ -123,6 +126,7 @@ tests/
     test_conversations.py  — "Conversations and contextual messaging — issue #10."
     test_decisions.py  — "Operational decisions — issue #6."
     test_epics_issues.py  — "Epics and issues — issue #8."
+    test_events.py  — "The mobile event stream, its polling fallback, and notification preferences — issue #13."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
     test_oauth_authorize.py  — "The browser OAuth form — the *other* caller of the password check."
     test_probes.py  — "Health, readiness and version — issue #3."
@@ -189,6 +193,7 @@ tests/
 > Authentication and authorization for the contract surface.
 
 - `unauthenticated(message)` — "The one shape of a 401 on this surface."
+- `principal_for_token(session, token)` *(async function)* — "The principal a bearer token resolves to right now, or None."
 - `current_principal(request, session)` *(async function)* — "Resolve the bearer token to a principal, or refuse the request."
 - `bearer_token(request)` — "The presented bearer token, or None when the header is absent or not one."
 - `require_action(action)` — "Dependency factory refusing a principal that may not perform `action`."
@@ -315,6 +320,22 @@ tests/
 - `create_epic(payload, response, idempotency_key, principal, session)` *(async function)*
 - `link_issue(epic_id, issue_id, response, if_match, idempotency_key, principal, session)` *(async function)* — "Attach an issue to an epic. Both must be in a project the caller may see."
 
+### `gateway/app/api/routes/events.py`
+
+> Near-real-time delivery of what changed, and the backlog behind it — issue #13.
+
+- **`StreamSlot`** *(class)* — "One acquired slot, releasable exactly once."
+  - `__init__(self, slots)` *(method)*
+  - `release(self)` *(method)*
+- **`StreamSlots`** *(class)* — "How many event streams this process will hold open at once."
+  - `__init__(self, limit)` *(method)*
+  - `active` *(property)*
+  - `acquire(self)` *(method)*
+  - `release(self)` *(method)*
+- `list_events(response, after, project, type, limit, principal, session)` *(async function)* — "Events the caller may see, oldest first, after `after`."
+- `event_stream()` *(async function)* — "The SSE body: an async generator of frames."
+- `stream_events(request, after, project, type, last_event_id, principal)` *(async function)* — "Open a live event stream for the caller's projects."
+
 ### `gateway/app/api/routes/issues.py`
 
 > Issues — issue #8.
@@ -336,6 +357,14 @@ tests/
 - `get_mission_timeline(mission_id, response, cursor, limit, principal, session)` *(async function)* — "The mission's recorded events, oldest first — the order a narrative reads in."
 - `cancel_mission(mission_id, response, if_match, idempotency_key, body, principal, session)` *(async function)* — "Cancel a mission that is queued, waiting, running or awaiting approval."
 - `explain_mission(mission_id, principal, session)` *(async function)* — "A structured account of a mission's current state, assembled server-side."
+
+### `gateway/app/api/routes/notifications.py`
+
+> What this actor wants to be notified about — issue #13.
+
+- **`NotificationPreferencesRequest`** *(class)*
+- `get_preferences(response, principal, session)` *(async function)* — "This actor's preferences, or the defaults when nothing was ever saved."
+- `put_preferences(payload, response, principal, session)` *(async function)* — "Replace this actor's preferences."
 
 ### `gateway/app/api/routes/probes.py`
 
@@ -399,6 +428,8 @@ tests/
 ### `gateway/app/core/config.py`
 
 - **`Settings`** *(class)*
+  - `effective_event_stream_poll_interval(self)` *(method)*
+  - `effective_event_stream_batch_limit(self)` *(method)*
   - `effective_ready_cache_seconds(self)` *(method)*
   - `accepted_mcp_tokens(self)` *(method)*
   - `oauth_client_ids(self)` *(method)*
@@ -468,6 +499,7 @@ tests/
 ### `gateway/app/db/session.py`
 
 - `get_session()` *(async function)*
+- `session_factory()` — "The sessionmaker, for code that outlives a request's dependencies."
 
 ### `gateway/app/main.py`
 
@@ -509,6 +541,7 @@ tests/
 - **`ConversationReadStateModel`** *(class)* — "How far one actor has read into one conversation."
 - **`TaskLogModel`** *(class)*
 - **`AuditEventModel`** *(class)*
+- **`NotificationPreferenceModel`** *(class)* — "Which events one actor wants to be notified about — issue #13."
 - **`MessageReceiptModel`** *(class)*
 - **`IdempotencyRecordModel`** *(class)* — "A completed write, keyed so an offline retry replays instead of repeating."
 - **`OAuthAuthorizationCodeModel`** *(class)*
@@ -539,6 +572,18 @@ tests/
 
 - **`ConversationPlanningError`** *(class)* — "A create input that fails validation inside the store itself."
   - `__init__(self, field, code, message)` *(method)*
+
+### `gateway/app/services/event_types.py`
+
+> Which audit rows become mobile events, and what those events may say — issue #13.
+
+- **`MobileEvent`** *(class)* — "One translated event, in the shape the contract publishes."
+  - `action` *(property)*
+  - `as_dict(self)` *(method)*
+- `classify(audit_event_type, payload)` — "`(mobile type, entity kind)` for one audit row, or None when it is internal."
+- `summarize(mobile_type, payload, redact)` — "A short, human-readable line for one event. Never the raw payload."
+- `actor_of(payload)`
+- `state_of(payload)`
 
 ### `gateway/app/services/issue_types.py`
 
@@ -599,6 +644,11 @@ tests/
 - `mission_stage(task)`
 - `list_missions_page(session)` *(async function)* — "Missions (tasks, in mission-control framing) the caller may see, newest"
 - `list_task_events_page(session, task_id)` *(async function)* — "A mission's timeline, oldest first — the order a narrative reads in (issue #7)."
+- `list_mobile_events_page(session)` *(async function)* — "Deliverable audit rows after `after`, oldest first, with their project."
+- `audit_cursor_status(session, after)` *(async function)* — "Whether resuming from `after` can be done without a silent gap."
+- `oldest_audit_event_id(session)` *(async function)* — "Lowest surviving audit id, reported alongside a `beyond_retention` gap."
+- `get_notification_preference(session, user_id)` *(async function)*
+- `set_notification_preference(session)` *(async function)* — "Replace one actor's preferences wholesale, creating the row if absent."
 - `create_epic(session)` *(async function)*
 - `get_epic(session, epic_id)` *(async function)*
 - `get_epic_for_projects(session, epic_id, project_ids)` *(async function)* — "An epic the caller may see, or None. Mirrors `get_task_for_projects`."
@@ -988,6 +1038,72 @@ tests/
 - `test_a_failed_link_does_not_keep_the_key_claimed(api)` *(async function)*
 - `test_the_epic_list_cursor_walks_every_epic_once(api)` *(async function)*
 - `test_list_epics_filters_by_status(api)` *(async function)*
+
+### `tests/integration/test_events.py`
+
+> The mobile event stream, its polling fallback, and notification preferences — issue #13.
+
+- `users_file(tmp_path)`
+- `api(users_file, monkeypatch)` *(async function)*
+- `auth(token)`
+- `make_task(factory, project_id)` *(async function)*
+- `emit(factory, entity_type, entity_id, event_type, payload)` *(async function)* — "Write one audit row directly and return its id."
+- `newest_audit_id(factory)` *(async function)*
+- **`FakeClock`** *(class)* — "A monotonic clock the test moves on purpose."
+  - `__init__(self)` *(method)*
+  - `__call__(self)` *(method)*
+- `stepping_sleep(clock, step, on_poll)` — "An `asyncio.sleep` replacement that advances the fake clock instead."
+- `parse_frames(chunks)` — "SSE text as a list of `{id?, event?, data?, comment?}` dicts."
+- `run_stream(factory)` *(async function)* — "Drive `event_stream` for exactly `polls` iterations and return its frames."
+- `entity_frames(frames)` — "Only the frames that carry an event — control frames and heartbeats out."
+- `test_the_backlog_returns_translated_events_oldest_first(api)` *(async function)*
+- `test_the_page_reports_more_and_a_position_to_continue_from(api)` *(async function)*
+- `test_a_type_filter_narrows_without_making_the_position_stall(api)` *(async function)* — "`nextAfter` is the last id *loaded*, not the last id returned."
+- `test_an_unknown_type_filter_is_a_validation_error(api)` *(async function)*
+- `test_a_declared_but_unemitted_type_filters_to_nothing_rather_than_failing(api)` *(async function)* — "`artifact.*` is in the vocabulary and produced by nothing in this build."
+- `test_the_project_filter_only_ever_narrows(api)` *(async function)*
+- `test_a_restricted_principal_sees_only_its_own_projects_events(api)` *(async function)*
+- `test_authentication_events_never_appear_on_any_principals_feed(api)` *(async function)* — "Sign-in activity is not a product event, and streaming it is a disclosure."
+- `test_a_preference_change_is_not_a_project_event(api)` *(async function)* — "`notification` rows are excluded the same way `auth` rows are."
+- `test_an_event_whose_project_cannot_be_derived_reaches_nobody(api)` *(async function)* — "Fail closed, administrators included."
+- `test_reading_events_requires_the_read_scope(api)` *(async function)*
+- `test_no_stored_payload_key_is_passed_through_to_a_client(api)` *(async function)* — "The audit payload is written by eleven call sites and is not a response."
+- `test_free_text_in_a_summary_is_redacted_and_bounded(api)` *(async function)* — "`redact` is applied to executor free text, and the line has a ceiling."
+- `test_every_emitted_event_type_has_a_summary_builder()` — "A type with no builder falls back to a bland sentence — silently."
+- `test_every_audited_domain_event_type_is_translated()` — "A new audit event under a deliverable entity must be classified on purpose."
+- `test_the_non_deliverable_entity_constants_stay_non_deliverable()` — "The exclusion of auth and preference rows is by construction; pin it."
+- `test_the_declared_but_unemitted_types_are_not_produced_by_this_build()` — "`artifact.*` and `androidBuild.*` are contract, not behaviour, until #11."
+- `test_the_stream_opens_with_an_acknowledgement_carrying_no_position(api)` *(async function)* — "`stream.open` must not carry `id:`."
+- `test_events_recorded_while_the_stream_runs_are_delivered(api)` *(async function)*
+- `test_reconnecting_from_the_last_id_loses_nothing_and_repeats_nothing(api)` *(async function)* — "The acceptance criterion, end to end."
+- `test_the_same_position_replayed_twice_delivers_the_same_events(api)` *(async function)* — "Resume is a pure function of the position, so a duplicated reconnect is safe."
+- `test_a_position_the_log_has_moved_past_is_announced_before_anything_is_delivered(api)` *(async function)* — "A gap is signalled, never papered over — and signalled *first*."
+- `test_a_position_ahead_of_the_log_is_a_gap_too(api)` *(async function)* — "The mirror case: a cursor from another deployment, or a restored backup."
+- `test_a_continuous_position_produces_no_gap_frame(api)` *(async function)* — "The signal is only worth having if it stays quiet when nothing was lost."
+- `test_the_polling_fallback_reports_the_same_gap(api)` *(async function)* — ""No silent loss" is a property of the events, not of one transport."
+- `test_a_revoked_token_stops_the_stream_it_had_already_opened(api)` *(async function)* — "Authorization is re-checked on every poll, not once at `GET`."
+- `test_an_expired_token_stops_the_stream(api)` *(async function)* — "Expiry is the same failure as revocation and must end the stream too."
+- `test_a_project_removed_from_the_actor_stops_reaching_them(api, users_file)` *(async function)* — "`allowed_projects` is re-read per poll, not captured when the stream opened."
+- `test_a_disconnected_client_ends_the_stream_without_a_closing_frame(api)` *(async function)* — "Nothing is listening, so there is nothing to tell."
+- `test_an_idle_stream_sends_a_comment_not_an_event(api)` *(async function)* — "A heartbeat keeps a proxy from timing out an idle connection."
+- `test_a_stream_type_filter_narrows_delivery_without_stalling_the_cursor(api)` *(async function)*
+- `test_the_slot_ceiling_refuses_rather_than_degrading_the_shared_pool(api)` *(async function)* — "The rate limiter bounds requests per window, not connections held open."
+- `test_a_finished_stream_gives_its_slot_back(api)` *(async function)* — "A slot that is not returned is gone for good, and the ceiling ratchets down."
+- `test_the_stream_is_served_as_an_event_stream_that_a_proxy_will_not_buffer(api, monkeypatch)` *(async function)*
+- `test_last_event_id_resumes_and_beats_the_query_parameter(api, monkeypatch)` *(async function)* — "The header is what a reconnecting `EventSource` sends by itself."
+- `test_a_malformed_last_event_id_is_ignored_rather_than_refused(api)` *(async function)* — "The user agent sets that header, not the application."
+- `test_a_bad_type_filter_fails_before_the_body_starts(api, monkeypatch)` *(async function)* — "Once an event-stream body has started there is no status code left to change."
+- `test_preferences_round_trip(api)` *(async function)*
+- `test_a_put_replaces_the_document_rather_than_merging_into_it(api)` *(async function)* — "`PUT`, not `PATCH`: an absent field takes its default."
+- `test_preferences_are_per_actor_and_never_another_accounts(api)` *(async function)*
+- `test_an_unknown_event_type_is_refused_with_the_field_named(api)` *(async function)*
+- `test_writing_preferences_needs_a_scope_reading_them_does_not(api)` *(async function)* — "Two actions, because an operator may grant one without the other."
+- `test_a_stored_type_that_no_longer_exists_is_dropped_on_the_way_out(api)` *(async function)* — "A stored preference can outlive the type it names."
+- `test_preferences_do_not_filter_the_stream(api)` *(async function)* — "A documented decision, not an omission — so it is pinned as behaviour."
+- `test_an_empty_project_list_matches_nothing_and_is_not_no_restriction(api)` *(async function)* — "The one-character mistake: `if project_ids:` instead of `is not None`."
+- `test_task_created_forks_on_the_state_it_was_created_in(api)` *(async function)* — "One audit row, two mobile meanings, resolved from the payload."
+- `test_epics_issues_and_conversations_all_resolve_to_their_project(api)` *(async function)* — "Every deliverable entity type must have a working project derivation."
+- `test_the_poll_interval_is_floored_rather_than_honoured()` — "A zero interval is a busy loop against the pool every endpoint shares."
 
 ### `tests/integration/test_missions.py`
 

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,11 +1,11 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-08-26 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--gh-13`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--gh-13 map`
+> Generated: 2026-08-26 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge map`
 
 ## Summary
 
-- 99 file(s) · 968 symbol(s) indexed
+- 99 file(s) · 987 symbol(s) indexed
 - Languages: config (2), python (95), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -324,14 +324,15 @@ tests/
 
 > Near-real-time delivery of what changed, and the backlog behind it — issue #13.
 
-- **`StreamSlot`** *(class)* — "One acquired slot, releasable exactly once."
-  - `__init__(self, slots)` *(method)*
+- **`StreamSlot`** *(class)* — "One acquired slot, releasable exactly once, remembering whose it was."
+  - `__init__(self, slots, owner)` *(method)*
   - `release(self)` *(method)*
 - **`StreamSlots`** *(class)* — "How many event streams this process will hold open at once."
-  - `__init__(self, limit)` *(method)*
+  - `__init__(self, limit, per_actor)` *(method)*
   - `active` *(property)*
-  - `acquire(self)` *(method)*
-  - `release(self)` *(method)*
+  - `active_for(self, owner)` *(method)*
+  - `acquire(self, owner)` *(method)*
+  - `release(self, owner)` *(method)*
 - `list_events(response, after, project, type, limit, principal, session)` *(async function)* — "Events the caller may see, oldest first, after `after`."
 - `event_stream()` *(async function)* — "The SSE body: an async generator of frames."
 - `stream_events(request, after, project, type, last_event_id, principal)` *(async function)* — "Open a live event stream for the caller's projects."
@@ -583,7 +584,7 @@ tests/
 - `classify(audit_event_type, payload)` — "`(mobile type, entity kind)` for one audit row, or None when it is internal."
 - `summarize(mobile_type, payload, redact)` — "A short, human-readable line for one event. Never the raw payload."
 - `actor_of(payload)`
-- `state_of(payload)`
+- `state_of(payload)` — "The entity's state, or None when the row does not record a defined one."
 
 ### `gateway/app/services/issue_types.py`
 
@@ -646,7 +647,7 @@ tests/
 - `list_task_events_page(session, task_id)` *(async function)* — "A mission's timeline, oldest first — the order a narrative reads in (issue #7)."
 - `list_mobile_events_page(session)` *(async function)* — "Deliverable audit rows after `after`, oldest first, with their project."
 - `audit_cursor_status(session, after)` *(async function)* — "Whether resuming from `after` can be done without a silent gap."
-- `oldest_audit_event_id(session)` *(async function)* — "Lowest surviving audit id, reported alongside a `beyond_retention` gap."
+- `oldest_audit_event_id(session)` *(async function)* — "Lowest id still in **this caller's** feed, reported alongside a gap."
 - `get_notification_preference(session, user_id)` *(async function)*
 - `set_notification_preference(session)` *(async function)* — "Replace one actor's preferences wholesale, creating the row if absent."
 - `create_epic(session)` *(async function)*
@@ -710,6 +711,9 @@ tests/
 
 - `test_the_codemap_names_every_module_it_claims_to_index()` — "`.docs/agents/programmer.md` tells the next agent to read this instead of scanning."
 - `test_the_api_readme_does_not_deny_the_limiter_that_ships(denial)` — "§"Rate limiting — vocabulary only, so far" outlived the wiring."
+- `test_no_document_names_a_capability_flag_the_probe_does_not_report()` — "A `false` flag a client can read is the point; a *missing* key is not one."
+- `test_the_codemap_names_the_canonical_checkout_not_a_worktree()` — "`governancekit map` stamps the root it was run from, and agents run in worktrees."
+- `test_the_audit_payload_writer_count_is_the_real_one()` — "Five files tell a reader how many writers can put a key in an audit payload."
 
 ### `tests/contract/test_openapi_document.py`
 
@@ -1067,8 +1071,14 @@ tests/
 - `test_a_preference_change_is_not_a_project_event(api)` *(async function)* — "`notification` rows are excluded the same way `auth` rows are."
 - `test_an_event_whose_project_cannot_be_derived_reaches_nobody(api)` *(async function)* — "Fail closed, administrators included."
 - `test_reading_events_requires_the_read_scope(api)` *(async function)*
-- `test_no_stored_payload_key_is_passed_through_to_a_client(api)` *(async function)* — "The audit payload is written by eleven call sites and is not a response."
+- `test_no_stored_payload_key_is_passed_through_to_a_client(api)` *(async function)* — "The audit payload is written by thirty-one call sites and is not a response."
 - `test_free_text_in_a_summary_is_redacted_and_bounded(api)` *(async function)* — "`redact` is applied to executor free text, and the line has a ceiling."
+- `test_an_executors_control_and_state_strings_cannot_reach_a_notification_line(api)` *(async function)* — "Council round 1, the adversarial user — the whitelist's premise was false."
+- `test_every_echoed_payload_value_comes_from_a_closed_vocabulary()` — "The guard behind the test above, asserted directly."
+- `test_the_gap_signal_cannot_report_on_events_the_caller_may_not_see(api)` *(async function)* — "Council round 1 — the `gap` block was a one-bit oracle over the whole log."
+- `test_the_oldest_available_id_is_the_callers_own_oldest(api)` *(async function)* — "`oldestAvailableId` returned the global minimum audit id to any reader."
+- `test_a_resume_position_beyond_the_id_range_is_refused_not_a_500(api)` *(async function)* — "Council round 1 — `?after=2**63+1` was an authenticated 500."
+- `test_an_out_of_range_last_event_id_is_clamped_not_replayed(api)` *(async function)* — "The same overflow on the stream, where a 500 is not even available."
 - `test_every_emitted_event_type_has_a_summary_builder()` — "A type with no builder falls back to a bland sentence — silently."
 - `test_every_audited_domain_event_type_is_translated()` — "A new audit event under a deliverable entity must be classified on purpose."
 - `test_the_non_deliverable_entity_constants_stay_non_deliverable()` — "The exclusion of auth and preference rows is by construction; pin it."
@@ -1086,9 +1096,14 @@ tests/
 - `test_a_project_removed_from_the_actor_stops_reaching_them(api, users_file)` *(async function)* — "`allowed_projects` is re-read per poll, not captured when the stream opened."
 - `test_a_disconnected_client_ends_the_stream_without_a_closing_frame(api)` *(async function)* — "Nothing is listening, so there is nothing to tell."
 - `test_an_idle_stream_sends_a_comment_not_an_event(api)` *(async function)* — "A heartbeat keeps a proxy from timing out an idle connection."
+- `test_a_newline_in_stored_text_cannot_split_one_frame_into_two(api)` *(async function)* — "SSE is a line protocol: a raw newline inside `data:` ends the frame early."
 - `test_a_stream_type_filter_narrows_delivery_without_stalling_the_cursor(api)` *(async function)*
 - `test_the_slot_ceiling_refuses_rather_than_degrading_the_shared_pool(api)` *(async function)* — "The rate limiter bounds requests per window, not connections held open."
 - `test_a_finished_stream_gives_its_slot_back(api)` *(async function)* — "A slot that is not returned is gone for good, and the ceiling ratchets down."
+- `test_a_connection_that_dies_before_the_body_starts_still_returns_its_slot(api)` *(async function)* — "The release path the generator's `finally` cannot reach — council round 1."
+- `test_one_account_cannot_take_every_stream_slot(api)` *(async function)* — "A global ceiling is not a share — council round 1, the adversarial user."
+- `test_the_per_actor_ceiling_can_never_exceed_the_process_ceiling()` — "A per-actor ceiling above the global one reads as a share and is not one."
+- `test_the_stream_ceiling_fits_inside_the_connection_pool()` — "32 streams against a 15-connection pool is the incident `probes.py` records."
 - `test_the_stream_is_served_as_an_event_stream_that_a_proxy_will_not_buffer(api, monkeypatch)` *(async function)*
 - `test_last_event_id_resumes_and_beats_the_query_parameter(api, monkeypatch)` *(async function)* — "The header is what a reconnecting `EventSource` sends by itself."
 - `test_a_malformed_last_event_id_is_ignored_rather_than_refused(api)` *(async function)* — "The user agent sets that header, not the application."
@@ -1098,6 +1113,10 @@ tests/
 - `test_preferences_are_per_actor_and_never_another_accounts(api)` *(async function)*
 - `test_an_unknown_event_type_is_refused_with_the_field_named(api)` *(async function)*
 - `test_writing_preferences_needs_a_scope_reading_them_does_not(api)` *(async function)* — "Two actions, because an operator may grant one without the other."
+- `test_the_manage_scope_is_one_a_signed_in_client_can_actually_be_granted()` — "A scope outside `oauth_default_scopes` can never be granted to anyone."
+- `test_the_env_template_can_grant_every_scope_the_catalogue_needs()` — "The allowlist has two sources, and production reads the one nobody edits."
+- `test_a_rejected_subscription_list_cannot_amplify_the_response(api)` *(async function)* — "Council round 1 — the count was bounded, the bytes were not."
+- `test_a_rejected_type_filter_cannot_amplify_the_response(api)` *(async function)* — "The same reflection on the query side, where the URL is the only limit."
 - `test_a_stored_type_that_no_longer_exists_is_dropped_on_the_way_out(api)` *(async function)* — "A stored preference can outlive the type it names."
 - `test_preferences_do_not_filter_the_stream(api)` *(async function)* — "A documented decision, not an omission — so it is pinned as behaviour."
 - `test_an_empty_project_list_matches_nothing_and_is_not_no_restriction(api)` *(async function)* — "The one-character mistake: `if project_ids:` instead of `is not None`."

--- a/docs/issues/013-mobile-event-stream/RESUME.md
+++ b/docs/issues/013-mobile-event-stream/RESUME.md
@@ -1,0 +1,86 @@
+# RESUME — WK-20260826-gh13-events (issue #13, epic #1)
+
+- work_id: WK-20260826-gh13-events
+- data: 2026-08-26
+- branch: `feature/gh-13/mobile-event-stream`
+- contract: 1.8.0 (`probes.API_CONTRACT_VERSION` matched)
+
+## What shipped
+
+An authenticated **SSE** event stream (`GET /api/v1/events/stream`) plus a
+polling/backlog fallback (`GET /api/v1/events`) and notification-subscription
+preferences (`GET`/`PUT /api/v1/notifications/preferences`, migration
+`0009_event_subscriptions.sql`). Events are projected from `audit_events`
+(monotonic `id` is the resume cursor). Auth/security events are excluded; a
+project-scoped principal sees only its own projects' events (fail-closed on an
+underivable project); payloads go through a closed vocabulary, never raw
+`payload_json`. Resume from an id older than retention returns a typed
+`stream.gap` signal (no silent loss). New permissions `events.read`,
+`notifications.manage` reported by `/auth/me`.
+
+Endpoints, transport choice (SSE over WS: rides existing bearer auth on a GET,
+native `Last-Event-ID` reconnect) and the polling fallback are documented in
+`docs/api/README.md`.
+
+## Adversarial review — two rounds (`.docs/agents/council.md` §4)
+
+**Round 1 — raised 11 · survived §2 11 · became tests 11 · questions 0.** Lenses:
+claim auditor, second caller, adversarial user (commit `a49ccb8`). Every finding
+arrived with a reproduction and closed with a test that fails without the fix.
+Highest blast radius:
+- the payload whitelist admitted `control`/`state`, which `main.py` reads from an
+  executor's `task.ack` **unvalidated** — a connected executor could put a path,
+  an internal `host:port`, a `Bearer` value and a 200 KB blob into a mobile line.
+  Fixed with a closed vocabulary (membership, not an `assert`).
+- the `gap` block queried `audit_events` **unscoped** while the page was scoped —
+  a project-limited token could binary-search the global newest id. One
+  visibility predicate now used everywhere.
+- bounds: `?after=2**63+1` → 500 / killed the stream with no closing frame; unbounded
+  `?type=`/`eventTypes` reflected into `details[]`; one token could take all slots
+  (per-actor ceiling added; process ceiling lowered 32→8 to fit the 15-connection
+  pool).
+
+**Round 2 — raised 7 · survived §2 7 · became tests 1 · questions 2.** Verified by
+mutation that 6 of 7 round-1 fixes are genuinely pinned (revert → suite red); the
+core security properties (cross-project isolation, token-expiry/revocation ends
+the stream within one poll, resume with no off-by-one, auth rows excluded, NULL-
+project dropped for admins too) confirmed closed. Classification:
+
+| # | class | finding | disposition |
+|---|---|---|---|
+| 1 | introduzido-pela-r1 | per-actor slot ceiling untested at the wiring (the `api` fixture drops `per_actor`; dropping the arg leaves the suite green) | **CLOSED this session** — `test_the_module_level_slots_carry_the_configured_per_actor_ceiling` (fails when the arg is dropped) |
+| 2 | aberto-da-r1 | 4 accounts still lock out the admin (32→8 made it 4× cheaper); the 503 does not advertise that `GET /api/v1/events` is available now | **operator** — slot arithmetic / whether to advertise the fallback is a direction call |
+| 3 | introduzido-pela-r1 | the rescoping made `cursor_ahead`/`oldestAvailableId` per-feed, but the OpenAPI/README text still says "this log" — a client new to a quiet project is told its position "came from another deployment" | **operator/follow-up** — doc correction + whether losing project access deserves a distinct reason vs `beyond_retention` |
+| 4 | pré-existente | `actorId` is a whitelisted key with no vocabulary/redaction/length bound (**not reproduced end-to-end** — every live writer passes a server-side `user_id`) | **operator/follow-up** — bound + redact it defensively |
+| 5 | pré-existente | `redact` is a pattern list, not a closed set; `error`/`reason` free-text keys still ship a Stripe key, `pw=`, an S3 URI, a UNC path, an email. Same redactor and same `codexbridge.read` audience as the rest of the surface — **not an audience widening** | **operator** — improving `redact` is a whole-surface change |
+| 6 | pré-existente | a principal whose project is quiet re-scans the whole tail every poll (cursor never advances when the scoped page is empty); O(n) per poll, 96 ms @ 100k rows | **operator/follow-up** — advance the cursor past the scanned id even on an empty scoped page |
+| 7 | pré-existente | a malformed `Last-Event-ID` with no `?after=` replays the entire feed (`_resume_from("-4", None) == 0`); low severity — duplicates not loss, a compliant EventSource cannot produce it | **operator/follow-up** — clamp the no-`after` malformed case |
+
+Round-2 questions left open: (a) is 8/2 the right operating point for the number
+of operator accounts this deployment has, or advertise the fallback in the 503;
+(b) should losing access to a project be reported as `beyond_retention` or a
+third reason.
+
+Per `.docs/agents/council.md` §4 (two rounds, then the operator), the surviving
+round-2 findings that are not closed here are the operator's — none is a live
+security regression; the core isolation/expiry/resume properties are
+mutation-proven closed.
+
+## Checks
+
+`PYTHONPATH=. .venv/bin/python -m pytest -q` (project `.venv`; system python
+cannot collect `tests/contract` — pre-existing `fastapi.routing.iter_route_contexts`
+ImportError) → **617 passed, 3 skipped**. The round-2 wiring test verified failing
+against the unfixed wiring.
+
+Not validated: Postgres; any deployed environment; multi-worker uvicorn; nginx
+buffering of a long-lived SSE connection; push delivery (preferences are
+future-push hooks only). Migration `0009` NOT applied anywhere. Contract at
+1.8.0 — the operator re-bumps on merge order if #11 (1.7.0) lands first.
+`governancekit council --record` was not produced (no pre-commit hook here); the
+four counts per round are recorded here and in `docs/napkin-lessons.md`.
+
+## Next
+
+Operator: rule on round-2 findings 2–7 (mostly follow-up/pre-existing); merge
+order vs #11's 1.7.0; run `scripts/publish_contract.py` after merge (#14 gate).

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1022,3 +1022,32 @@ It expects `state_version`, `values`, and `refs`; a hand-written flat JSON with
 shared-contract kit refreshes, stage the real delivery first and record the
 council round against that staged diff, because the fingerprint binding is what
 actually clears the gate.
+
+## 2026-08-26 — council on gh-13 (mobile event stream), Squad E
+
+Two rounds against an SSE stream over `audit_events`. Branch
+`feature/gh-13/mobile-event-stream`.
+
+- Round 1 — raised: 11 · survived §2: 11 · became tests: 11 · questions: 0
+- Round 2 — raised: 7 · survived §2: 7 · became tests: 1 · questions: 2
+
+Lessons:
+
+- A per-actor slot ceiling that the deployment wires from settings was tested
+  only on a hand-built `StreamSlots(4, per_actor=2)`, while the `api` fixture
+  replaced the module-level object with `StreamSlots(limit)` — dropping
+  `per_actor`. So the guard that actually runs had no test: removing
+  `settings.event_stream_max_per_actor` from the construction left the whole
+  suite green. Pin the wired object, not just the class. Round 2 closed it with a
+  module-level assertion that the live `stream_slots.per_actor` equals the
+  configured value (and that the two config numbers differ, or the assertion
+  could not tell a dropped argument from the default).
+- Rescoping a "gap"/"oldest id" signal from the whole log to the caller's own
+  feed silently invalidated the published contract text ("beyond anything this
+  log has ever held … came from a different deployment"): a client simply new to
+  a quiet project now hits that reason on every connect. When you narrow what a
+  signal means, the OpenAPI/README sentence describing it is part of the change.
+- `redact` is a pattern list, not a closed set; whitelisting a payload key does
+  not make it safe unless the key is a closed vocabulary OR goes through
+  redaction+truncation. `actorId` was whitelisted with neither — latent only
+  because every live writer happens to pass a server-side id.

--- a/gateway/app/api/auth.py
+++ b/gateway/app/api/auth.py
@@ -62,6 +62,61 @@ def unauthenticated(message: str = TOKEN_REJECTED) -> ApiError:
     )
 
 
+async def principal_for_token(
+    session: AsyncSession, token: str
+) -> AuthenticatedPrincipal | None:
+    """The principal a bearer token resolves to right now, or None.
+
+    One function, two callers, on purpose. `current_principal` below authorizes
+    a single request; `gateway/app/api/routes/events.py` re-runs this on every
+    poll of a long-lived SSE stream, because a stream that authorized once at
+    `GET` time would keep delivering a project's events for as long as it stayed
+    open — through a revocation, an expiry, an account the operator disabled and
+    a project removed from `allowed_projects`. Both need the *same* answer, so
+    a second copy of these three checks is exactly the drift
+    `design-standards.md` §3 is about: the guard belongs next to the dangerous
+    thing, once.
+
+    Returns None for every failure rather than distinguishing them. The caller
+    decides what that means — a `401` for a request, an end-of-stream for a
+    stream — but not *why*, because unknown, expired, revoked and
+    account-disabled are indistinguishable to a caller by design (see
+    `unauthenticated` above).
+    """
+    item = await store.get_oauth_access_token(session, token)
+    if item is None:
+        # Covers unknown, expired and revoked alike: the store refuses all
+        # three, and telling them apart tells a probing caller whether a token
+        # was ever real.
+        return None
+
+    user = lookup_user(settings.user_registry_file, item.user_id)
+    if user is None or not user.enabled:
+        # 401, not 403, at the request caller. The operator disabled the account
+        # or removed it, so the credential is dead and the only recovery is to
+        # present another one — which is what 401 means and what the client's
+        # 401 branch does. A 403 here told the client "you are authenticated and
+        # not permitted", so it showed a permissions error and kept the dead
+        # session; and it made `/api/v1/auth/me` — the one endpoint whose
+        # purpose is reporting authorization — answer a status its contract does
+        # not declare.
+        #
+        # It also makes the rule the rest of this surface is documented by
+        # actually true: on `/api/v1`, `403` comes from `require_action` and
+        # from nowhere else.
+        return None
+
+    return AuthenticatedPrincipal(
+        user_id=user.user_id,
+        email=user.email,
+        roles=user.roles,
+        allowed_projects=user.allowed_projects,
+        scopes=json.loads(item.scopes_json or "[]"),
+        can_approve_sensitive=user.can_approve_sensitive,
+        auth_scheme="oauth",
+    )
+
+
 async def current_principal(
     request: Request,
     session: AsyncSession = Depends(get_session),
@@ -75,37 +130,9 @@ async def current_principal(
     if token is None:
         raise unauthenticated()
 
-    item = await store.get_oauth_access_token(session, token)
-    if item is None:
-        # Covers unknown, expired and revoked alike: the store refuses all
-        # three, and telling them apart tells a probing caller whether a token
-        # was ever real.
+    principal = await principal_for_token(session, token)
+    if principal is None:
         raise unauthenticated()
-
-    user = lookup_user(settings.user_registry_file, item.user_id)
-    if user is None or not user.enabled:
-        # 401, not 403. The operator disabled the account or removed it, so the
-        # credential is dead and the only recovery is to present another one —
-        # which is what 401 means and what the client's 401 branch does. A 403
-        # here told the client "you are authenticated and not permitted", so it
-        # showed a permissions error and kept the dead session; and it made
-        # `/api/v1/auth/me` — the one endpoint whose purpose is reporting
-        # authorization — answer a status its contract does not declare.
-        #
-        # It also makes the rule the rest of this surface is documented by
-        # actually true: on `/api/v1`, `403` comes from `require_action` and
-        # from nowhere else.
-        raise unauthenticated()
-
-    principal = AuthenticatedPrincipal(
-        user_id=user.user_id,
-        email=user.email,
-        roles=user.roles,
-        allowed_projects=user.allowed_projects,
-        scopes=json.loads(item.scopes_json or "[]"),
-        can_approve_sensitive=user.can_approve_sensitive,
-        auth_scheme="oauth",
-    )
     # Recorded for handlers and for anything that runs *after* authentication.
     #
     # NOT for the rate limiter, despite `client_key` preferring an actor bucket:

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -51,6 +51,12 @@ ISSUES_WRITE_SCOPE = "codexbridge.issues.write"
 # CANCEL_SCOPE: writing a project plan and starting a discussion about it are
 # different capabilities an operator may grant separately.
 CONVERSATIONS_WRITE_SCOPE = "codexbridge.conversations.write"
+# Changing one's own notification-subscription preferences (issue #13). Distinct
+# from every scope above for the same reason they are distinct from each other:
+# an operator may want a phone that can watch the event stream (READ_SCOPE)
+# without that phone being able to rewrite what the account gets notified about.
+# Reading the preferences needs only READ_SCOPE; this scope guards the write.
+NOTIFICATIONS_MANAGE_SCOPE = "codexbridge.notifications.manage"
 
 READ = "read"
 OPERATIONAL = "operational"
@@ -253,6 +259,28 @@ CONVERSATIONS_POST_MESSAGE = Action(
     summary="Post a message to a conversation.",
 )
 
+EVENTS_READ = Action(
+    name="events.read",
+    category=READ,
+    scope=READ_SCOPE,
+    summary="Read the event backlog and open the live event stream, within the actor's projects.",
+)
+
+NOTIFICATIONS_READ = Action(
+    name="notifications.read",
+    category=READ,
+    scope=READ_SCOPE,
+    summary="Read this actor's own notification-subscription preferences.",
+)
+
+NOTIFICATIONS_MANAGE = Action(
+    name="notifications.manage",
+    category=OPERATIONAL,
+    scope=NOTIFICATIONS_MANAGE_SCOPE,
+    summary="Change this actor's own notification-subscription preferences.",
+)
+
+
 # Order is the reported order. Grouped by class, read first, so a client that
 # renders the list without sorting produces something sensible.
 CATALOGUE: tuple[Action, ...] = (
@@ -266,6 +294,8 @@ CATALOGUE: tuple[Action, ...] = (
     EPICS_READ,
     ISSUES_READ,
     CONVERSATIONS_READ,
+    EVENTS_READ,
+    NOTIFICATIONS_READ,
     SESSIONS_STOP,
     SESSIONS_PAUSE,
     SESSIONS_RESUME,
@@ -277,6 +307,7 @@ CATALOGUE: tuple[Action, ...] = (
     EPICS_LINK_ISSUE,
     CONVERSATIONS_CREATE,
     CONVERSATIONS_POST_MESSAGE,
+    NOTIFICATIONS_MANAGE,
     SESSIONS_READ_ALL_PROJECTS,
     DECISIONS_READ,
     DECISIONS_DECIDE,

--- a/gateway/app/api/routes/events.py
+++ b/gateway/app/api/routes/events.py
@@ -105,6 +105,35 @@ router = APIRouter(prefix="/api/v1")
 
 EVENTS_ENDPOINT = "/api/v1/events"
 
+# The largest resume position this API accepts. `audit_events.id` is a 64-bit
+# signed identity column, so nothing above this can ever name a row — but until
+# this bound existed, `?after=2**63+1` was bound straight into the query and the
+# driver raised `OverflowError: Python int too large to convert to SQLite
+# INTEGER`, which reached the caller as `500 internal_error`. On the stream it
+# was worse: the response had already committed to `200 text/event-stream`, so
+# the body emitted `stream.open` and then simply ended — no `stream.gap`, no
+# `stream.closed`, and a client cannot tell that from a quiet feed (council
+# round 1, the adversarial user). `ge=0` bounded the low end only; an unbounded
+# integer parameter is an unbounded integer parameter in both directions.
+MAX_EVENT_ID = 2**63 - 1
+
+# How many `details[]` entries a rejected filter or subscription list may quote
+# back, and how much of each value. The details array exists so a client can
+# show which value it got wrong; quoting an unbounded number of unbounded
+# strings turned a large request into an equally large error response.
+MAX_ECHOED_DETAILS = 10
+MAX_ECHOED_VALUE = 64
+
+
+def _echo(value: str) -> str:
+    """One caller-supplied value, safe to put in an error message.
+
+    Truncated rather than omitted: a client that mistyped one event type needs
+    to see which one, and 64 characters is longer than every value this
+    vocabulary contains.
+    """
+    return value if len(value) <= MAX_ECHOED_VALUE else value[:MAX_ECHOED_VALUE] + "…"
+
 
 # --------------------------------------------------------------------------
 # Concurrency ceiling
@@ -112,7 +141,7 @@ EVENTS_ENDPOINT = "/api/v1/events"
 
 
 class StreamSlot:
-    """One acquired slot, releasable exactly once.
+    """One acquired slot, releasable exactly once, remembering whose it was.
 
     Idempotent because the slot is released down two paths that both have to
     exist: the generator's `finally`, which covers a normal end and a client
@@ -124,15 +153,16 @@ class StreamSlot:
     permanent: the ceiling ratchets down until the endpoint answers 503 forever.
     """
 
-    def __init__(self, slots: "StreamSlots") -> None:
+    def __init__(self, slots: "StreamSlots", owner: str) -> None:
         self._slots = slots
+        self._owner = owner
         self._released = False
 
     def release(self) -> None:
         if self._released:
             return
         self._released = True
-        self._slots.release()
+        self._slots.release(self._owner)
 
 
 class StreamSlots:
@@ -150,17 +180,32 @@ class StreamSlots:
     queueing: a client told to come back later reconnects with its
     `Last-Event-ID` and loses nothing, while a queued client holds the
     connection it was refused for.
+
+    **Two ceilings, because one global ceiling is not a share.** The process
+    ceiling protects the gateway; the per-actor ceiling is what stops one
+    read-only token from taking every slot and answering `503` to everybody
+    else — including an administrator — for as long as it keeps its connections
+    (council round 1, the adversarial user). Neither is a rate limit: the
+    limiter counts requests per window, and a request here is a connection held
+    for minutes.
     """
 
-    def __init__(self, limit: int) -> None:
+    def __init__(self, limit: int, per_actor: int | None = None) -> None:
         self.limit = limit
+        # A per-actor ceiling above the process ceiling would never bind, which
+        # reads as "there is a per-actor ceiling" while there is not.
+        self.per_actor = min(per_actor if per_actor is not None else limit, limit)
         self._active = 0
+        self._by_actor: dict[str, int] = {}
 
     @property
     def active(self) -> int:
         return self._active
 
-    def acquire(self) -> StreamSlot:
+    def active_for(self, owner: str) -> int:
+        return self._by_actor.get(owner, 0)
+
+    def acquire(self, owner: str) -> StreamSlot:
         if self._active >= self.limit:
             raise ApiError(
                 status_code=503,
@@ -168,17 +213,38 @@ class StreamSlots:
                 message="Too many event streams are open on this gateway. Retry shortly.",
                 headers={"Retry-After": "5"},
             )
+        if self._by_actor.get(owner, 0) >= self.per_actor:
+            raise ApiError(
+                status_code=503,
+                code=DEPENDENCY_UNAVAILABLE,
+                message=(
+                    "This account already has as many event streams open as it may. "
+                    "Close one, or retry shortly."
+                ),
+                headers={"Retry-After": "5"},
+            )
         self._active += 1
-        return StreamSlot(self)
+        self._by_actor[owner] = self._by_actor.get(owner, 0) + 1
+        return StreamSlot(self, owner)
 
-    def release(self) -> None:
+    def release(self, owner: str) -> None:
         # Never below zero. A counter that underflows reads as "off" forever
         # after, which would silently remove the ceiling
         # (`design-standards.md` §6).
         self._active = max(0, self._active - 1)
+        remaining = self._by_actor.get(owner, 0) - 1
+        if remaining > 0:
+            self._by_actor[owner] = remaining
+        else:
+            # Popped rather than left at zero: the dict is keyed by user id and
+            # would otherwise grow once per actor that ever opened a stream and
+            # never shrink — a slow leak in a process that runs for weeks.
+            self._by_actor.pop(owner, None)
 
 
-stream_slots = StreamSlots(settings.event_stream_max_concurrent)
+stream_slots = StreamSlots(
+    settings.event_stream_max_concurrent, settings.event_stream_max_per_actor
+)
 
 
 # --------------------------------------------------------------------------
@@ -203,9 +269,12 @@ def _requested_types(types: list[str] | None) -> list[str]:
             status_code=400,
             code=VALIDATION_FAILED,
             message="Unknown event type in the type filter.",
+            # Bounded in both dimensions. Unbounded, this reflected every
+            # rejected value at full length, so a caller could turn a large
+            # query string into an equally large error body.
             details=[
-                {"field": "?type", "code": "unknown_event_type", "message": f"No such event type: {value}."}
-                for value in unknown
+                {"field": "?type", "code": "unknown_event_type", "message": f"No such event type: {_echo(value)}."}
+                for value in unknown[:MAX_ECHOED_DETAILS]
             ],
         )
     return list(types)
@@ -222,6 +291,31 @@ def _narrow_projects(principal: AuthenticatedPrincipal, requested: list[str] | N
     if requested:
         return [value for value in requested if projects is None or value in projects]
     return projects
+
+
+async def _gap_for(
+    session: AsyncSession, principal: AuthenticatedPrincipal, after: int
+) -> tuple[str, dict | None]:
+    """The gap block for one resume position, or None when it is continuous.
+
+    One function for both transports so the `stream.gap` frame and the polling
+    endpoint's `gap` object cannot describe the position differently — they are
+    the same answer to the same question, and a client is expected to move
+    between the two mid-feed.
+    """
+    scope = dict(
+        project_ids=visible_projects(principal),
+        entity_types=sorted(event_types.DELIVERABLE_ENTITY_TYPES),
+        audit_event_types=sorted(event_types.TRANSLATED_AUDIT_EVENT_TYPES),
+    )
+    status = await store.audit_cursor_status(session, after, **scope)
+    if status == store.CURSOR_OK:
+        return status, None
+    return status, {
+        "reason": status,
+        "from": after,
+        "oldestAvailableId": await store.oldest_audit_event_id(session, **scope),
+    }
 
 
 def _to_event(row, project_id: str) -> event_types.MobileEvent | None:
@@ -253,7 +347,7 @@ def _to_event(row, project_id: str) -> event_types.MobileEvent | None:
 def _payload(raw: str | None) -> dict:
     """The stored payload as a dict, or an empty one.
 
-    Never raises. `payload_json` is years of rows written by eleven call sites,
+    Never raises. `payload_json` is years of rows written by thirty-one call sites,
     and one unparseable row must not take down a stream that is otherwise
     correct — the summary degrades to its default sentence instead.
     """
@@ -318,7 +412,7 @@ async def _load_events(
 @router.get("/events", tags=["events"])
 async def list_events(
     response: Response,
-    after: int | None = Query(default=None, ge=0),
+    after: int | None = Query(default=None, ge=0, le=MAX_EVENT_ID),
     project: list[str] | None = Query(default=None),
     type: list[str] | None = Query(default=None),  # noqa: A002 - the contract's parameter name
     limit: int | None = Query(default=None),
@@ -365,13 +459,14 @@ async def list_events(
         "page": {"hasMore": has_more, "nextAfter": next_after},
     }
     if after is not None:
-        status = await store.audit_cursor_status(session, after)
-        if status != store.CURSOR_OK:
-            body["gap"] = {
-                "reason": status,
-                "from": after,
-                "oldestAvailableId": await store.oldest_audit_event_id(session),
-            }
+        # Scoped to what this principal may see, and to `visible_projects` rather
+        # than to `projects` above: `?project=` is a filter the client chose for
+        # this one request, while continuity is a property of the whole feed the
+        # client resumes from. Narrowing the gap check by a transient filter
+        # would report a gap to a client that had merely changed its filter.
+        status, gap = await _gap_for(session, principal, after)
+        if gap is not None:
+            body["gap"] = gap
 
     response.headers["Cache-Control"] = "no-store"
     return body
@@ -394,8 +489,20 @@ def _frame(*, event: str, data: dict, event_id: int | None = None) -> str:
     if event_id is not None:
         lines.append(f"id: {event_id}")
     lines.append(f"event: {event}")
-    # `ensure_ascii=True` so a frame is always one line of ASCII: a raw newline
-    # inside `data:` would end the frame early and split one event into two.
+    # What keeps a frame on one line is `json.dumps` escaping `\r` and `\n`,
+    # which it does whatever `ensure_ascii` says: no value can end a `data:`
+    # line early and split one event into two. The first cut of this comment
+    # credited `ensure_ascii` with that, which would have told the next reader
+    # that turning it off breaks frame integrity — it does not (council round 1,
+    # the claim auditor).
+    #
+    # `ensure_ascii=True` is still not decorative. With it off, Python leaves
+    # U+2028 and U+2029 raw; neither is an SSE line terminator, so the frame
+    # survives, but both are *JavaScript* line terminators, and a client that
+    # evaluates a payload rather than parsing it would see a different program.
+    # An all-ASCII body also survives a proxy or client that mishandles UTF-8.
+    # Both properties are pinned by
+    # `test_a_newline_in_stored_text_cannot_split_one_frame_into_two`.
     lines.append(f"data: {json.dumps(data, ensure_ascii=True, separators=(',', ':'))}")
     return "\n".join(lines) + "\n\n"
 
@@ -413,6 +520,12 @@ def _resume_from(last_event_id: str | None, after: int | None) -> int:
     A malformed header is treated as absent rather than as an error. It is set
     by the user agent, not the application, and refusing the connection over it
     would strand a client that cannot control the value.
+
+    A value above `MAX_EVENT_ID` is **clamped, not discarded**. Discarding it
+    would fall back to `after`, or to 0, and replay the whole feed to a client
+    that asked to resume — the one outcome this endpoint must never produce.
+    Clamped, the position is beyond every row, so the client is told
+    `cursor_ahead` and knows exactly where it stands.
     """
     if last_event_id is not None:
         try:
@@ -420,8 +533,8 @@ def _resume_from(last_event_id: str | None, after: int | None) -> int:
         except (TypeError, ValueError):
             parsed = -1
         if parsed >= 0:
-            return parsed
-    return after or 0
+            return min(parsed, MAX_EVENT_ID)
+    return min(after or 0, MAX_EVENT_ID)
 
 
 async def _authorize(session: AsyncSession, token: str) -> AuthenticatedPrincipal | None:
@@ -478,22 +591,14 @@ async def event_stream(
     try:
         yield _frame(event=event_types.STREAM_OPEN, data={"type": event_types.STREAM_OPEN, "from": cursor, "at": now_z()})
 
-        async with factory() as session:
-            status = await store.audit_cursor_status(session, cursor)
-            oldest = await store.oldest_audit_event_id(session) if status != store.CURSOR_OK else None
-        if status != store.CURSOR_OK:
-            # Announced before a single event is delivered. Delivering first and
-            # mentioning the gap later would let a client act on a partial view
-            # believing it was continuous.
-            yield _frame(
-                event=event_types.STREAM_GAP,
-                data={
-                    "type": event_types.STREAM_GAP,
-                    "reason": status,
-                    "from": cursor,
-                    "oldestAvailableId": oldest,
-                },
-            )
+        # Computed on the first poll rather than before the loop, because the
+        # answer is scoped to the principal and the principal is resolved inside
+        # the loop. That ordering is not merely convenient: the gap block names
+        # positions in the caller's own feed, so producing it before the token
+        # was re-checked would have been a read performed for a credential this
+        # generator had not yet verified.
+        pending_gap: dict | None = None
+        first_poll = True
 
         while True:
             if is_disconnected is not None and await is_disconnected():
@@ -505,6 +610,8 @@ async def event_stream(
                 if principal is None:
                     closed_reason = "unauthenticated"
                     break
+                if first_poll:
+                    _status, pending_gap = await _gap_for(session, principal, cursor)
                 projects = _narrow_projects(principal, requested_projects)
                 # The cursor advances past every row this poll *loaded*, not
                 # just the ones a type filter kept. Advancing only past
@@ -517,6 +624,17 @@ async def event_stream(
                     after=cursor,
                     limit=batch_limit,
                 )
+
+            if first_poll:
+                first_poll = False
+                if pending_gap is not None:
+                    # Announced before a single event is delivered. Delivering
+                    # first and mentioning the gap later would let a client act
+                    # on a partial view believing it was continuous.
+                    yield _frame(
+                        event=event_types.STREAM_GAP,
+                        data={"type": event_types.STREAM_GAP, **pending_gap},
+                    )
 
             for event in events:
                 yield _frame(event=event.type, data=event.as_dict(), event_id=event.id)
@@ -558,7 +676,7 @@ async def event_stream(
 @router.get("/events/stream", tags=["events"])
 async def stream_events(
     request: Request,
-    after: int | None = Query(default=None, ge=0),
+    after: int | None = Query(default=None, ge=0, le=MAX_EVENT_ID),
     project: list[str] | None = Query(default=None),
     type: list[str] | None = Query(default=None),  # noqa: A002 - the contract's parameter name
     last_event_id: str | None = Header(default=None, alias="Last-Event-ID"),
@@ -583,7 +701,10 @@ async def stream_events(
     wanted = _requested_types(type)
     resume = _resume_from(last_event_id, after)
 
-    slot = stream_slots.acquire()
+    # Keyed by user id, not by token: two tokens for one account are one
+    # account's share, and a client that reconnects with a fresh token must not
+    # be able to double its allowance by doing so.
+    slot = stream_slots.acquire(principal.user_id)
     try:
         body = event_stream(
             factory=session_factory(),

--- a/gateway/app/api/routes/events.py
+++ b/gateway/app/api/routes/events.py
@@ -1,0 +1,624 @@
+"""Near-real-time delivery of what changed, and the backlog behind it — issue #13.
+
+Two endpoints, one source of truth:
+
+- `GET /api/v1/events/stream` — Server-Sent Events, the live transport.
+- `GET /api/v1/events` — the same events as an ordinary paged read. This is the
+  documented **fallback**, not a second-class path: a client on a network that
+  breaks long-lived connections, or one in the background where the platform
+  will not keep a socket open, polls this and gets exactly the same events with
+  exactly the same ids.
+
+## Why SSE and not WebSocket
+
+The gateway already speaks WebSocket at `/agent/ws`, so "we have no WebSocket"
+is not the reason. The reasons are:
+
+- **Authentication.** Every endpoint on this contract authenticates with
+  `Authorization: Bearer` through `api/auth.py:current_principal`, which is an
+  ordinary FastAPI dependency on an ordinary `GET`. A browser/mobile WebSocket
+  cannot set that header on the handshake, so a WebSocket stream would need a
+  *second* authentication scheme — a token in the URL is what
+  `security-standards.md` §3 forbids by name, and a post-handshake auth frame is
+  a bespoke protocol to keep correct forever. SSE rides the scheme that already
+  exists.
+- **Resume is in the transport.** `Last-Event-ID` is part of SSE: a client that
+  drops reconnects and the browser/EventSource sends the last id it saw, with no
+  application protocol on top. Issue #13's "resume from the last acknowledged
+  event" is the mechanism SSE was designed around.
+- **One direction is all this needs.** Nothing in the issue asks the client to
+  send anything on the channel. A bidirectional transport whose reverse channel
+  is unused is surface with no consumer.
+- **`/agent/ws` is not a precedent for this.** It is the executor's reverse
+  channel, authenticated by a machine token, contracted by `docs/protocol.md`,
+  and explicitly excluded from this contract. A mobile client never opens it.
+
+The trade-off, stated rather than hidden: SSE is HTTP/1.1 text and holds a
+connection. That is why this module bounds the number of concurrent streams
+(`stream_slots`), bounds each stream's lifetime, and sends heartbeats — see
+below.
+
+## What is delivered, and what could never be
+
+Events are `audit_events` rows translated by
+`gateway/app/services/event_types.py`. That module owns *what may be said*; this
+one owns *who may hear it and when*. Three properties this module is responsible
+for:
+
+1. **Project authorization is on the query.** `store.list_mobile_events_page`
+   filters by the caller's projects in SQL, so a page is never a filtered-down
+   view of rows the caller was allowed to load. A row whose project cannot be
+   derived is delivered to nobody, admins included.
+
+2. **Authorization is re-checked on every poll, not once at `GET`.** A stream
+   opened at 09:00 and still running at 17:00 authorized once, and everything
+   after that is a decision made with an eight-hour-old credential. `_authorize`
+   below re-resolves the bearer token through `api/auth.py:principal_for_token`
+   on each iteration, so a revoked token, an expired token, a disabled account
+   and a project removed from `allowed_projects` all take effect within one poll
+   interval. Pinned by
+   `tests/integration/test_events.py::test_a_revoked_token_stops_the_stream_it_had_already_opened`.
+
+3. **A gap is announced, never silent.** Resume is `id > cursor`, so the only
+   way to lose an event is for the row itself to be gone. `store.audit_cursor_status`
+   detects that (and the mirror case, a cursor from another deployment) and the
+   stream opens with a `stream.gap` frame instead of quietly delivering from
+   wherever the log now starts.
+
+## Frames
+
+    event: stream.open        no id — an opening acknowledgement, not a position
+    event: stream.gap         no id — resume is not continuous; re-read
+    event: <MobileEventType>  id: <audit id>  — the events themselves
+    : keep-alive              a comment, so proxies do not time out an idle stream
+    event: stream.closed      no id — why the server ended it
+
+Only the third kind carries `id:`, and that is deliberate: `Last-Event-ID` must
+never advance past an event the client actually received, so a control frame is
+not allowed to move it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections.abc import AsyncIterator, Callable
+
+from fastapi import APIRouter, Depends, Header, Query, Request, Response
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.background import BackgroundTask
+
+from gateway.app.api import pagination, permissions
+from gateway.app.api.auth import bearer_token, principal_for_token, require_action, visible_projects
+from gateway.app.api.errors import DEPENDENCY_UNAVAILABLE, VALIDATION_FAILED, ApiError
+from gateway.app.api.routes.sessions import redact
+from gateway.app.api.timestamps import now_z, utc_z
+from gateway.app.core.config import settings
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.session import get_session, session_factory
+from gateway.app.services import event_types, store
+
+
+router = APIRouter(prefix="/api/v1")
+
+EVENTS_ENDPOINT = "/api/v1/events"
+
+
+# --------------------------------------------------------------------------
+# Concurrency ceiling
+# --------------------------------------------------------------------------
+
+
+class StreamSlot:
+    """One acquired slot, releasable exactly once.
+
+    Idempotent because the slot is released down two paths that both have to
+    exist: the generator's `finally`, which covers a normal end and a client
+    disconnect once the body has started, and the response's background task,
+    which covers the case the `finally` cannot — a connection dropped after the
+    route returned but before the generator was ever iterated. An async
+    generator that never started running has no `finally` to run, so relying on
+    it alone leaked a slot per dropped connection, and a leaked slot is
+    permanent: the ceiling ratchets down until the endpoint answers 503 forever.
+    """
+
+    def __init__(self, slots: "StreamSlots") -> None:
+        self._slots = slots
+        self._released = False
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        self._slots.release()
+
+
+class StreamSlots:
+    """How many event streams this process will hold open at once.
+
+    Not covered by the rate limiter, and that is the point: the limiter counts
+    *requests* per window, and one accepted request here becomes a connection
+    held for up to `event_stream_max_duration_seconds` that takes a database
+    session on every poll. Under the default ceiling of 120 requests/minute a
+    single bucket could pin 120 concurrent pollers against the same pool
+    `GET /api/v1/sessions` uses — so the endpoint that is cheap per request is
+    the one that can take the API down.
+
+    Refusing with `503 dependency_unavailable` + `Retry-After` rather than
+    queueing: a client told to come back later reconnects with its
+    `Last-Event-ID` and loses nothing, while a queued client holds the
+    connection it was refused for.
+    """
+
+    def __init__(self, limit: int) -> None:
+        self.limit = limit
+        self._active = 0
+
+    @property
+    def active(self) -> int:
+        return self._active
+
+    def acquire(self) -> StreamSlot:
+        if self._active >= self.limit:
+            raise ApiError(
+                status_code=503,
+                code=DEPENDENCY_UNAVAILABLE,
+                message="Too many event streams are open on this gateway. Retry shortly.",
+                headers={"Retry-After": "5"},
+            )
+        self._active += 1
+        return StreamSlot(self)
+
+    def release(self) -> None:
+        # Never below zero. A counter that underflows reads as "off" forever
+        # after, which would silently remove the ceiling
+        # (`design-standards.md` §6).
+        self._active = max(0, self._active - 1)
+
+
+stream_slots = StreamSlots(settings.event_stream_max_concurrent)
+
+
+# --------------------------------------------------------------------------
+# Shared reads
+# --------------------------------------------------------------------------
+
+
+def _requested_types(types: list[str] | None) -> list[str]:
+    """Validate a `type` filter against the published vocabulary.
+
+    Checked against `ALL_EVENT_TYPES`, which includes the types this build
+    declares and does not yet emit (`artifact.*`, `androidBuild.*`): a client
+    filtering on one of those must get an empty result, not a `400`, or the
+    declared-but-unemitted values would be unusable in exactly the way declaring
+    them was meant to avoid.
+    """
+    if not types:
+        return []
+    unknown = sorted({value for value in types if value not in event_types.ALL_EVENT_TYPES})
+    if unknown:
+        raise ApiError(
+            status_code=400,
+            code=VALIDATION_FAILED,
+            message="Unknown event type in the type filter.",
+            details=[
+                {"field": "?type", "code": "unknown_event_type", "message": f"No such event type: {value}."}
+                for value in unknown
+            ],
+        )
+    return list(types)
+
+
+def _narrow_projects(principal: AuthenticatedPrincipal, requested: list[str] | None) -> list[str] | None:
+    """The projects to query: the caller's, narrowed by `?project=` if given.
+
+    `project` only ever narrows. An admin's `None` becomes the requested list;
+    a restricted caller cannot name a project outside `allowed_projects` and
+    have it survive the intersection. Same shape as `routes/decisions.py`.
+    """
+    projects = visible_projects(principal)
+    if requested:
+        return [value for value in requested if projects is None or value in projects]
+    return projects
+
+
+def _to_event(row, project_id: str) -> event_types.MobileEvent | None:
+    """One audit row as a mobile event, or None when it is not one of ours.
+
+    Returns None only for a row the query should already have excluded. Both
+    guards are here rather than only in SQL because this function is also the
+    one the stream calls, and a translation that silently produced a `type` of
+    `None` would ship a malformed frame.
+    """
+    payload = _payload(row.payload_json)
+    classified = event_types.classify(row.event_type, payload)
+    if classified is None:
+        return None
+    mobile_type, entity_kind = classified
+    return event_types.MobileEvent(
+        id=row.id,
+        type=mobile_type,
+        project_id=project_id,
+        entity_kind=entity_kind,
+        entity_id=row.entity_id,
+        at=utc_z(row.created_at),
+        summary=event_types.summarize(mobile_type, payload, redact),
+        state=event_types.state_of(payload),
+        actor_id=event_types.actor_of(payload),
+    )
+
+
+def _payload(raw: str | None) -> dict:
+    """The stored payload as a dict, or an empty one.
+
+    Never raises. `payload_json` is years of rows written by eleven call sites,
+    and one unparseable row must not take down a stream that is otherwise
+    correct — the summary degrades to its default sentence instead.
+    """
+    try:
+        value = json.loads(raw or "{}")
+    except (TypeError, ValueError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+async def _load_events(
+    session: AsyncSession,
+    *,
+    projects: list[str] | None,
+    types: list[str],
+    after: int | None,
+    limit: int,
+) -> tuple[list[event_types.MobileEvent], bool, int | None]:
+    """A page of translated events, whether more follow, and the last id *loaded*.
+
+    The `type` filter is applied **after** translation because the client's
+    vocabulary is the mobile one and the column holds the internal one; the
+    query still narrows by the full set of translatable audit types, so the
+    rows loaded are bounded by `limit + 1` either way. `has_more` is computed
+    from the over-fetch before filtering, so it stays truthful: a page short
+    because of a type filter still reports that more rows exist.
+
+    The third element is the id of the last row this page **loaded**, which is
+    not the id of the last event returned when a type filter dropped the tail.
+    Both callers advance their position by it, and they need it from the same
+    query that produced the page: computing it with a second identical query
+    doubled the work of every poll of every open stream, and left a window in
+    which the two queries could see different rows — the second one advancing
+    the cursor past an event the first had not yet delivered, which is the
+    silent loss this endpoint exists to rule out.
+    """
+    rows = await store.list_mobile_events_page(
+        session,
+        project_ids=projects,
+        entity_types=sorted(event_types.DELIVERABLE_ENTITY_TYPES),
+        audit_event_types=sorted(event_types.TRANSLATED_AUDIT_EVENT_TYPES),
+        after=after,
+        limit=limit,
+    )
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    last_loaded_id = page[-1][0].id if page else None
+    events: list[event_types.MobileEvent] = []
+    for row, project_id in page:
+        event = _to_event(row, project_id)
+        if event is None or (types and event.type not in types):
+            continue
+        events.append(event)
+    return events, has_more, last_loaded_id
+
+
+# --------------------------------------------------------------------------
+# GET /api/v1/events — the backlog, and the documented polling fallback
+# --------------------------------------------------------------------------
+
+
+@router.get("/events", tags=["events"])
+async def list_events(
+    response: Response,
+    after: int | None = Query(default=None, ge=0),
+    project: list[str] | None = Query(default=None),
+    type: list[str] | None = Query(default=None),  # noqa: A002 - the contract's parameter name
+    limit: int | None = Query(default=None),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.EVENTS_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Events the caller may see, oldest first, after `after`.
+
+    **Not cursor-paged, deliberately.** Every other collection in this contract
+    uses an opaque signed cursor; this one is addressed by the same integer id
+    the stream puts in `id:`, for the reason `gateway/app/api/pagination.py`
+    already gives about session logs: an append-only stream keyed by a monotonic
+    integer must not be given a second paging vocabulary, and here the id is
+    *public by necessity* — it is the SSE resume token, so wrapping it in an
+    opaque cursor would publish two names for one position and make `Last-Event-ID`
+    and `?after=` incompatible.
+
+    Oldest first, like `GET /api/v1/missions/{id}/timeline` and unlike the
+    newest-first collections: a client is catching up, and catching up reads
+    forward.
+
+    Carries the same `gap` signal the stream sends as a `stream.gap` frame. The
+    polling fallback is the transport a client on a hostile network ends up
+    living on, and "no silent loss on resume" is a property of the *events*, not
+    of one transport — a client that fell out of retention and polls would
+    otherwise be handed a page starting wherever the log now begins, with
+    nothing to distinguish it from continuity.
+    """
+    projects = _narrow_projects(principal, project)
+    wanted = _requested_types(type)
+    size = pagination.parse_limit(limit)
+
+    events, has_more, last_loaded_id = await _load_events(
+        session, projects=projects, types=wanted, after=after, limit=size
+    )
+    # `nextAfter` is the last id **loaded**, not the last id returned: with a
+    # type filter the two differ, and reporting the last *returned* id would
+    # make the next request re-scan rows the filter already rejected — forever,
+    # if nothing in the tail matches.
+    next_after = last_loaded_id if has_more else None
+
+    body: dict = {
+        "items": [event.as_dict() for event in events],
+        "page": {"hasMore": has_more, "nextAfter": next_after},
+    }
+    if after is not None:
+        status = await store.audit_cursor_status(session, after)
+        if status != store.CURSOR_OK:
+            body["gap"] = {
+                "reason": status,
+                "from": after,
+                "oldestAvailableId": await store.oldest_audit_event_id(session),
+            }
+
+    response.headers["Cache-Control"] = "no-store"
+    return body
+
+
+# --------------------------------------------------------------------------
+# GET /api/v1/events/stream — Server-Sent Events
+# --------------------------------------------------------------------------
+
+
+def _frame(*, event: str, data: dict, event_id: int | None = None) -> str:
+    """One SSE frame.
+
+    `id:` is emitted only when an event actually has a position. A control frame
+    that carried one would advance the client's `Last-Event-ID` past events it
+    never received, which is precisely the silent loss this endpoint's
+    acceptance criterion forbids.
+    """
+    lines = []
+    if event_id is not None:
+        lines.append(f"id: {event_id}")
+    lines.append(f"event: {event}")
+    # `ensure_ascii=True` so a frame is always one line of ASCII: a raw newline
+    # inside `data:` would end the frame early and split one event into two.
+    lines.append(f"data: {json.dumps(data, ensure_ascii=True, separators=(',', ':'))}")
+    return "\n".join(lines) + "\n\n"
+
+
+HEARTBEAT_FRAME = ": keep-alive\n\n"
+
+
+def _resume_from(last_event_id: str | None, after: int | None) -> int:
+    """Where to resume, from the SSE header or the query parameter.
+
+    `Last-Event-ID` wins when both are present: the header is what a reconnecting
+    EventSource sends by itself, and it is the more recent of the two by
+    construction — a client's `?after=` is whatever it first opened with.
+
+    A malformed header is treated as absent rather than as an error. It is set
+    by the user agent, not the application, and refusing the connection over it
+    would strand a client that cannot control the value.
+    """
+    if last_event_id is not None:
+        try:
+            parsed = int(last_event_id.strip())
+        except (TypeError, ValueError):
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return after or 0
+
+
+async def _authorize(session: AsyncSession, token: str) -> AuthenticatedPrincipal | None:
+    """The principal for this stream right now, or None if it may no longer read.
+
+    Both halves matter. `principal_for_token` covers revocation, expiry and a
+    disabled account; the `is_allowed` check covers a scope the token no longer
+    carries. Together they mean the answer to "may this connection still receive
+    events" is recomputed from scratch on every poll rather than inherited from
+    the `GET` that opened it.
+    """
+    principal = await principal_for_token(session, token)
+    if principal is None:
+        return None
+    if not permissions.is_allowed(principal, permissions.EVENTS_READ):
+        return None
+    return principal
+
+
+async def event_stream(
+    *,
+    factory,
+    token: str,
+    resume_from: int,
+    requested_projects: list[str] | None,
+    requested_types: list[str],
+    poll_interval: float,
+    heartbeat_seconds: float,
+    max_duration_seconds: float,
+    batch_limit: int,
+    on_close: Callable[[], None] | None = None,
+    is_disconnected: Callable[[], object] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], object] = asyncio.sleep,
+) -> AsyncIterator[str]:
+    """The SSE body: an async generator of frames.
+
+    Written as a free function taking its collaborators as parameters rather
+    than reading them from the request, because that is the seam the tests need
+    (`design-standards.md` §2): `tests/integration/test_events.py` drives this
+    directly with a tiny poll interval and a real database, and asserts on the
+    frames — no sleeping on wall-clock timing, no flaky "did it arrive yet".
+
+    A **session per poll**, not one held for the stream's lifetime. A stream can
+    live fifteen minutes; a database session that lives that long pins a pooled
+    connection for the whole time and would make the concurrency ceiling a
+    ceiling on the pool itself.
+    """
+    started = monotonic()
+    cursor = resume_from
+    last_emission = started
+    closed_reason = "max_duration"
+
+    try:
+        yield _frame(event=event_types.STREAM_OPEN, data={"type": event_types.STREAM_OPEN, "from": cursor, "at": now_z()})
+
+        async with factory() as session:
+            status = await store.audit_cursor_status(session, cursor)
+            oldest = await store.oldest_audit_event_id(session) if status != store.CURSOR_OK else None
+        if status != store.CURSOR_OK:
+            # Announced before a single event is delivered. Delivering first and
+            # mentioning the gap later would let a client act on a partial view
+            # believing it was continuous.
+            yield _frame(
+                event=event_types.STREAM_GAP,
+                data={
+                    "type": event_types.STREAM_GAP,
+                    "reason": status,
+                    "from": cursor,
+                    "oldestAvailableId": oldest,
+                },
+            )
+
+        while True:
+            if is_disconnected is not None and await is_disconnected():
+                closed_reason = "disconnected"
+                return
+
+            async with factory() as session:
+                principal = await _authorize(session, token)
+                if principal is None:
+                    closed_reason = "unauthenticated"
+                    break
+                projects = _narrow_projects(principal, requested_projects)
+                # The cursor advances past every row this poll *loaded*, not
+                # just the ones a type filter kept. Advancing only past
+                # delivered events would re-scan the filtered ones on every
+                # poll for as long as the stream lives.
+                events, _, last_loaded_id = await _load_events(
+                    session,
+                    projects=projects,
+                    types=requested_types,
+                    after=cursor,
+                    limit=batch_limit,
+                )
+
+            for event in events:
+                yield _frame(event=event.type, data=event.as_dict(), event_id=event.id)
+                last_emission = monotonic()
+            # Advanced only after the frames are out. A cursor moved before the
+            # yields would skip the batch if the consumer went away mid-loop and
+            # the generator were resumed — and `max` because a client's
+            # `Last-Event-ID` may legitimately be ahead of anything visible to
+            # it, and the cursor must never move backwards.
+            if last_loaded_id is not None:
+                cursor = max(cursor, last_loaded_id)
+
+            now = monotonic()
+            if not events and now - last_emission >= heartbeat_seconds:
+                # A comment, not an event: it keeps the connection warm through
+                # a proxy's read timeout without appearing in the client's
+                # `onmessage` or moving `Last-Event-ID`.
+                yield HEARTBEAT_FRAME
+                last_emission = now
+
+            if now - started >= max_duration_seconds:
+                closed_reason = "max_duration"
+                break
+            await sleep(poll_interval)
+
+        yield _frame(
+            event=event_types.STREAM_CLOSED,
+            data={"type": event_types.STREAM_CLOSED, "reason": closed_reason, "at": now_z()},
+        )
+    finally:
+        # Runs on a normal end, on `aclose()` when the client disconnects, and
+        # on cancellation. The slot is taken by the route before this generator
+        # is handed to the response, so releasing it anywhere else would leak
+        # one per dropped connection — and a leaked slot is permanent.
+        if on_close is not None:
+            on_close()
+
+
+@router.get("/events/stream", tags=["events"])
+async def stream_events(
+    request: Request,
+    after: int | None = Query(default=None, ge=0),
+    project: list[str] | None = Query(default=None),
+    type: list[str] | None = Query(default=None),  # noqa: A002 - the contract's parameter name
+    last_event_id: str | None = Header(default=None, alias="Last-Event-ID"),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.EVENTS_READ)),
+) -> StreamingResponse:
+    """Open a live event stream for the caller's projects.
+
+    The `principal` dependency authorizes the *opening* of the stream and gives
+    the caller the same `401`/`403` shape as every other endpoint. It is not
+    what keeps the stream authorized — `event_stream` re-checks the token on
+    every poll; see the module docstring.
+
+    No `AsyncSession` dependency here on purpose. FastAPI closes a request's
+    dependencies when the handler returns, which for a streaming response is
+    *before* the body is produced, so a session injected here would be closed
+    under the generator. The generator opens its own, one per poll, through
+    `db/session.py:session_factory`.
+    """
+    # Validated before the response starts: once the first byte of an
+    # `text/event-stream` body is out, there is no status code left to change,
+    # so a bad `?type=` would have to be reported inside the stream.
+    wanted = _requested_types(type)
+    resume = _resume_from(last_event_id, after)
+
+    slot = stream_slots.acquire()
+    try:
+        body = event_stream(
+            factory=session_factory(),
+            token=bearer_token(request) or "",
+            resume_from=resume,
+            requested_projects=project,
+            requested_types=wanted,
+            poll_interval=settings.effective_event_stream_poll_interval(),
+            heartbeat_seconds=settings.event_stream_heartbeat_seconds,
+            max_duration_seconds=settings.event_stream_max_duration_seconds,
+            batch_limit=settings.effective_event_stream_batch_limit(),
+            on_close=slot.release,
+            is_disconnected=request.is_disconnected,
+        )
+    except Exception:
+        slot.release()
+        raise
+    return StreamingResponse(
+        body,
+        media_type="text/event-stream",
+        # Belt and braces on the slot; `StreamSlot.release` is idempotent. The
+        # generator's `finally` covers everything from its first iteration
+        # onwards, and this covers the gap before it — a connection dropped
+        # between this `return` and the first `__anext__` leaves an async
+        # generator that never started, and one that never started has no
+        # `finally` to run.
+        background=BackgroundTask(slot.release),
+        headers={
+            "Cache-Control": "no-store",
+            # nginx buffers a proxied response by default, which would hold each
+            # frame until the buffer filled and turn a live stream into a batch
+            # one. This header switches it off for this response only, so the
+            # vhost's `/api/` block does not have to disable buffering for every
+            # other endpoint. Harmless to a proxy that does not understand it.
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/gateway/app/api/routes/notifications.py
+++ b/gateway/app/api/routes/notifications.py
@@ -1,0 +1,165 @@
+"""What this actor wants to be notified about — issue #13.
+
+Two operations over one document: `GET /api/v1/notifications/preferences` and
+`PUT` of the same shape back. One row per actor, keyed by the `user_id` from
+`users.json`.
+
+## Recorded intent, not a delivery mechanism, and not a stream filter
+
+There is no push transport in this build — `GET /api/version` reports
+`pushNotifications`/`artifactDownloads` style flags for exactly this reason, and
+nothing reads these rows to decide delivery. They are the hook a later push
+integration reads, stored now so a client can offer the setting and so the
+choice survives a reinstall.
+
+They also **do not filter `GET /api/v1/events/stream`**, and that is a decision
+rather than an omission. A client that opened the stream asked for the stream;
+withholding events from it because of a preference set on another device is how
+a phone silently misses the decision its operator was waiting for, and the
+failure would be invisible from the client side — indistinguishable from a quiet
+system. A client that wants a narrower live feed says so per connection, with
+`?type=`, which is per-connection state and cannot be changed underneath it.
+`docs/api/README.md` §"Events and notifications (issue #13)" states this to the
+client author in the same words.
+
+## No `ETag`, no `If-Match`
+
+The only writer of a row is the actor it belongs to, through a `PUT` that
+replaces the document wholesale. Optimistic concurrency protects against a
+concurrent *third party*, and there is not one: two devices of the same person
+racing is last-write-wins on a two-field preference, which is what the person
+would expect either way. `ConversationModel` is this schema's other
+revision-less table for a related reason (`docs/api/README.md` §"No `revision`,
+no `ETag`, no `If-Match`").
+
+## Reading is `notifications.read`, writing is `notifications.manage`
+
+Two actions, because an operator may want a phone that can watch the event
+stream without that phone being able to rewrite what the account gets notified
+about. Reading needs only `codexbridge.read`; the write has a scope of its own.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.app.api import permissions
+from gateway.app.api.auth import require_action
+from gateway.app.api.errors import VALIDATION_FAILED, ApiError
+from gateway.app.api.timestamps import utc_z
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.session import get_session
+from gateway.app.services import event_types, store
+
+
+router = APIRouter(prefix="/api/v1")
+
+# Bounded independently of `ALL_EVENT_TYPES`'s current size. The list is stored
+# as JSON text and echoed back to its author, so its length is caller-controlled
+# input to a database column; a subset of a closed vocabulary can never
+# legitimately need more entries than the vocabulary has, and the ceiling has to
+# be a constant rather than `len(ALL_EVENT_TYPES)` so that adding a type cannot
+# quietly widen an accepted request body.
+MAX_SUBSCRIBED_TYPES = 64
+
+
+class NotificationPreferencesRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    # Validated against the published vocabulary in the handler rather than with
+    # a Pydantic `Literal[...]`: the rejection has to be an `Error` envelope with
+    # a `details[].field` naming `eventTypes`, and a 422 from the model layer
+    # names the Python field and lists every allowed value back at the caller.
+    event_types: list[str] = Field(default_factory=list, alias="eventTypes", max_length=MAX_SUBSCRIBED_TYPES)
+    push_enabled: bool = Field(default=False, alias="pushEnabled")
+
+
+def _body(event_types_json: str | None, push_enabled: bool, updated_at) -> dict:
+    """The document, from a row or from the absence of one.
+
+    `eventTypes` is re-validated against the current vocabulary on the way
+    **out**, not only on the way in. A stored value can outlive the type it
+    names — a later build that retires an event type would otherwise keep
+    handing a client a subscription to something that no longer exists, and the
+    client would echo it back on its next `PUT` and be rejected for a value it
+    never chose.
+    """
+    try:
+        stored = json.loads(event_types_json or "[]")
+    except (TypeError, ValueError):
+        stored = []
+    known = [
+        value
+        for value in (stored if isinstance(stored, list) else [])
+        if isinstance(value, str) and value in event_types.ALL_EVENT_TYPES
+    ]
+    return {
+        "eventTypes": sorted(set(known)),
+        "pushEnabled": bool(push_enabled),
+        # Null when the actor has never saved preferences, so a client can tell
+        # "defaults, never touched" from "explicitly set to the defaults".
+        "updatedAt": utc_z(updated_at) if updated_at is not None else None,
+        # Stated in the payload, not only in the prose: a client rendering a
+        # "push notifications" switch needs to know, at the moment it renders
+        # it, that saving the setting will not make anything arrive yet.
+        "pushDeliveryAvailable": False,
+    }
+
+
+@router.get("/notifications/preferences", tags=["notifications"])
+async def get_preferences(
+    response: Response,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NOTIFICATIONS_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """This actor's preferences, or the defaults when nothing was ever saved.
+
+    Always this actor's own. There is no `userId` parameter and no admin
+    override: a preference document is personal data, and an endpoint that could
+    read another account's would be a disclosure with no product behind it.
+    """
+    row = await store.get_notification_preference(session, principal.user_id)
+    response.headers["Cache-Control"] = "no-store"
+    if row is None:
+        return _body(None, False, None)
+    return _body(row.event_types_json, row.push_enabled, row.updated_at)
+
+
+@router.put("/notifications/preferences", tags=["notifications"])
+async def put_preferences(
+    payload: NotificationPreferencesRequest,
+    response: Response,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NOTIFICATIONS_MANAGE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Replace this actor's preferences.
+
+    A full replacement, and idempotent by construction: the same body sent twice
+    produces the same document. That is why there is no `Idempotency-Key` here —
+    the header exists so a retried *creating* write does not create twice, and a
+    `PUT` of a single document owned by one actor has nothing to duplicate.
+    """
+    unknown = sorted({value for value in payload.event_types if value not in event_types.ALL_EVENT_TYPES})
+    if unknown:
+        raise ApiError(
+            status_code=400,
+            code=VALIDATION_FAILED,
+            message="Unknown event type in the subscription list.",
+            details=[
+                {"field": "eventTypes", "code": "unknown_event_type", "message": f"No such event type: {value}."}
+                for value in unknown
+            ],
+        )
+
+    row = await store.set_notification_preference(
+        session,
+        user_id=principal.user_id,
+        event_types=list(payload.event_types),
+        push_enabled=payload.push_enabled,
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return _body(row.event_types_json, row.push_enabled, row.updated_at)

--- a/gateway/app/api/routes/notifications.py
+++ b/gateway/app/api/routes/notifications.py
@@ -6,11 +6,16 @@ Two operations over one document: `GET /api/v1/notifications/preferences` and
 
 ## Recorded intent, not a delivery mechanism, and not a stream filter
 
-There is no push transport in this build — `GET /api/version` reports
-`pushNotifications`/`artifactDownloads` style flags for exactly this reason, and
-nothing reads these rows to decide delivery. They are the hook a later push
-integration reads, stored now so a client can offer the setting and so the
-choice survives a reinstall.
+There is no push transport in this build, and nothing reads these rows to decide
+delivery. They are the hook a later push integration reads, stored now so a
+client can offer the setting and so the choice survives a reinstall.
+
+The client learns that from `pushDeliveryAvailable` in the body below, **not**
+from `GET /api/version`: that probe's `capabilities` map has no push key at all,
+and three comments in the first cut of this delivery said it reported
+`pushNotifications: false` (council round 1, the claim auditor). A capability
+flag belongs in `probes.CAPABILITIES` only when a served endpoint honours it;
+this one is a property of the preferences resource, so it is reported there.
 
 They also **do not filter `GET /api/v1/events/stream`**, and that is a decision
 rather than an omission. A client that opened the stream asked for the stream;
@@ -42,6 +47,7 @@ about. Reading needs only `codexbridge.read`; the write has a scope of its own.
 from __future__ import annotations
 
 import json
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel, ConfigDict, Field
@@ -66,6 +72,16 @@ router = APIRouter(prefix="/api/v1")
 # quietly widen an accepted request body.
 MAX_SUBSCRIBED_TYPES = 64
 
+# And how long any one of them may be. Bounding the count alone was not a bound:
+# 64 strings of 100,000 characters passed the list check, and `put_preferences`
+# then quoted every one of them back in `details[]`, turning a 6.4 MB request
+# into a 6.4 MB error response (council round 1, the adversarial user). Every
+# value in `MobileEventType` is well under this.
+MAX_EVENT_TYPE_LENGTH = 64
+
+# How many rejected values one error response quotes back.
+MAX_ECHOED_UNKNOWN = 10
+
 
 class NotificationPreferencesRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
@@ -74,7 +90,13 @@ class NotificationPreferencesRequest(BaseModel):
     # a Pydantic `Literal[...]`: the rejection has to be an `Error` envelope with
     # a `details[].field` naming `eventTypes`, and a 422 from the model layer
     # names the Python field and lists every allowed value back at the caller.
-    event_types: list[str] = Field(default_factory=list, alias="eventTypes", max_length=MAX_SUBSCRIBED_TYPES)
+    #
+    # The per-item `max_length` *is* on the model, though, because it is a size
+    # bound rather than a vocabulary check — it has to reject the body before the
+    # handler builds an error message out of it.
+    event_types: list[Annotated[str, Field(max_length=MAX_EVENT_TYPE_LENGTH)]] = Field(
+        default_factory=list, alias="eventTypes", max_length=MAX_SUBSCRIBED_TYPES
+    )
     push_enabled: bool = Field(default=False, alias="pushEnabled")
 
 
@@ -149,9 +171,16 @@ async def put_preferences(
             status_code=400,
             code=VALIDATION_FAILED,
             message="Unknown event type in the subscription list.",
+            # Bounded in count as well as in item length: the model caps each
+            # value at MAX_EVENT_TYPE_LENGTH, and this caps how many of them a
+            # single rejection quotes back.
             details=[
-                {"field": "eventTypes", "code": "unknown_event_type", "message": f"No such event type: {value}."}
-                for value in unknown
+                {
+                    "field": "eventTypes",
+                    "code": "unknown_event_type",
+                    "message": f"No such event type: {value}.",
+                }
+                for value in unknown[:MAX_ECHOED_UNKNOWN]
             ],
         )
 

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -67,7 +67,23 @@ version_router = APIRouter()
 # an optional `reason` field on its request body, recorded on the mission's
 # timeline. Additive only (new optional field; an existing client sending no
 # body is unaffected), so another minor bump.
-API_CONTRACT_VERSION = "1.6.0"
+#
+# 1.6.0 -> 1.8.0: the mobile event stream (issue #13) — `GET /api/v1/events`,
+# `GET /api/v1/events/stream` and `GET`/`PUT
+# /api/v1/notifications/preferences`, plus the `MobileEvent` family of schemas.
+# Additive only, so a minor bump.
+#
+# **1.7.0 is skipped on purpose.** It is reserved for the artifacts and Android
+# build work (issue #11), developed in parallel on its own branch, which bumps
+# this same line for its own endpoints. Two branches that both claimed "the next
+# minor" would produce two different 1.7.0 contracts, and whichever merged
+# second would either silently overwrite the other's number or ship a version a
+# client already pinned against different endpoints. Taking the number issue #11
+# is not taking costs nothing — semver does not require contiguity — and it
+# makes the merge a text conflict in one line rather than a version collision
+# nothing detects. `MobileEventType` already declares `artifact.*` and
+# `androidBuild.*` for the same reason: to make #11 additive when it lands.
+API_CONTRACT_VERSION = "1.8.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a
@@ -94,7 +110,11 @@ CAPABILITIES = {
     "tokenRevocation": True,     # POST /api/v1/auth/revoke
     "effectivePermissions": True,  # GET /api/v1/auth/me
     "deviceAuthorization": False,  # RFC 8628; sign-in is what #4 delivered
-    "eventStream": False,        # issue #13
+    # GET /api/v1/events/stream (SSE) and GET /api/v1/events (the polling
+    # fallback). True because both routes are served — the flag is about the
+    # transport existing, not about push notifications, which are a different
+    # thing and still absent (see `routes/notifications.py`).
+    "eventStream": True,         # issue #13
     "artifactDownloads": False,  # issue #11
 }
 

--- a/gateway/app/core/config.py
+++ b/gateway/app/core/config.py
@@ -189,7 +189,26 @@ class Settings(BaseSettings):
     # session every poll. This is the ceiling that actually bounds that, and
     # exceeding it answers 503 with Retry-After rather than degrading the API
     # everything else shares.
-    event_stream_max_concurrent: int = 32
+    #
+    # **8, not 32, and the number is chosen against the connection pool.**
+    # `gateway/app/db/session.py` builds the engine with SQLAlchemy's defaults:
+    # `pool_size=5` plus `max_overflow=10` is a hard ceiling of **15**
+    # connections, shared with every other endpoint. A stream takes one from
+    # that pool on every poll. At 32 the ceiling was more than twice the pool it
+    # is documented to protect, so a slow poll — the state a missing index or a
+    # large `audit_events` produces — would have exhausted the pool and made
+    # real requests block for the 30s `pool_timeout`. That is not hypothetical:
+    # `routes/probes.py` records the production incident with exactly that
+    # shape, where the resulting TimeoutError was reported as
+    # `database: unavailable` and the gateway asked to be pulled from rotation.
+    # Raising this above the pool means raising the pool with it.
+    event_stream_max_concurrent: int = 8
+    # Concurrent streams one actor may hold. Without it the process ceiling is
+    # not a share: one read-only token could take every slot and answer 503 to
+    # every other principal, administrators included, for as long as it held its
+    # connections. Two is a phone and a tablet; a third device reconnects when
+    # one of them ends.
+    event_stream_max_per_actor: int = 2
     # Rows one poll may deliver. Bounds the work a single iteration can do when
     # a client resumes from far behind; the next iteration continues immediately
     # because the cursor advanced.

--- a/gateway/app/core/config.py
+++ b/gateway/app/core/config.py
@@ -46,7 +46,8 @@ class Settings(BaseSettings):
     oauth_allowed_redirect_uri_prefixes: str = "https://chatgpt.com,https://chat.openai.com,https://auth.openai.com"
     oauth_default_scopes: str = (
         "codexbridge.read codexbridge.task.submit codexbridge.task.cancel "
-        "codexbridge.issues.write codexbridge.conversations.write"
+        "codexbridge.issues.write codexbridge.conversations.write "
+        "codexbridge.notifications.manage"
     )
     oauth_access_token_ttl_seconds: int = 3600
     oauth_authorization_code_ttl_seconds: int = 600
@@ -161,6 +162,48 @@ class Settings(BaseSettings):
     # connection from the same pool that serves the API, and enough of them made
     # the gateway report itself database-down and ask to be pulled from rotation.
     ready_cache_seconds: float = 5.0
+
+    # --- GET /api/v1/events/stream (issue #13) ----------------------------
+    #
+    # The stream polls `audit_events` for `id > cursor` on a timer. That is the
+    # honest shape for this backend: there is one gateway process, the writes
+    # already land in a table, and a pub/sub bus would be a second delivery path
+    # to keep correct with no second consumer (docs/limits.md: no speculative
+    # architecture expansion).
+    event_stream_poll_interval_seconds: float = 1.0
+    # A comment (`: keep-alive`) on an otherwise idle stream. Must stay well
+    # under the front door's `proxy_read_timeout` (nginx default 60s), or an
+    # idle stream is killed by the proxy and every client reconnects on a timer
+    # it did not choose.
+    event_stream_heartbeat_seconds: float = 15.0
+    # How long one stream is allowed to live before the server closes it with a
+    # `stream.closed` frame. Bounded on purpose: an unbounded stream holds a
+    # worker slot and a connection through every deploy and every network
+    # change, and the client already knows how to resume exactly
+    # (`Last-Event-ID`). 0 or less means "one pass, then close", which is what
+    # tests use.
+    event_stream_max_duration_seconds: float = 900.0
+    # Concurrent streams this process will serve. The rate limiter bounds the
+    # request *rate*, not the number of connections held open — 120 accepted
+    # requests per minute per bucket is 120 live streams, each taking a database
+    # session every poll. This is the ceiling that actually bounds that, and
+    # exceeding it answers 503 with Retry-After rather than degrading the API
+    # everything else shares.
+    event_stream_max_concurrent: int = 32
+    # Rows one poll may deliver. Bounds the work a single iteration can do when
+    # a client resumes from far behind; the next iteration continues immediately
+    # because the cursor advanced.
+    event_stream_batch_limit: int = 200
+
+    def effective_event_stream_poll_interval(self) -> float:
+        # Floored, not honoured: a zero interval is a busy loop that queries the
+        # database as fast as the event loop allows, which is a self-inflicted
+        # denial of service on the pool every other endpoint shares. Same
+        # reasoning as `effective_ready_cache_seconds` below.
+        return max(0.05, float(self.event_stream_poll_interval_seconds))
+
+    def effective_event_stream_batch_limit(self) -> int:
+        return max(1, min(int(self.event_stream_batch_limit), 500))
 
     def effective_ready_cache_seconds(self) -> float:
         # A zero or negative TTL disables caching and restores the DoS the cache

--- a/gateway/app/db/schema_guard.py
+++ b/gateway/app/db/schema_guard.py
@@ -45,6 +45,10 @@ REQUIRED_TABLES: dict[str, str] = {
     "conversations": "0007_conversations.sql",
     "conversation_messages": "0007_conversations.sql",
     "conversation_read_states": "0007_conversations.sql",
+    # Issue #13's event stream adds no table of its own — it reads `audit_events`,
+    # which 0001 already created. This is the notification-preferences table, the
+    # one thing that issue does persist.
+    "notification_preferences": "0009_event_subscriptions.sql",
 }
 
 REQUIRED_COLUMNS: dict[str, dict[str, str]] = {

--- a/gateway/app/db/session.py
+++ b/gateway/app/db/session.py
@@ -13,3 +13,19 @@ async def get_session() -> AsyncSession:
     async with SessionLocal() as session:
         yield session
 
+
+def session_factory() -> async_sessionmaker[AsyncSession]:
+    """The sessionmaker, for code that outlives a request's dependencies.
+
+    `get_session` is a FastAPI dependency, and FastAPI closes a request's
+    dependencies when the handler *returns*. For a `StreamingResponse` the body
+    is produced after that, so a session injected as a dependency is already
+    closed by the time the generator runs — `gateway/app/api/routes/events.py`
+    opens one per poll through this instead.
+
+    A function rather than the module attribute itself, and reading the global
+    at call time on purpose: a test that swaps `SessionLocal` for an in-memory
+    engine must be seen by callers that imported this module at import time.
+    """
+    return SessionLocal
+

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -15,7 +15,9 @@ from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import decisions, missions, probes, projects, sessions
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import epics as epics_routes
+from gateway.app.api.routes import events as events_routes
 from gateway.app.api.routes import issues as issues_routes
+from gateway.app.api.routes import notifications as notifications_routes
 from gateway.app.api.setup import install_api_conventions
 from gateway.app.core.agent_auth import TokenSource, resolve_executor_token
 from gateway.app.core.config import settings
@@ -135,6 +137,17 @@ app.include_router(issues_routes.router, dependencies=[Depends(RateLimitDependen
 # projects, sessions/decisions/missions and issues. Same limiter, same
 # authorization plumbing as epics and issues above.
 app.include_router(conversations_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# The mobile event stream and its polling fallback (issue #13). Same limiter as
+# every other /api router — and note what the limiter does *not* bound here: it
+# counts requests per window, while one accepted request to `/events/stream`
+# becomes a connection held open for minutes. `routes/events.py:StreamSlots` is
+# what bounds that; the limiter still guards the rate of opening attempts.
+app.include_router(events_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# Notification-subscription preferences (issue #13): recorded intent for a push
+# transport this build does not have. See `routes/notifications.py`.
+app.include_router(notifications_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 
 
 def oauth_www_authenticate_header() -> str:

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -213,6 +213,39 @@ class AuditEventModel(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
 
+class NotificationPreferenceModel(Base):
+    """Which events one actor wants to be notified about — issue #13.
+
+    Recorded intent, not a delivery mechanism. This build has no push transport
+    (`GET /api/version` reports `pushNotifications: false`), and these rows do
+    **not** filter `GET /api/v1/events/stream`: a client that subscribed to the
+    stream asked for the stream, and silently withholding events from it because
+    of a preference set on another device is how a mobile client misses a
+    decision it was waiting for. See `gateway/app/api/routes/notifications.py`.
+
+    One row per actor, keyed by `user_id` — the id from `users.json`, never an
+    email. There is no `revision`/`ETag`: the only writer of a row is the actor
+    it belongs to, through a `PUT` that replaces the document wholesale, so
+    there is no concurrent third party for an optimistic check to protect
+    against (`ConversationModel` is this schema's other revision-less table, for
+    the same kind of reason).
+    """
+
+    __tablename__ = "notification_preferences"
+
+    user_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    # JSON list of `event_types.ALL_EVENT_TYPES` members, validated at the route
+    # before it is written: an unvalidated list here would be a store of
+    # arbitrary caller text echoed back to that caller later.
+    event_types_json: Mapped[str] = mapped_column(Text, default="[]", server_default="[]")
+    # No `server_default`: `"0"` renders as a quoted literal that Postgres
+    # refuses for a boolean column, and every other boolean in this schema
+    # (`ExecutorModel.enabled`, `TaskModel.run_when_available`) sets its default
+    # in Python and in the migration rather than through SQLAlchemy's DDL.
+    push_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
 class MessageReceiptModel(Base):
     __tablename__ = "message_receipts"
 

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from gateway.app.db.base import Base
@@ -203,6 +203,18 @@ class TaskLogModel(Base):
 
 
 class AuditEventModel(Base):
+    # Declared in the model as well as in `migrations/0009_event_subscriptions.sql`
+    # so a **fresh** install gets it: `main.py` bootstraps a new database with
+    # `Base.metadata.create_all`, which knows nothing about the migrations
+    # directory, so an index that lived only in SQL would exist on upgraded
+    # deployments and be missing on new ones — the harder of the two to notice,
+    # because it is the one nobody ran a migration for (council round 1, the
+    # second caller). `create_all(checkfirst=True)` does not add an index to a
+    # table that already exists, which is exactly why 0009 has to carry it too.
+    __table_args__ = (
+        Index("audit_events_entity_type_id_idx", "entity_type", "id"),
+    )
+
     __tablename__ = "audit_events"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -216,8 +228,10 @@ class AuditEventModel(Base):
 class NotificationPreferenceModel(Base):
     """Which events one actor wants to be notified about — issue #13.
 
-    Recorded intent, not a delivery mechanism. This build has no push transport
-    (`GET /api/version` reports `pushNotifications: false`), and these rows do
+    Recorded intent, not a delivery mechanism. This build has no push transport —
+    reported to the client as `pushDeliveryAvailable: false` in the preferences
+    body, not by `GET /api/version`, whose `capabilities` map has no push key —
+    and these rows do
     **not** filter `GET /api/v1/events/stream`: a client that subscribed to the
     stream asked for the stream, and silently withholding events from it because
     of a preference set on another device is how a mobile client misses a

--- a/gateway/app/services/event_types.py
+++ b/gateway/app/services/event_types.py
@@ -9,7 +9,7 @@ Three rules shape everything below.
 
 ## 1. The row is internal; the event is public
 
-`AuditEventModel.payload_json` is written by eleven call sites that were never
+`AuditEventModel.payload_json` is written by thirty-one call sites that were never
 audited for what they may contain. It carries `actor_email`, `requested_by_email`,
 free-text `reason` and `error` strings from an executor, and `context` blobs.
 `docs/api/README.md`'s "Fields that must never ship" applies to every byte of it,
@@ -75,6 +75,9 @@ asserts `classify` can never return one.
 from __future__ import annotations
 
 from dataclasses import dataclass
+
+from gateway.app.services.issue_types import EPIC_STATUSES, ISSUE_PRIORITIES, ISSUE_STATUSES
+from shared.protocol import ApprovalDecision, TaskState
 
 
 # Entity types whose rows carry a `project_id` this stream can authorize against.
@@ -233,22 +236,57 @@ def classify(audit_event_type: str, payload: dict) -> tuple[str, str] | None:
 # Summaries — the only place a stored payload is read
 # --------------------------------------------------------------------------
 
-# Payload keys that are safe to echo verbatim, per key, because their values are
-# server-generated enums rather than free text: a `TaskState`, a control name, an
-# `ApprovalDecision`, an issue status. Free text (`error`, `reason`) is read only
-# through `redact`, and `actor_email` / `requested_by_email` are read by nothing.
-_ENUM_KEYS = frozenset({"state", "control", "decision", "outcome", "status", "priority"})
+# Payload keys whose values are echoed, and the **closed set each one may take**.
+#
+# The first cut of this module keyed on the name alone and returned any non-empty
+# string, on the stated premise that these values "are server-generated enums
+# rather than free text". That premise was false for two of them, and the council
+# reproduced it end to end (round 1, the adversarial user): `control` and `state`
+# on a `task.control_acknowledged` / `task.ack_refused` row come straight from an
+# executor's `task.ack` frame — `gateway/app/main.py` reads
+# `envelope.payload.get("control")` and `.get("state")` with no validation, and
+# the `invalid_state` branch deliberately records the very string it just refused
+# as a `TaskState`. A connected executor could therefore put a filesystem path, an
+# internal `host:port`, a `Bearer` value or a 200 KB blob into a mobile
+# notification line, past every guard in this module.
+#
+# Membership, not redaction, is the fix. `redact` strips the patterns it knows;
+# a closed set admits only the values this system actually defines, so a value
+# nobody defined cannot be echoed at all whatever it contains. That is the
+# fail-closed direction (`design-standards.md` §6) and it bounds the length for
+# free, because every member is short by construction.
+_ENUM_VOCABULARIES: dict[str, frozenset[str]] = {
+    # Every `TaskState`. The one enum a client is most likely to switch on.
+    "state": frozenset(state.value for state in TaskState),
+    # The controls `routes/sessions.py` dispatches, plus the cancel path that
+    # `main.py` acknowledges under its own audit type.
+    "control": frozenset({"pause", "resume", "restart", "cancel"}),
+    # `decision` and `outcome` are both an `ApprovalDecision`; they differ only
+    # in which writer chose the key.
+    "decision": frozenset(decision.value for decision in ApprovalDecision),
+    "outcome": frozenset(decision.value for decision in ApprovalDecision),
+    "status": EPIC_STATUSES | ISSUE_STATUSES,
+    "priority": ISSUE_PRIORITIES,
+}
 
 
 def _enum(payload: dict, key: str, default: str = "unknown") -> str:
-    """One enum-ish payload value, defended against a non-string.
+    """One closed-vocabulary payload value, or `default` for anything else.
 
-    `payload_json` is JSON this process wrote, but it is also years of rows on
-    disk and a `null` there must not become the string "None" in a client's UI.
+    Anything else means: a missing key, a non-string, an empty string, and — the
+    case that matters — a string this system does not define. `payload_json` is
+    years of rows on disk written by many call sites, and one of those call sites
+    records unvalidated executor text; a value that is not in the vocabulary is
+    not a value this endpoint may repeat.
     """
-    assert key in _ENUM_KEYS, f"{key!r} is not an enum payload key; free text needs redact()"
+    allowed = _ENUM_VOCABULARIES.get(key)
+    if allowed is None:
+        # Not an assert: `python -O` strips those, and a guard that disappears
+        # under a flag is not a guard. An unknown key yields the default, which
+        # is the same fail-closed answer with no way to switch it off.
+        return default
     value = payload.get(key)
-    return value if isinstance(value, str) and value else default
+    return value if isinstance(value, str) and value in allowed else default
 
 
 def _free_text(payload: dict, key: str, redact) -> str | None:
@@ -414,5 +452,17 @@ def actor_of(payload: dict) -> str | None:
 
 
 def state_of(payload: dict) -> str | None:
+    """The entity's state, or None when the row does not record a defined one.
+
+    Checked against `TaskState` for the same reason `_enum` is, and it is the
+    same defect: `main.py`'s `invalid_state` branch records the executor's raw
+    `state` string — the one the gateway just refused *because* it is not a
+    `TaskState` — and this field was echoing it verbatim into a response body.
+    None rather than "unknown" here, because `state` is omitted from the event
+    when absent and a client switching on it must not be handed a value that is
+    not in the enum it was given.
+    """
     value = payload.get("state")
-    return value if isinstance(value, str) and value else None
+    if not isinstance(value, str) or value not in _ENUM_VOCABULARIES["state"]:
+        return None
+    return value

--- a/gateway/app/services/event_types.py
+++ b/gateway/app/services/event_types.py
@@ -1,0 +1,418 @@
+"""Which audit rows become mobile events, and what those events may say — issue #13.
+
+`audit_events` is this gateway's durable event log: every domain mutation already
+calls `gateway/app/services/audit.py:record_event`, so issue #13 needs no second
+write path, no message bus and no new table. What it needs is a **translation**,
+and translation is this module's one reason to change.
+
+Three rules shape everything below.
+
+## 1. The row is internal; the event is public
+
+`AuditEventModel.payload_json` is written by eleven call sites that were never
+audited for what they may contain. It carries `actor_email`, `requested_by_email`,
+free-text `reason` and `error` strings from an executor, and `context` blobs.
+`docs/api/README.md`'s "Fields that must never ship" applies to every byte of it,
+and no existing sanitizer covers a response body.
+
+So the payload is **never passed through**. Each mobile event type names the
+handful of payload keys it may read (`_SUMMARY_BUILDERS` below), every free-text
+value goes through `routes/sessions.py:redact` on the way out, and a key nobody
+whitelisted simply does not leave the process. Adding a field to an audit payload
+therefore cannot leak it — the default is exclusion, which is the direction
+`design-standards.md` §6 calls fail-closed.
+
+## 2. An audit row with no project is not deliverable
+
+Authorization for this stream is by project (`gateway/app/api/routes/events.py`),
+and `AuditEventModel` has no project column. A row's project is derived from the
+entity it names: `tasks`, `epics`, `issues` and `conversations` all carry
+`project_id`. `DELIVERABLE_ENTITY_TYPES` is exactly that set.
+
+`entity_type == "auth"` is **excluded by construction**, not by a filter someone
+must remember: sign-in, sign-in-failure and revocation rows have a `user_id` where
+a project would be, they are not in issue #13's list of event kinds, and streaming
+them would tell any token holder when the operator signs in. `notification` rows
+(preference changes) are excluded the same way — a user's own preference is not a
+project's event.
+
+## 3. The vocabulary is closed, and every writer must land in it
+
+`classify` maps one audit `event_type` to one `MobileEventType`. A type it does
+not know is **not emitted**, which is safe — and would also be silent, which is
+not. `tests/integration/test_events.py::test_every_audited_domain_event_type_is_translated`
+parses every `record_event(...)` call in `gateway/` with `ast` and fails when a
+call under a deliverable entity type writes a type this module does not map. A
+future author who adds an audit event has to decide what the mobile client sees;
+they cannot decide it by accident.
+
+## Sessions, missions and decisions are one row under three names
+
+`docs/api/README.md` already establishes that a session, a mission and a decision
+are the same `TaskModel` row seen through three vocabularies. This module does not
+triple every event to match: it emits **one** event per audit row, with
+`entity.kind` naming the vocabulary that fits what happened — `decision` for the
+approval lifecycle, `session` for everything else. The id is the same id, so a
+mission-control client fetches `/api/v1/missions/{id}` with it and a session
+client fetches `/api/v1/sessions/{id}`.
+
+## Types declared here and never emitted by this build
+
+`artifact.created`, `artifact.updated` and `androidBuild.status_changed` are in
+`ALL_EVENT_TYPES` and in the contract's `MobileEventType` enum, and **nothing in
+this build ever produces one**: there is no `ArtifactModel` and no Android build
+record (issue #11 has not shipped). They are declared rather than omitted because
+`docs/api/README.md` makes adding a value to a non-`ErrorCode` enum a breaking
+change — a client that switches exhaustively on this enum would have to be
+rewritten when #11 lands. Declaring them now costs a client nothing (they never
+arrive) and saves a `v2`.
+
+`NOT_YET_EMITTED` is what keeps that honest rather than becoming a quiet promise:
+`test_events.py::test_the_declared_but_unemitted_types_are_not_produced_by_this_build`
+asserts `classify` can never return one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# Entity types whose rows carry a `project_id` this stream can authorize against.
+# Everything else — `auth`, `notification` — is out by construction. See §2 above.
+DELIVERABLE_ENTITY_TYPES: frozenset[str] = frozenset({"task", "epic", "issue", "conversation"})
+
+# What a client fetches to see the whole resource behind an event.
+ENTITY_KIND_SESSION = "session"
+ENTITY_KIND_DECISION = "decision"
+ENTITY_KIND_EPIC = "epic"
+ENTITY_KIND_ISSUE = "issue"
+ENTITY_KIND_CONVERSATION = "conversation"
+ENTITY_KIND_ARTIFACT = "artifact"
+ENTITY_KIND_ANDROID_BUILD = "androidBuild"
+
+ENTITY_KINDS: tuple[str, ...] = (
+    ENTITY_KIND_SESSION,
+    ENTITY_KIND_DECISION,
+    ENTITY_KIND_EPIC,
+    ENTITY_KIND_ISSUE,
+    ENTITY_KIND_CONVERSATION,
+    ENTITY_KIND_ARTIFACT,
+    ENTITY_KIND_ANDROID_BUILD,
+)
+
+
+@dataclass(frozen=True)
+class MobileEvent:
+    """One translated event, in the shape the contract publishes.
+
+    `action` is not stored anywhere: it is the part of `type` after the dot, so
+    a client can branch coarsely (`created`, `state_changed`) without parsing
+    the string and the two can never disagree.
+    """
+
+    id: int
+    type: str
+    project_id: str
+    entity_kind: str
+    entity_id: str
+    at: str
+    summary: str
+    state: str | None = None
+    actor_id: str | None = None
+
+    @property
+    def action(self) -> str:
+        return self.type.partition(".")[2]
+
+    def as_dict(self) -> dict:
+        body: dict = {
+            "id": self.id,
+            "type": self.type,
+            "projectId": self.project_id,
+            "entity": {"kind": self.entity_kind, "id": self.entity_id},
+            "action": self.action,
+            "at": self.at,
+            "summary": self.summary,
+        }
+        # Both are optional rather than always-null: a null-always field is
+        # indistinguishable from one a client can build against
+        # (docs/api/README.md, the `probes.CAPABILITIES` reasoning).
+        if self.state is not None:
+            body["state"] = self.state
+        if self.actor_id is not None:
+            body["actorId"] = self.actor_id
+        return body
+
+
+# --------------------------------------------------------------------------
+# The vocabulary
+# --------------------------------------------------------------------------
+
+# audit `event_type` -> (mobile type, entity kind). One entry per writer.
+#
+# `task.created` is deliberately absent: it is the one row whose mobile type
+# depends on the payload (a task created straight into `awaiting_approval` is a
+# decision being requested, not a session starting), and `classify` resolves it.
+_STATIC_MAPPING: dict[str, tuple[str, str]] = {
+    # --- sessions: the run's own lifecycle -------------------------------
+    "task.state_changed": ("session.state_changed", ENTITY_KIND_SESSION),
+    "task.result": ("session.completed", ENTITY_KIND_SESSION),
+    "task.recovered": ("session.recovered", ENTITY_KIND_SESSION),
+    "task.restarted": ("session.restarted", ENTITY_KIND_SESSION),
+    "task.stopped_by_actor": ("session.stopped", ENTITY_KIND_SESSION),
+    "task.control_requested": ("session.control_requested", ENTITY_KIND_SESSION),
+    "task.control_acknowledged": ("session.control_acknowledged", ENTITY_KIND_SESSION),
+    "task.cancel_acknowledged": ("session.stop_acknowledged", ENTITY_KIND_SESSION),
+    "task.ack_refused": ("session.control_refused", ENTITY_KIND_SESSION),
+    # --- decisions: the approval lifecycle over the same row -------------
+    "task.approval_decision": ("decision.resolved", ENTITY_KIND_DECISION),
+    "task.decision_resolved_by_actor": ("decision.resolved_by_actor", ENTITY_KIND_DECISION),
+    # --- planning ---------------------------------------------------------
+    "epic.created": ("epic.created", ENTITY_KIND_EPIC),
+    "issue.created": ("issue.created", ENTITY_KIND_ISSUE),
+    "issue.updated": ("issue.updated", ENTITY_KIND_ISSUE),
+    "issue.linked_to_epic": ("issue.linked_to_epic", ENTITY_KIND_ISSUE),
+    # --- conversations ----------------------------------------------------
+    "conversation.created": ("conversation.created", ENTITY_KIND_CONVERSATION),
+    "conversation.message_created": ("conversation.message_created", ENTITY_KIND_CONVERSATION),
+}
+
+# Both halves of the `task.created` fork.
+SESSION_CREATED = "session.created"
+DECISION_REQUESTED = "decision.requested"
+
+# Audit event types this module translates. This is what the SQL query filters
+# on, so a row nothing maps is excluded *by the query* rather than dropped after
+# the fact — which is what keeps `hasMore` truthful (docs/api/README.md:
+# "Project scope is enforced on the query, not on the response", same reasoning).
+TRANSLATED_AUDIT_EVENT_TYPES: frozenset[str] = frozenset(_STATIC_MAPPING) | {"task.created"}
+
+# Declared in the contract, never produced here. See the module docstring.
+NOT_YET_EMITTED: tuple[str, ...] = (
+    "artifact.created",
+    "artifact.updated",
+    "androidBuild.status_changed",
+)
+
+EMITTED_EVENT_TYPES: tuple[str, ...] = tuple(
+    sorted({mobile for mobile, _ in _STATIC_MAPPING.values()} | {SESSION_CREATED, DECISION_REQUESTED})
+)
+
+# Everything a client may filter on or switch over: what this build emits, plus
+# what a later build will. A value outside this set is a client error.
+ALL_EVENT_TYPES: tuple[str, ...] = tuple(sorted(set(EMITTED_EVENT_TYPES) | set(NOT_YET_EMITTED)))
+
+# Stream control frames. Not entity events and deliberately not in
+# `MobileEventType`: they carry no entity, no project and no resume id, and a
+# client that switched over the entity enum must not have to know them to
+# compile. See `routes/events.py`.
+STREAM_OPEN = "stream.open"
+STREAM_GAP = "stream.gap"
+STREAM_CLOSED = "stream.closed"
+STREAM_CONTROL_TYPES: tuple[str, ...] = (STREAM_OPEN, STREAM_GAP, STREAM_CLOSED)
+
+
+def classify(audit_event_type: str, payload: dict) -> tuple[str, str] | None:
+    """`(mobile type, entity kind)` for one audit row, or None when it is internal.
+
+    The one payload-dependent fork is `task.created`: `store.create_task` writes
+    it for every submission, and a submission that `shared/policy.py` held for
+    approval is a *decision being requested* — the event issue #13 names — while
+    every other submission is a session starting. The two are the same row and
+    the same audit type, so the fork lives here rather than in a second writer.
+    """
+    if audit_event_type == "task.created":
+        state = payload.get("state")
+        if state == "awaiting_approval":
+            return DECISION_REQUESTED, ENTITY_KIND_DECISION
+        return SESSION_CREATED, ENTITY_KIND_SESSION
+    return _STATIC_MAPPING.get(audit_event_type)
+
+
+# --------------------------------------------------------------------------
+# Summaries — the only place a stored payload is read
+# --------------------------------------------------------------------------
+
+# Payload keys that are safe to echo verbatim, per key, because their values are
+# server-generated enums rather than free text: a `TaskState`, a control name, an
+# `ApprovalDecision`, an issue status. Free text (`error`, `reason`) is read only
+# through `redact`, and `actor_email` / `requested_by_email` are read by nothing.
+_ENUM_KEYS = frozenset({"state", "control", "decision", "outcome", "status", "priority"})
+
+
+def _enum(payload: dict, key: str, default: str = "unknown") -> str:
+    """One enum-ish payload value, defended against a non-string.
+
+    `payload_json` is JSON this process wrote, but it is also years of rows on
+    disk and a `null` there must not become the string "None" in a client's UI.
+    """
+    assert key in _ENUM_KEYS, f"{key!r} is not an enum payload key; free text needs redact()"
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else default
+
+
+def _free_text(payload: dict, key: str, redact) -> str | None:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    cleaned = redact(value)
+    if cleaned is None:
+        return None
+    cleaned = cleaned.strip()
+    # Bounded: a summary is a notification line, and `last_error` can be a
+    # multi-kilobyte executor traceback. Truncating here rather than at the
+    # route keeps every caller of this module bounded by construction.
+    return (cleaned[:SUMMARY_TEXT_LIMIT] + "…") if len(cleaned) > SUMMARY_TEXT_LIMIT else cleaned
+
+
+SUMMARY_TEXT_LIMIT = 200
+
+
+def summarize(mobile_type: str, payload: dict, redact) -> str:
+    """A short, human-readable line for one event. Never the raw payload.
+
+    `redact` is injected rather than imported so this module does not depend on
+    a route module (and so a test can prove redaction is actually applied, by
+    passing a spy). It is `gateway/app/api/routes/sessions.py:redact`.
+    """
+    builder = _SUMMARY_BUILDERS.get(mobile_type)
+    if builder is None:
+        # Unreachable for anything `classify` returns — `test_events.py`
+        # asserts every emitted type has a builder — and a bland, correct
+        # sentence rather than an exception if that ever stops being true.
+        return "Event recorded."
+    return builder(payload, redact)
+
+
+def _session_created(payload: dict, redact) -> str:
+    return f"Session submitted; state {_enum(payload, 'state')}."
+
+
+def _decision_requested(payload: dict, redact) -> str:
+    return "A sensitive session is waiting for a decision."
+
+
+def _session_state_changed(payload: dict, redact) -> str:
+    error = _free_text(payload, "error", redact)
+    return f"State changed to {_enum(payload, 'state')}." + (f" {error}" if error else "")
+
+
+def _session_completed(payload: dict, redact) -> str:
+    return f"Execution finished; state {_enum(payload, 'state')}."
+
+
+def _session_recovered(payload: dict, redact) -> str:
+    return f"Recovered after a gateway restart; marked {_enum(payload, 'state')}."
+
+
+def _session_restarted(payload: dict, redact) -> str:
+    return f"Session restarted; state {_enum(payload, 'state')}."
+
+
+def _session_stopped(payload: dict, redact) -> str:
+    reason = _free_text(payload, "reason", redact)
+    return "Cancelled by an operator." + (f" {reason}" if reason else "")
+
+
+def _session_control_requested(payload: dict, redact) -> str:
+    return f"An operator requested {_enum(payload, 'control', 'a control')}."
+
+
+def _session_control_acknowledged(payload: dict, redact) -> str:
+    accepted = payload.get("accepted")
+    verb = "accepted" if accepted is True else "refused" if accepted is False else "answered"
+    return f"The executor {verb} {_enum(payload, 'control', 'a control')}."
+
+
+def _session_stop_acknowledged(payload: dict, redact) -> str:
+    return "The executor confirmed the session is stopped."
+
+
+def _session_control_refused(payload: dict, redact) -> str:
+    # `reason` here is one of three server-side constants
+    # (`unknown_task`/`not_owner`/`invalid_state`, gateway/app/main.py), never
+    # caller text — but it is read through the free-text path anyway rather than
+    # `_enum`, so that widening it later cannot turn this line into a leak.
+    reason = _free_text(payload, "reason", redact)
+    return "A control acknowledgement was refused." + (f" Reason: {reason}." if reason else "")
+
+
+def _decision_resolved(payload: dict, redact) -> str:
+    reason = _free_text(payload, "reason", redact)
+    return f"Decision recorded: {_enum(payload, 'decision')}." + (f" {reason}" if reason else "")
+
+
+def _decision_resolved_by_actor(payload: dict, redact) -> str:
+    return f"An operator resolved the decision: {_enum(payload, 'outcome')}."
+
+
+def _epic_created(payload: dict, redact) -> str:
+    return f"Epic created with status {_enum(payload, 'status')}."
+
+
+def _issue_created(payload: dict, redact) -> str:
+    return f"Issue created with status {_enum(payload, 'status')}."
+
+
+def _issue_updated(payload: dict, redact) -> str:
+    return f"Issue updated; status {_enum(payload, 'status')}, priority {_enum(payload, 'priority')}."
+
+
+def _issue_linked_to_epic(payload: dict, redact) -> str:
+    return "Issue attached to an epic."
+
+
+def _conversation_created(payload: dict, redact) -> str:
+    # `context` is deliberately not read: it is a list of entity references the
+    # conversation endpoints already authorize individually, and echoing ids
+    # from it here would publish them under this event's single-project check.
+    return "Conversation started."
+
+
+def _conversation_message_created(payload: dict, redact) -> str:
+    attachments = payload.get("attachments")
+    count = attachments if isinstance(attachments, int) and attachments > 0 else 0
+    # The message body is never read. `Message.body` is operator/agent prose and
+    # belongs behind `GET /api/v1/conversations/{id}/messages`, which authorizes
+    # it; a notification says *that* there is a message, not what it says.
+    return "New message." + (f" {count} attachment(s)." if count else "")
+
+
+_SUMMARY_BUILDERS = {
+    SESSION_CREATED: _session_created,
+    DECISION_REQUESTED: _decision_requested,
+    "session.state_changed": _session_state_changed,
+    "session.completed": _session_completed,
+    "session.recovered": _session_recovered,
+    "session.restarted": _session_restarted,
+    "session.stopped": _session_stopped,
+    "session.control_requested": _session_control_requested,
+    "session.control_acknowledged": _session_control_acknowledged,
+    "session.stop_acknowledged": _session_stop_acknowledged,
+    "session.control_refused": _session_control_refused,
+    "decision.resolved": _decision_resolved,
+    "decision.resolved_by_actor": _decision_resolved_by_actor,
+    "epic.created": _epic_created,
+    "issue.created": _issue_created,
+    "issue.updated": _issue_updated,
+    "issue.linked_to_epic": _issue_linked_to_epic,
+    "conversation.created": _conversation_created,
+    "conversation.message_created": _conversation_message_created,
+}
+
+
+# Payload keys read for the two structured fields on `MobileEvent`. `actor_id`
+# is the opaque user id the mission timeline already publishes; `actor_email` is
+# in several payloads and is read by nothing here, which is the whole point of
+# whitelisting rather than filtering.
+def actor_of(payload: dict) -> str | None:
+    for key in ("actor_id", "requested_by_user_id"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def state_of(payload: dict) -> str | None:
+    value = payload.get("state")
+    return value if isinstance(value, str) and value else None

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -1480,20 +1480,48 @@ async def list_mobile_events_page(
 
     Over-fetches by one, same convention as every other collection here.
     """
-    project_expression = _event_project_expression()
-    statement = (
-        select(AuditEventModel, project_expression.label("project_id"))
-        .where(AuditEventModel.entity_type.in_(list(entity_types)))
-        .where(AuditEventModel.event_type.in_(list(audit_event_types)))
-        .where(project_expression.is_not(None))
+    statement = select(AuditEventModel, _event_project_expression().label("project_id"))
+    statement = _restrict_to_visible_events(
+        statement,
+        project_ids=project_ids,
+        entity_types=entity_types,
+        audit_event_types=audit_event_types,
     )
-    if project_ids is not None:
-        statement = statement.where(project_expression.in_(project_ids))
     if after is not None:
         statement = statement.where(AuditEventModel.id > after)
     statement = statement.order_by(AuditEventModel.id.asc()).limit(limit + 1)
     result = await session.execute(statement)
     return [(row[0], row[1]) for row in result.all()]
+
+
+def _restrict_to_visible_events(
+    statement,
+    *,
+    project_ids: list[str] | None,
+    entity_types: Sequence[str],
+    audit_event_types: Sequence[str],
+):
+    """Every guard that decides whether one audit row is visible to one caller.
+
+    Factored out so the page query and the *gap* queries below cannot answer
+    different questions about the same row. They did: `audit_cursor_status` and
+    `oldest_audit_event_id` were written against the whole table while the page
+    was correctly scoped, which made the `gap` block a one-bit oracle over rows
+    the caller may never see — a project-scoped token could watch the signal
+    flip and learn that *some* audit row had been written, including the
+    operator's sign-in, and binary-search `?after=` for the global newest id
+    (council round 1, the adversarial user). The fix is not "scope the two other
+    queries as well" but "there is one predicate, and everything uses it".
+    """
+    project_expression = _event_project_expression()
+    statement = (
+        statement.where(AuditEventModel.entity_type.in_(list(entity_types)))
+        .where(AuditEventModel.event_type.in_(list(audit_event_types)))
+        .where(project_expression.is_not(None))
+    )
+    if project_ids is not None:
+        statement = statement.where(project_expression.in_(project_ids))
+    return statement
 
 
 # What `audit_cursor_status` returns. Constants rather than bare strings: the
@@ -1504,24 +1532,45 @@ CURSOR_BEYOND_RETENTION = "beyond_retention"
 CURSOR_AHEAD = "cursor_ahead"
 
 
-async def audit_cursor_status(session: AsyncSession, after: int) -> str:
+async def audit_cursor_status(
+    session: AsyncSession,
+    after: int,
+    *,
+    project_ids: list[str] | None,
+    entity_types: Sequence[str],
+    audit_event_types: Sequence[str],
+) -> str:
     """Whether resuming from `after` can be done without a silent gap.
 
     Issue #13's acceptance criterion is that reconnection does not *silently*
     lose events — not that no event is ever lost, which no retention policy can
     promise. This is the signal that keeps the loss from being silent.
 
+    **Answered over the caller's own events, never the whole table.** The scope
+    arguments are not optional and there is no unscoped default, because the
+    unscoped version of this function was an information leak rather than a
+    looser answer: every caller's `gap` block moved whenever *any* audit row was
+    written anywhere in the system, so a project-scoped token could detect the
+    operator's sign-in, a revocation, or another tenant's activity — the exact
+    events this surface excludes by construction — and could binary-search
+    `?after=` for the global newest id (council round 1, the adversarial user).
+
+    Scoping it also makes the answer *more* correct, not less. The question a
+    resuming client is asking is "can my position still be continued from", and
+    its position is an id from this feed. An id from someone else's feed is not
+    a position this client can hold.
+
     A resume cursor is always an id this gateway handed out, so the row it names
     exists unless something removed it. Three cases:
 
-    - the row is still there, or `after` is 0 (start from the beginning) —
-      nothing was lost;
-    - the row is gone and the log has moved past it — rows between the client's
-      position and the oldest surviving one were removed, so the client must
-      re-read rather than assume continuity (`beyond_retention`);
-    - `after` is beyond the newest id this log has ever had — the cursor came
-      from another deployment, or this database was restored from a backup older
-      than the client. Left unsignalled, the stream would simply never deliver
+    - the row is still there and still visible, or `after` is 0 (start from the
+      beginning) — nothing was lost;
+    - the row is gone and this feed has moved past it — rows between the
+      client's position and the oldest surviving one were removed, so the client
+      must re-read rather than assume continuity (`beyond_retention`);
+    - `after` is beyond the newest id in this feed — the cursor came from
+      another deployment, or this database was restored from a backup older than
+      the client. Left unsignalled, the stream would simply never deliver
       anything again, which is the same silence in the other direction
       (`cursor_ahead`).
 
@@ -1534,22 +1583,42 @@ async def audit_cursor_status(session: AsyncSession, after: int) -> str:
     """
     if after <= 0:
         return CURSOR_OK
-    exists = await session.execute(select(AuditEventModel.id).where(AuditEventModel.id == after).limit(1))
+    visible = _restrict_to_visible_events(
+        select(AuditEventModel.id),
+        project_ids=project_ids,
+        entity_types=entity_types,
+        audit_event_types=audit_event_types,
+    )
+    exists = await session.execute(visible.where(AuditEventModel.id == after).limit(1))
     if exists.scalars().first() is not None:
         return CURSOR_OK
-    newest = (await session.execute(select(func.max(AuditEventModel.id)))).scalar()
+    newest = (await session.execute(select(func.max(visible.subquery().c.id)))).scalar()
     if newest is None or after > newest:
         return CURSOR_AHEAD
     return CURSOR_BEYOND_RETENTION
 
 
-async def oldest_audit_event_id(session: AsyncSession) -> int | None:
-    """Lowest surviving audit id, reported alongside a `beyond_retention` gap.
+async def oldest_audit_event_id(
+    session: AsyncSession,
+    *,
+    project_ids: list[str] | None,
+    entity_types: Sequence[str],
+    audit_event_types: Sequence[str],
+) -> int | None:
+    """Lowest id still in **this caller's** feed, reported alongside a gap.
 
     A client that learns it fell behind still has to know where to restart from;
-    "you lost some" with no position leaves it guessing.
+    "you lost some" with no position leaves it guessing. Scoped for the same
+    reason `audit_cursor_status` is: unscoped, this returned the global minimum
+    audit id to anyone holding a read token.
     """
-    return (await session.execute(select(func.min(AuditEventModel.id)))).scalar()
+    visible = _restrict_to_visible_events(
+        select(AuditEventModel.id),
+        project_ids=project_ids,
+        entity_types=entity_types,
+        audit_event_types=audit_event_types,
+    )
+    return (await session.execute(select(func.min(visible.subquery().c.id)))).scalar()
 
 
 # --------------------------------------------------------------------------

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-from sqlalchemy import and_, delete, func, or_, select, update
+from sqlalchemy import and_, case, delete, func, null, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.app.models.entities import (
@@ -16,6 +17,7 @@ from gateway.app.models.entities import (
     ExecutorModel,
     IssueModel,
     MessageReceiptModel,
+    NotificationPreferenceModel,
     OAuthAccessTokenModel,
     OAuthAuthorizationCodeModel,
     OAuthRefreshTokenModel,
@@ -59,6 +61,12 @@ from shared.security import hash_token
 # `purge_expired_audit_events` is allowed to remove. A literal at each call site
 # would have made the retention window's scope a coincidence of spelling.
 AUTH_ENTITY_TYPE = "auth"
+
+# `entity_type` of a notification-preference change (issue #13). Its `entity_id`
+# is a user id, not a project entity, so it is outside
+# `event_types.DELIVERABLE_ENTITY_TYPES` and can never reach the mobile event
+# stream — the same construction that keeps `auth` rows off it.
+NOTIFICATION_ENTITY_TYPE = "notification"
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -1393,6 +1401,201 @@ async def list_task_events_page(
     statement = statement.order_by(AuditEventModel.created_at.asc(), AuditEventModel.id.asc()).limit(limit + 1)
     result = await session.execute(statement)
     return list(result.scalars())
+
+
+# --------------------------------------------------------------------------
+# The mobile event stream (issue #13) — the same `audit_events` rows, derived
+# a project at a time. See gateway/app/services/event_types.py for which rows
+# become events and gateway/app/api/routes/events.py for the transport.
+# --------------------------------------------------------------------------
+
+
+def _event_project_expression():
+    """The project an audit row belongs to, derived from the entity it names.
+
+    `audit_events` has no `project_id` column and is not getting one: adding it
+    would need a backfill of every historical row and would leave two answers to
+    the same question, one of which can go stale. The four entity tables all
+    carry `project_id` already, so the derivation is a `CASE` over correlated
+    subqueries — one expression, used for both the SELECT list and the WHERE.
+
+    That reuse is the point. Authorization for this stream is "the caller may
+    see this project", and `docs/api/README.md` requires project scope be
+    enforced **on the query**: filtering after loading is how `hasMore` ends up
+    describing rows the caller may not see. An entity type not listed here
+    yields NULL and is refused by the `IS NOT NULL` guard in the query below —
+    fail-closed, so a future entity type is invisible until someone teaches this
+    function where its project lives.
+    """
+    return case(
+        (
+            AuditEventModel.entity_type == "task",
+            select(TaskModel.project_id).where(TaskModel.id == AuditEventModel.entity_id).scalar_subquery(),
+        ),
+        (
+            AuditEventModel.entity_type == "epic",
+            select(EpicModel.project_id).where(EpicModel.id == AuditEventModel.entity_id).scalar_subquery(),
+        ),
+        (
+            AuditEventModel.entity_type == "issue",
+            select(IssueModel.project_id).where(IssueModel.id == AuditEventModel.entity_id).scalar_subquery(),
+        ),
+        (
+            AuditEventModel.entity_type == "conversation",
+            select(ConversationModel.project_id)
+            .where(ConversationModel.id == AuditEventModel.entity_id)
+            .scalar_subquery(),
+        ),
+        else_=null(),
+    )
+
+
+async def list_mobile_events_page(
+    session: AsyncSession,
+    *,
+    project_ids: list[str] | None,
+    entity_types: Sequence[str],
+    audit_event_types: Sequence[str],
+    after: int | None = None,
+    limit: int = 50,
+) -> list[tuple[AuditEventModel, str]]:
+    """Deliverable audit rows after `after`, oldest first, with their project.
+
+    Oldest first and keyed on the autoincrement `id`, which is what makes resume
+    exact: the client's last acknowledged id is the whole cursor, it survives a
+    reconnect with no server-side session, and `id > after` cannot deliver a row
+    twice or skip one. `created_at` is deliberately not part of the ordering —
+    two rows written in the same millisecond would tie, and a tie in a resume key
+    is a duplicate or a loss.
+
+    `project_ids=None` means an admin: no project restriction. An **empty list**
+    means a principal with no projects and must match nothing — collapsing the
+    two is the one-character mistake `docs/api/README.md` warns about, so it is
+    written as an explicit `is not None` rather than as a truthiness test.
+
+    Rows whose project cannot be derived are dropped for **every** caller,
+    admins included: an event that belongs to no project cannot be shown as
+    belonging to one, and delivering it would be the only path on this endpoint
+    that is not covered by a project check.
+
+    Over-fetches by one, same convention as every other collection here.
+    """
+    project_expression = _event_project_expression()
+    statement = (
+        select(AuditEventModel, project_expression.label("project_id"))
+        .where(AuditEventModel.entity_type.in_(list(entity_types)))
+        .where(AuditEventModel.event_type.in_(list(audit_event_types)))
+        .where(project_expression.is_not(None))
+    )
+    if project_ids is not None:
+        statement = statement.where(project_expression.in_(project_ids))
+    if after is not None:
+        statement = statement.where(AuditEventModel.id > after)
+    statement = statement.order_by(AuditEventModel.id.asc()).limit(limit + 1)
+    result = await session.execute(statement)
+    return [(row[0], row[1]) for row in result.all()]
+
+
+# What `audit_cursor_status` returns. Constants rather than bare strings: the
+# value reaches the client in a `stream.gap` frame, so a typo would be a
+# contract violation that nothing catches.
+CURSOR_OK = "ok"
+CURSOR_BEYOND_RETENTION = "beyond_retention"
+CURSOR_AHEAD = "cursor_ahead"
+
+
+async def audit_cursor_status(session: AsyncSession, after: int) -> str:
+    """Whether resuming from `after` can be done without a silent gap.
+
+    Issue #13's acceptance criterion is that reconnection does not *silently*
+    lose events — not that no event is ever lost, which no retention policy can
+    promise. This is the signal that keeps the loss from being silent.
+
+    A resume cursor is always an id this gateway handed out, so the row it names
+    exists unless something removed it. Three cases:
+
+    - the row is still there, or `after` is 0 (start from the beginning) —
+      nothing was lost;
+    - the row is gone and the log has moved past it — rows between the client's
+      position and the oldest surviving one were removed, so the client must
+      re-read rather than assume continuity (`beyond_retention`);
+    - `after` is beyond the newest id this log has ever had — the cursor came
+      from another deployment, or this database was restored from a backup older
+      than the client. Left unsignalled, the stream would simply never deliver
+      anything again, which is the same silence in the other direction
+      (`cursor_ahead`).
+
+    Note what this build's retention actually does:
+    `purge_expired_audit_events` deletes `entity_type == "auth"` rows and
+    nothing else, so **no domain event has ever been purged here** and
+    `beyond_retention` cannot be reached in production today. The check exists
+    so that a future retention policy over domain rows — an operator decision
+    this code does not make — cannot cause a silent loss the day it is enabled.
+    """
+    if after <= 0:
+        return CURSOR_OK
+    exists = await session.execute(select(AuditEventModel.id).where(AuditEventModel.id == after).limit(1))
+    if exists.scalars().first() is not None:
+        return CURSOR_OK
+    newest = (await session.execute(select(func.max(AuditEventModel.id)))).scalar()
+    if newest is None or after > newest:
+        return CURSOR_AHEAD
+    return CURSOR_BEYOND_RETENTION
+
+
+async def oldest_audit_event_id(session: AsyncSession) -> int | None:
+    """Lowest surviving audit id, reported alongside a `beyond_retention` gap.
+
+    A client that learns it fell behind still has to know where to restart from;
+    "you lost some" with no position leaves it guessing.
+    """
+    return (await session.execute(select(func.min(AuditEventModel.id)))).scalar()
+
+
+# --------------------------------------------------------------------------
+# Notification preferences (issue #13) — recorded intent for a push transport
+# this build does not have. See gateway/app/api/routes/notifications.py.
+# --------------------------------------------------------------------------
+
+
+async def get_notification_preference(
+    session: AsyncSession, user_id: str
+) -> NotificationPreferenceModel | None:
+    return await session.get(NotificationPreferenceModel, user_id)
+
+
+async def set_notification_preference(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    event_types: list[str],
+    push_enabled: bool,
+) -> NotificationPreferenceModel:
+    """Replace one actor's preferences wholesale, creating the row if absent.
+
+    A full replacement rather than a merge: the resource is a single document
+    owned by one actor, `PUT` is what the contract publishes, and a partial
+    update would need a `PATCH` and an `If-Match` for a resource nothing else
+    can mutate. See `routes/notifications.py` for why there is no `ETag` here.
+    """
+    now = datetime.now(timezone.utc)
+    row = await session.get(NotificationPreferenceModel, user_id)
+    if row is None:
+        row = NotificationPreferenceModel(user_id=user_id, updated_at=now)
+        session.add(row)
+    row.event_types_json = json.dumps(sorted(set(event_types)), ensure_ascii=True)
+    row.push_enabled = push_enabled
+    row.updated_at = now
+    await record_event(
+        session,
+        NOTIFICATION_ENTITY_TYPE,
+        user_id,
+        "notification.preferences_updated",
+        {"event_type_count": len(set(event_types)), "push_enabled": push_enabled},
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
 
 
 # --------------------------------------------------------------------------

--- a/migrations/0009_event_subscriptions.sql
+++ b/migrations/0009_event_subscriptions.sql
@@ -1,0 +1,57 @@
+-- WK-20260826-gh13-events / issue #13
+--
+-- Notification-subscription preferences for CodexBridgeMobile.
+--
+-- Issue #13's event stream itself adds NO schema: `audit_events` is already
+-- this gateway's durable event log, its autoincrement `id` is already the
+-- resume cursor, and the four entity tables already carry the `project_id`
+-- authorization needs (see gateway/app/services/store.py:_event_project_expression).
+-- Adding a projection table would have meant a backfill of every historical row
+-- and two answers to "which project is this event in", one of which can go
+-- stale. This file therefore creates one table, and it is the preferences one.
+--
+-- Numbered 0009 with no 0008 in this branch on purpose: 0008 belongs to the
+-- artifacts work developed in parallel (issue #11). `scripts/apply_migrations.py`
+-- applies files in filename order and records each one in `schema_migrations`
+-- independently, so a gap costs nothing and re-numbering after the fact would
+-- rename a file an already-migrated database has recorded as applied.
+--
+-- Apply with `python3 scripts/apply_migrations.py`. Each file runs exactly once.
+
+create table if not exists notification_preferences (
+  -- The `user_id` from users.json, never an email: an audit/preference table
+  -- keyed by a personal identifier is a personal-data store with a different
+  -- retention question attached (docs/api/README.md, security-standards.md §2).
+  user_id varchar(255) primary key,
+  -- JSON list of MobileEventType values, validated against the closed
+  -- vocabulary in gateway/app/services/event_types.py before it is written.
+  event_types_json text not null default '[]',
+  -- Recorded intent only. This build has no push transport and
+  -- `GET /api/version` reports `pushNotifications: false`; nothing reads this
+  -- column to decide delivery. See gateway/app/api/routes/notifications.py.
+  push_enabled boolean not null default false,
+  updated_at timestamptz not null
+);
+
+-- Issue #13 is what turns `audit_events` into a read path for the first time.
+-- Until now it was written and never queried except by
+-- `purge_expired_audit_events`, so the primary key was the only index it
+-- needed. Both event endpoints run `entity_type in (...) and event_type in
+-- (...) and id > $cursor order by id limit n`, once per poll of every open
+-- stream, and the tail read (`id > cursor` near the head) is the overwhelmingly
+-- common shape.
+--
+-- Leading on `entity_type` and then `id` serves exactly that: the deliverable
+-- entity types are four of the six values the column holds, and within each the
+-- rows are already ordered by the cursor. `event_type` is deliberately not in
+-- the index — it would triple its width to filter a set the entity type has
+-- already narrowed to something small.
+--
+-- Built without `concurrently`. `scripts/apply_migrations.py` runs each file in
+-- a transaction and `create index concurrently` cannot run inside one; this
+-- deployment's `audit_events` is small enough that the write lock is measured in
+-- milliseconds. An operator whose table has grown large should build this index
+-- by hand with `concurrently` before applying the file, which then no-ops on the
+-- `if not exists`.
+create index if not exists audit_events_entity_type_id_idx
+  on audit_events (entity_type, id);

--- a/migrations/0009_event_subscriptions.sql
+++ b/migrations/0009_event_subscriptions.sql
@@ -26,9 +26,10 @@ create table if not exists notification_preferences (
   -- JSON list of MobileEventType values, validated against the closed
   -- vocabulary in gateway/app/services/event_types.py before it is written.
   event_types_json text not null default '[]',
-  -- Recorded intent only. This build has no push transport and
-  -- `GET /api/version` reports `pushNotifications: false`; nothing reads this
-  -- column to decide delivery. See gateway/app/api/routes/notifications.py.
+  -- Recorded intent only. This build has no push transport, and nothing reads
+  -- this column to decide delivery. The client is told so by
+  -- `pushDeliveryAvailable` in the preferences response body; `GET /api/version`
+  -- has no push capability flag. See gateway/app/api/routes/notifications.py.
   push_enabled boolean not null default false,
   updated_at timestamptz not null
 );

--- a/tests/contract/test_docs_match_the_runtime.py
+++ b/tests/contract/test_docs_match_the_runtime.py
@@ -13,6 +13,7 @@ one at a time. A general "the docs are true" test is not a thing that exists.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -164,4 +165,104 @@ def test_the_api_readme_does_not_deny_the_limiter_that_ships(denial: str) -> Non
     assert denial not in prose, (
         f"docs/api/README.md still says {denial!r}, while {len(limited)} served "
         "/api routes carry RateLimitDependency"
+    )
+
+
+def test_no_document_names_a_capability_flag_the_probe_does_not_report() -> None:
+    """A `false` flag a client can read is the point; a *missing* key is not one.
+
+    Issue #13 shipped three artifacts asserting `GET /api/version` reports
+    `pushNotifications: false` — the model, the route module and the migration.
+    It reports no such key, so a client branching on
+    `capabilities.pushNotifications === false` reads `undefined` and takes the
+    wrong branch for the one capability the delivery went out of its way to
+    describe as absent (council round 1, both the claim auditor and the second
+    caller, independently).
+
+    Scanned across the trees a client author actually reads. The check is
+    "named as a capability", not "mentioned": the real name for this signal,
+    `pushDeliveryAvailable`, lives in the preferences body and is not a
+    `/api/version` flag at all.
+    """
+    from gateway.app.api.routes.probes import CAPABILITIES
+
+    pattern = re.compile(r"`?GET /api/version`?[^\n]{0,200}?`(\w+)`\s*:\s*(?:true|false)")
+    offenders: list[str] = []
+    for tree in ("gateway", "migrations", "docs"):
+        for path in sorted((REPO_ROOT / tree).rglob("*")):
+            if path.suffix not in {".py", ".sql", ".md", ".yaml"} or not path.is_file():
+                continue
+            text = path.read_text(encoding="utf-8")
+            for match in pattern.finditer(" ".join(text.split())):
+                if match.group(1) not in CAPABILITIES:
+                    offenders.append(f"{path.relative_to(REPO_ROOT)}: {match.group(1)}")
+
+    assert not offenders, (
+        "these claim GET /api/version reports a capability flag it does not have: "
+        f"{offenders}. Either add the flag to probes.CAPABILITIES (only if a "
+        "served endpoint honours it) or stop naming it."
+    )
+
+
+def test_the_codemap_names_the_canonical_checkout_not_a_worktree() -> None:
+    """`governancekit map` stamps the root it was run from, and agents run in worktrees.
+
+    Issue #13 was developed in `CodexBridge--gh-13` and committed a map whose
+    `Root:`/`Refresh:` lines pointed at that throwaway directory, so anyone on
+    `development` following the document's own refresh command would target a
+    path that does not exist on their machine (council round 1, the claim
+    auditor). The map's *content* is identical either way; only the provenance
+    header is wrong, which is what makes it easy to ship.
+    """
+    header = " ".join(CODEMAP.read_text(encoding="utf-8").split()[:60])
+    stray = re.findall(r"/[\w./-]*CodexBridge--[\w.-]+", header)
+    assert not stray, (
+        f"docs/codemap.md names a worktree as the project root: {stray}. "
+        "Regenerate against the canonical checkout, or correct the header."
+    )
+
+
+def test_the_audit_payload_writer_count_is_the_real_one() -> None:
+    """Five files tell a reader how many writers can put a key in an audit payload.
+
+    That number is the whole premise of issue #13's whitelist: a reader auditing
+    what may leak enumerates the writers. The delivery said "eleven" in five
+    places while there were 31 — so an auditor following the prose would stop
+    after roughly a third of them (council round 1, the claim auditor).
+    """
+    import ast
+
+    spelled = {11: "eleven", 31: "thirty-one"}
+    count = 0
+    for path in (REPO_ROOT / "gateway").rglob("*.py"):
+        if path.name == "audit.py":
+            continue
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name == "record_event":
+                count += 1
+
+    truth = spelled.get(count)
+    assert truth is not None, (
+        f"there are now {count} record_event call sites and this test has no word "
+        f"for it; add one to `spelled` and update the prose that names the number"
+    )
+    wrong = sorted(
+        str(path.relative_to(REPO_ROOT))
+        for tree in ("gateway", "docs", "tests")
+        for path in (REPO_ROOT / tree).rglob("*")
+        if path.is_file()
+        and path.suffix in {".py", ".md"}
+        and any(
+            f"{word} call sites" in " ".join(path.read_text(encoding="utf-8").split())
+            for word in spelled.values()
+            if word != truth
+        )
+    )
+    assert not wrong, (
+        f"there are {count} ({truth}) record_event call sites; these still name a "
+        f"different number: {wrong}"
     )

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -31,8 +31,10 @@ from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import decisions as decisions_routes
 from gateway.app.api.routes import epics as epics_routes
+from gateway.app.api.routes import events as events_routes
 from gateway.app.api.routes import issues as issues_routes
 from gateway.app.api.routes import missions as missions_routes
+from gateway.app.api.routes import notifications as notifications_routes
 from gateway.app.api.routes import projects as projects_routes
 from gateway.app.api.routes import sessions as sessions_routes
 from gateway.app.api.setup import install_api_conventions
@@ -164,6 +166,8 @@ async def api(users_file, monkeypatch):
     app.include_router(epics_routes.router)
     app.include_router(issues_routes.router)
     app.include_router(conversations_routes.router)
+    app.include_router(events_routes.router)
+    app.include_router(notifications_routes.router)
 
     async def override():
         async with factory() as s:
@@ -1038,6 +1042,18 @@ ENDPOINT_FOR_ACTION = {
     "conversations.read": ("GET", "/api/v1/conversations"),
     "conversations.create": ("POST", "/api/v1/conversations"),
     "conversations.postMessage": ("POST", "/api/v1/conversations/{id}/messages"),
+    # The backlog endpoint, never `/events/stream`: this loop issues a plain
+    # request and reads the status, and an SSE body does not end until the
+    # server closes it, so pointing the parity check at the stream would hang
+    # the suite for `event_stream_max_duration_seconds`. Both are guarded by
+    # the same `events.read` action, which is what is being checked here.
+    "events.read": ("GET", "/api/v1/events"),
+    "notifications.read": ("GET", "/api/v1/notifications/preferences"),
+    # No body sent, on purpose. `require_action` is a sub-dependency and runs
+    # before the request body is validated, so a caller lacking the scope gets
+    # the 403 this loop looks for; one that has it gets a 422 for the missing
+    # body, which is a non-403 and is exactly what the loop asserts.
+    "notifications.manage": ("PUT", "/api/v1/notifications/preferences"),
 }
 
 # Actions with no endpoint of their own, each naming the test that covers it

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1,0 +1,1370 @@
+"""The mobile event stream, its polling fallback, and notification preferences — issue #13.
+
+Weighted toward the acceptance criteria the issue names and toward the two
+properties that fail silently when they fail:
+
+- **no silent loss on resume.** Reconnecting from the last acknowledged id
+  delivers every event in between exactly once, and a position the log can no
+  longer continue from is *announced* rather than papered over.
+- **authorization is by project, and it is re-checked while the stream runs.** A
+  restricted principal sees its own projects and nothing else; authentication
+  events never reach any principal; a token revoked or expired while a stream is
+  open ends that stream.
+
+## Why the stream is driven directly rather than through `TestClient`
+
+`event_stream` takes its clock, its sleep and its session factory as parameters
+(`gateway/app/api/routes/events.py`). Every stream test below drives that
+generator with a fake clock and a fake sleep, so "did the second poll happen
+yet" is a fact about the test rather than a race with wall-clock time. A test
+that opened a real SSE connection and slept would be slow *and* flaky, and would
+still not be able to assert what happens on the eleventh poll.
+
+The route around it — the slot ceiling, the `text/event-stream` media type, the
+`Last-Event-ID` header — is covered through the app, where it belongs.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import pathlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import events as events_routes
+from gateway.app.api.routes import notifications as notifications_routes
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.services import event_types, store
+from gateway.app.services.audit import record_event
+from shared.protocol import (
+    ExecutorRegistration,
+    ProjectRegistration,
+    SubmitTaskRequest,
+    TaskMode,
+    TaskPriority,
+)
+
+
+ALICE_TOKEN = "token-alice"    # p1 only, read + notifications.manage
+READER_TOKEN = "token-reader"  # p1 only, read-only (no notifications.manage)
+BOB_TOKEN = "token-bob"        # p2 only
+ADMIN_TOKEN = "token-admin"    # everything
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "alice", "email": "alice@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read", "codexbridge.notifications.manage"],
+                        "enabled": True,
+                    },
+                    {
+                        "user_id": "reader", "email": "reader@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read"], "enabled": True,
+                    },
+                    {
+                        "user_id": "bob", "email": "bob@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p2"],
+                        "scopes": ["codexbridge.read"], "enabled": True,
+                    },
+                    {
+                        "user_id": "admin", "email": "admin@example.com", "password_hash": "x",
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def api(users_file, monkeypatch):
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="E1", display_name="E1", machine_token="t",
+                    allowed_projects=["p1", "p2"], enabled=True,
+                )
+            ],
+            projects=[
+                ProjectRegistration(
+                    project_id=pid, name=pid, path=f"/srv/{pid}",
+                    allowed_modes=[TaskMode.ANALYZE], max_timeout_seconds=600,
+                    sensitive_patterns=[], enabled=True,
+                )
+                for pid in ("p1", "p2")
+            ],
+        )
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        for token, user_id, scopes in (
+            (ALICE_TOKEN, "alice", ["codexbridge.read", "codexbridge.notifications.manage"]),
+            (READER_TOKEN, "reader", ["codexbridge.read"]),
+            (BOB_TOKEN, "bob", ["codexbridge.read"]),
+            (ADMIN_TOKEN, "admin", ["codexbridge.admin"]),
+        ):
+            await store.create_oauth_access_token(
+                seed, token=token, client_id="c", user_id=user_id, scopes=scopes, expires_at=future
+            )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(events_routes.router)
+    app.include_router(notifications_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    # The slot ceiling is process-global. Restoring it keeps a test that fills
+    # it from making every later test in the session answer 503.
+    original_slots = events_routes.stream_slots
+    events_routes.stream_slots = events_routes.StreamSlots(original_slots.limit)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.factory = factory  # type: ignore[attr-defined]
+    yield client
+    events_routes.stream_slots = original_slots
+    await engine.dispose()
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def make_task(factory, project_id: str = "p1"):
+    async with factory() as s:
+        return await store.create_task(
+            s,
+            SubmitTaskRequest(
+                executor_id="E1", project_id=project_id, instruction="analyze it",
+                mode=TaskMode.ANALYZE, priority=TaskPriority.NORMAL, timeout_seconds=60,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            ),
+            executor_online=True,
+        )
+
+
+async def emit(factory, entity_type: str, entity_id: str, event_type: str, payload: dict) -> int:
+    """Write one audit row directly and return its id.
+
+    Direct rather than through the endpoint that would produce it: these tests
+    are about the translation and the delivery, and driving eleven different
+    product flows to obtain eleven audit rows would test those flows instead.
+    The rows written here are the same rows `record_event` writes anywhere else
+    — same table, same columns, same autoincrement id.
+    """
+    async with factory() as s:
+        await record_event(s, entity_type, entity_id, event_type, payload)
+        await s.commit()
+    return await newest_audit_id(factory)
+
+
+async def newest_audit_id(factory) -> int:
+    async with factory() as s:
+        from sqlalchemy import func, select
+
+        from gateway.app.models.entities import AuditEventModel
+
+        return (await s.execute(select(func.max(AuditEventModel.id)))).scalar() or 0
+
+
+# --------------------------------------------------------------------------
+# Driving the generator
+# --------------------------------------------------------------------------
+
+
+class FakeClock:
+    """A monotonic clock the test moves on purpose.
+
+    `event_stream` reads the clock to decide when to heartbeat and when its
+    maximum duration is up. Both are timing decisions, and asserting on a timing
+    decision against `time.monotonic` means sleeping — which is slow when it
+    passes and flaky when it does not.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def stepping_sleep(clock: FakeClock, step: float = 1.0, on_poll=None):
+    """An `asyncio.sleep` replacement that advances the fake clock instead.
+
+    `on_poll` runs between polls, which is how a test inserts an event *while*
+    the stream is running rather than only before it opens.
+    """
+
+    async def _sleep(_seconds: float) -> None:
+        clock.now += step
+        if on_poll is not None:
+            await on_poll()
+
+    return _sleep
+
+
+def parse_frames(chunks: list[str]) -> list[dict]:
+    """SSE text as a list of `{id?, event?, data?, comment?}` dicts.
+
+    Parsed rather than string-matched: `id:` appearing on the right frames is
+    one of the properties under test, and a substring assertion cannot tell
+    which frame a line belongs to.
+    """
+    frames: list[dict] = []
+    for block in "".join(chunks).split("\n\n"):
+        if not block.strip():
+            continue
+        frame: dict = {}
+        for line in block.split("\n"):
+            if line.startswith(":"):
+                frame["comment"] = line[1:].strip()
+            elif line.startswith("id: "):
+                frame["id"] = int(line[4:])
+            elif line.startswith("event: "):
+                frame["event"] = line[7:]
+            elif line.startswith("data: "):
+                frame["data"] = json.loads(line[6:])
+        frames.append(frame)
+    return frames
+
+
+async def run_stream(factory, *, token: str, resume_from: int = 0, polls: int = 1,
+                     projects=None, types=None, on_poll=None, is_disconnected=None,
+                     heartbeat_seconds: float = 1e9, batch_limit: int = 200) -> list[dict]:
+    """Drive `event_stream` for exactly `polls` iterations and return its frames.
+
+    `max_duration_seconds` is set to `polls` and the fake clock advances by one
+    per sleep, so the generator stops itself after the requested number of
+    polls — no `aclose()` from outside, which means the `stream.closed` frame
+    and the `finally` block are both exercised the way production reaches them.
+    """
+    clock = FakeClock()
+    frames: list[str] = []
+    async for chunk in events_routes.event_stream(
+        factory=factory,
+        token=token,
+        resume_from=resume_from,
+        requested_projects=projects,
+        requested_types=types or [],
+        poll_interval=0.0,
+        heartbeat_seconds=heartbeat_seconds,
+        max_duration_seconds=float(polls),
+        batch_limit=batch_limit,
+        is_disconnected=is_disconnected,
+        monotonic=clock,
+        sleep=stepping_sleep(clock, 1.0, on_poll),
+    ):
+        frames.append(chunk)
+    return parse_frames(frames)
+
+
+def entity_frames(frames: list[dict]) -> list[dict]:
+    """Only the frames that carry an event — control frames and heartbeats out."""
+    return [f for f in frames if "id" in f]
+
+
+# --------------------------------------------------------------------------
+# The backlog endpoint
+# --------------------------------------------------------------------------
+
+
+async def test_the_backlog_returns_translated_events_oldest_first(api) -> None:
+    task = await make_task(api.factory, "p1")
+    await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+    await emit(api.factory, "task", task.id, "task.result", {"state": "succeeded"})
+
+    body = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()
+
+    types = [item["type"] for item in body["items"]]
+    assert types == ["session.created", "session.state_changed", "session.completed"]
+    ids = [item["id"] for item in body["items"]]
+    assert ids == sorted(ids), "the backlog is read forward; a client catching up reads oldest first"
+
+    first = body["items"][0]
+    assert first["projectId"] == "p1"
+    assert first["entity"] == {"kind": "session", "id": task.id}
+    assert first["action"] == "created"
+    assert first["at"].endswith("Z")
+
+
+async def test_the_page_reports_more_and_a_position_to_continue_from(api) -> None:
+    task = await make_task(api.factory, "p1")
+    for index in range(6):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": f"s{index}"})
+
+    first = api.get("/api/v1/events?limit=3", headers=auth(ALICE_TOKEN)).json()
+    assert len(first["items"]) == 3
+    assert first["page"]["hasMore"] is True
+    assert first["page"]["nextAfter"] == first["items"][-1]["id"]
+
+    second = api.get(
+        f"/api/v1/events?limit=3&after={first['page']['nextAfter']}", headers=auth(ALICE_TOKEN)
+    ).json()
+    assert [item["id"] for item in second["items"]] > [item["id"] for item in first["items"]]
+
+    walked = [item["id"] for item in first["items"] + second["items"]]
+    assert len(walked) == len(set(walked)), "a paginated walk must not repeat an event"
+
+
+async def test_a_type_filter_narrows_without_making_the_position_stall(api) -> None:
+    """`nextAfter` is the last id *loaded*, not the last id returned.
+
+    Reporting the last returned id would make the next request re-scan the rows
+    the filter already rejected — and when nothing in the tail matches, forever:
+    the client would poll the same page for the rest of the stream's life.
+    """
+    task = await make_task(api.factory, "p1")
+    wanted = await emit(api.factory, "task", task.id, "task.result", {"state": "succeeded"})
+    for _ in range(4):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+
+    body = api.get(
+        "/api/v1/events?limit=3&type=session.completed", headers=auth(ALICE_TOKEN)
+    ).json()
+
+    assert [item["id"] for item in body["items"]] == [wanted]
+    assert body["page"]["hasMore"] is True
+    assert body["page"]["nextAfter"] > wanted, (
+        "the position must advance past the filtered-out rows this page loaded"
+    )
+
+
+async def test_an_unknown_type_filter_is_a_validation_error(api) -> None:
+    response = api.get("/api/v1/events?type=session.exploded", headers=auth(ALICE_TOKEN))
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == "validation_failed"
+    assert body["details"][0]["code"] == "unknown_event_type"
+
+
+async def test_a_declared_but_unemitted_type_filters_to_nothing_rather_than_failing(api) -> None:
+    """`artifact.*` is in the vocabulary and produced by nothing in this build.
+
+    Rejecting it would make the declared-but-unemitted values unusable, which is
+    the opposite of why they were declared: a client written against the
+    contract must be able to subscribe to them before the build that emits them
+    exists.
+    """
+    task = await make_task(api.factory, "p1")
+    await emit(api.factory, "task", task.id, "task.result", {"state": "succeeded"})
+
+    response = api.get("/api/v1/events?type=artifact.created", headers=auth(ALICE_TOKEN))
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+
+async def test_the_project_filter_only_ever_narrows(api) -> None:
+    p1 = await make_task(api.factory, "p1")
+    p2 = await make_task(api.factory, "p2")
+
+    seen = api.get("/api/v1/events?project=p2", headers=auth(ALICE_TOKEN)).json()["items"]
+    assert seen == [], "naming a project outside allowedProjects must narrow, never widen"
+
+    as_admin = api.get("/api/v1/events?project=p2", headers=auth(ADMIN_TOKEN)).json()["items"]
+    assert {item["entity"]["id"] for item in as_admin} == {p2.id}
+    assert p1.id not in {item["entity"]["id"] for item in as_admin}
+
+
+# --------------------------------------------------------------------------
+# Authorization
+# --------------------------------------------------------------------------
+
+
+async def test_a_restricted_principal_sees_only_its_own_projects_events(api) -> None:
+    p1 = await make_task(api.factory, "p1")
+    p2 = await make_task(api.factory, "p2")
+
+    alice = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()["items"]
+    bob = api.get("/api/v1/events", headers=auth(BOB_TOKEN)).json()["items"]
+    admin = api.get("/api/v1/events", headers=auth(ADMIN_TOKEN)).json()["items"]
+
+    assert {item["projectId"] for item in alice} == {"p1"}
+    assert {item["entity"]["id"] for item in alice} == {p1.id}
+    assert {item["projectId"] for item in bob} == {"p2"}
+    assert {item["projectId"] for item in admin} == {"p1", "p2"}
+
+
+async def test_authentication_events_never_appear_on_any_principals_feed(api) -> None:
+    """Sign-in activity is not a product event, and streaming it is a disclosure.
+
+    The audit log these events are derived from also records sign-in, failed
+    sign-in and credential revocation. Delivering those would tell any token
+    holder — including one belonging to a *different* person — when the operator
+    signs in and from where. They are excluded by construction (`auth` carries no
+    project, so it is not in `DELIVERABLE_ENTITY_TYPES`) rather than by a filter
+    someone has to remember, and this is the test that says so.
+
+    Three independent guards have to all be removed for one of these to ship,
+    and each is asserted here so that removing any one of them is a red test
+    rather than a thinner defence nobody notices.
+    """
+    # Guard 1: the audit event types are outside the translated vocabulary, so
+    # the query never selects the row.
+    assert not {"auth.signed_in", "auth.sign_in_failed", "auth.credentials_revoked"} & set(
+        event_types.TRANSLATED_AUDIT_EVENT_TYPES
+    )
+    # Guard 2: the entity type is not deliverable, so the query never selects it
+    # by entity either. (Guard 3 — no project can be derived for it — is
+    # `test_an_event_whose_project_cannot_be_derived_reaches_nobody`.)
+    assert store.AUTH_ENTITY_TYPE not in event_types.DELIVERABLE_ENTITY_TYPES
+
+    async with api.factory() as s:
+        await store.record_auth_event(
+            s, user_id="alice", event_type="auth.signed_in", payload={"reason": "password"}
+        )
+        await store.record_auth_event(
+            s, user_id="alice", event_type="auth.sign_in_failed", payload={"reason": "bad_password"}
+        )
+        await store.revoke_access_token(s, token=BOB_TOKEN, user_id="bob", reason="test")
+
+    for token in (ALICE_TOKEN, ADMIN_TOKEN):
+        body = api.get("/api/v1/events", headers=auth(token)).json()
+        assert body["items"] == [], f"{token} received an authentication event"
+
+    frames = await run_stream(api.factory, token=ADMIN_TOKEN, polls=1)
+    assert entity_frames(frames) == []
+
+
+async def test_a_preference_change_is_not_a_project_event(api) -> None:
+    """`notification` rows are excluded the same way `auth` rows are.
+
+    A person's own preference is not a project's event, and the row's
+    `entity_id` is a user id where a project would be — so delivering it would
+    also publish which accounts exist.
+    """
+    api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["decision.requested"], "pushEnabled": True},
+    )
+
+    assert api.get("/api/v1/events", headers=auth(ADMIN_TOKEN)).json()["items"] == []
+
+
+async def test_an_event_whose_project_cannot_be_derived_reaches_nobody(api) -> None:
+    """Fail closed, administrators included.
+
+    An audit row naming an entity that no longer exists (or one this build
+    cannot resolve to a project) has no project to authorize against. Delivering
+    it to an administrator "because they see everything" would make it the one
+    event on this surface that no project check covers — and it would be
+    rendered by a client under whichever project it happened to be looking at.
+    """
+    await emit(api.factory, "task", "no-such-task", "task.state_changed", {"state": "running"})
+
+    for token in (ALICE_TOKEN, ADMIN_TOKEN):
+        assert api.get("/api/v1/events", headers=auth(token)).json()["items"] == []
+
+
+async def test_reading_events_requires_the_read_scope(api) -> None:
+    response = api.get("/api/v1/events", headers={"Authorization": "Bearer nonsense"})
+    assert response.status_code == 401
+    assert response.json()["code"] == "unauthenticated"
+
+
+# --------------------------------------------------------------------------
+# The payload is internal; the event is public
+# --------------------------------------------------------------------------
+
+
+async def test_no_stored_payload_key_is_passed_through_to_a_client(api) -> None:
+    """The audit payload is written by eleven call sites and is not a response.
+
+    It carries `actor_email`, `requested_by_email` and free-text `context`
+    blobs. A translation that spread the payload into the event — or that
+    included it as a `payload` field "for debugging" — would ship every one of
+    them. The contract is a whitelist, so this asserts on the *absence* of
+    everything nobody whitelisted.
+    """
+    task = await make_task(api.factory, "p1")
+    await emit(
+        api.factory, "task", task.id, "task.stopped_by_actor",
+        {
+            "state": "cancelled",
+            "actor_id": "alice",
+            "actor_email": "alice@example.com",
+            "requested_by_email": "boss@example.com",
+            "context": {"internal": "secret"},
+            "reason": "operator asked",
+        },
+    )
+
+    body = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()
+    serialized = json.dumps(body)
+
+    assert "alice@example.com" not in serialized
+    assert "boss@example.com" not in serialized
+    assert "secret" not in serialized
+    assert "payload" not in body["items"][-1]
+    # The whitelisted keys did come through, or the assertions above would pass
+    # trivially on an empty event.
+    stopped = body["items"][-1]
+    assert stopped["actorId"] == "alice"
+    assert "operator asked" in stopped["summary"]
+
+
+async def test_free_text_in_a_summary_is_redacted_and_bounded(api) -> None:
+    """`redact` is applied to executor free text, and the line has a ceiling.
+
+    `last_error` can be a multi-kilobyte traceback carrying a bearer token and a
+    server path. A summary is a notification line: it is redacted through the
+    same function `GET /api/v1/sessions/{id}/logs` uses, and truncated.
+    """
+    task = await make_task(api.factory, "p1")
+    await emit(
+        api.factory, "task", task.id, "task.state_changed",
+        {"state": "failed", "error": "Bearer sk-abcdefghijklmnop failed at " + ("x" * 500)},
+    )
+
+    body = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()
+    summary = body["items"][-1]["summary"]
+
+    assert "sk-abcdefghijklmnop" not in summary
+    assert len(summary) < 400, "a notification line must not be an unbounded traceback"
+
+
+def test_every_emitted_event_type_has_a_summary_builder() -> None:
+    """A type with no builder falls back to a bland sentence — silently.
+
+    The fallback exists so one unmapped type cannot break a stream, which means
+    it cannot be the thing that tells anyone the mapping is incomplete. This is.
+    """
+    missing = [
+        value for value in event_types.EMITTED_EVENT_TYPES
+        if event_types.summarize(value, {}, lambda text: text) == "Event recorded."
+    ]
+    assert not missing, f"emitted event types with no summary of their own: {missing}"
+
+
+def test_every_audited_domain_event_type_is_translated() -> None:
+    """A new audit event under a deliverable entity must be classified on purpose.
+
+    `classify` returning None is safe — the row is not emitted — and silent,
+    which is the failure this catches: an author who adds a `record_event` for a
+    new kind of issue update would ship a mobile client that never hears about
+    it, with the whole suite green. Parsed from the source rather than collected
+    at runtime, because the point is to catch a writer no test exercises yet.
+    """
+    unclassified: list[str] = []
+    for path in (REPO_ROOT / "gateway").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "record_event" or len(node.args) < 4:
+                continue
+            entity, event_type = node.args[1], node.args[3]
+            if not isinstance(entity, ast.Constant) or not isinstance(event_type, ast.Constant):
+                # A non-literal entity type is one of the two module constants
+                # (`AUTH_ENTITY_TYPE`, `NOTIFICATION_ENTITY_TYPE`), neither of
+                # which is deliverable. Skipping it is safe *because* those
+                # constants are asserted non-deliverable just below.
+                continue
+            if entity.value not in event_types.DELIVERABLE_ENTITY_TYPES:
+                continue
+            if event_type.value not in event_types.TRANSLATED_AUDIT_EVENT_TYPES:
+                unclassified.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno} {event_type.value}")
+
+    assert not unclassified, (
+        "audit events written under a deliverable entity that "
+        f"gateway/app/services/event_types.py does not translate: {unclassified}. "
+        "Add a mapping (and a summary), or the mobile client never hears about them."
+    )
+
+
+def test_the_non_deliverable_entity_constants_stay_non_deliverable() -> None:
+    """The exclusion of auth and preference rows is by construction; pin it.
+
+    `test_every_audited_domain_event_type_is_translated` skips call sites whose
+    entity type is one of these constants. That skip is only sound while the
+    constants are outside the deliverable set — otherwise the two tests together
+    would leave every auth writer unchecked.
+    """
+    assert store.AUTH_ENTITY_TYPE not in event_types.DELIVERABLE_ENTITY_TYPES
+    assert store.NOTIFICATION_ENTITY_TYPE not in event_types.DELIVERABLE_ENTITY_TYPES
+
+
+def test_the_declared_but_unemitted_types_are_not_produced_by_this_build() -> None:
+    """`artifact.*` and `androidBuild.*` are contract, not behaviour, until #11.
+
+    Declared so that issue #11 is additive rather than a new major version. That
+    is only honest while nothing produces one: a type that quietly started being
+    emitted here would be an undocumented behaviour change dressed as a
+    pre-agreed one.
+    """
+    assert set(event_types.NOT_YET_EMITTED) & set(event_types.EMITTED_EVENT_TYPES) == set()
+    produced = {
+        event_types.classify(audit_type, {"state": state})[0]
+        for audit_type in event_types.TRANSLATED_AUDIT_EVENT_TYPES
+        for state in ("awaiting_approval", "running")
+    }
+    assert produced & set(event_types.NOT_YET_EMITTED) == set()
+    assert set(event_types.NOT_YET_EMITTED) <= set(event_types.ALL_EVENT_TYPES)
+
+
+# --------------------------------------------------------------------------
+# The stream: resume, loss, duplicates
+# --------------------------------------------------------------------------
+
+
+async def test_the_stream_opens_with_an_acknowledgement_carrying_no_position(api) -> None:
+    """`stream.open` must not carry `id:`.
+
+    A control frame with an SSE id advances the client's `Last-Event-ID` past
+    events it never received — which is exactly the silent loss this endpoint's
+    acceptance criterion forbids.
+    """
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=1)
+
+    assert frames[0]["event"] == event_types.STREAM_OPEN
+    assert "id" not in frames[0]
+    assert frames[-1]["event"] == event_types.STREAM_CLOSED
+    assert "id" not in frames[-1]
+    assert frames[-1]["data"]["reason"] == "max_duration"
+
+
+async def test_events_recorded_while_the_stream_runs_are_delivered(api) -> None:
+    task = await make_task(api.factory, "p1")
+    pending = ["running", "succeeded"]
+
+    async def on_poll():
+        if pending:
+            await emit(api.factory, "task", task.id, "task.state_changed", {"state": pending.pop(0)})
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=4, on_poll=on_poll)
+
+    delivered = entity_frames(frames)
+    assert [f["event"] for f in delivered] == [
+        "session.created", "session.state_changed", "session.state_changed"
+    ]
+    assert [f["id"] for f in delivered] == sorted(f["id"] for f in delivered)
+    assert all(f["data"]["id"] == f["id"] for f in delivered), (
+        "the SSE id and the event body's id are one position, not two"
+    )
+
+
+async def test_reconnecting_from_the_last_id_loses_nothing_and_repeats_nothing(api) -> None:
+    """The acceptance criterion, end to end.
+
+    A first stream delivers some events; more are recorded while nothing is
+    connected; a second stream resumes from the last id the first delivered. The
+    union must be every event exactly once — no gap across the disconnect, no
+    replay of what was already acknowledged.
+    """
+    task = await make_task(api.factory, "p1")
+    for state in ("queued", "running"):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": state})
+
+    first = entity_frames(await run_stream(api.factory, token=ALICE_TOKEN, polls=1))
+    assert first, "the first connection must deliver the backlog"
+    last_seen = first[-1]["id"]
+
+    # Recorded while the client is disconnected: nothing is holding a cursor.
+    for state in ("paused", "resumed", "succeeded"):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": state})
+
+    second = entity_frames(
+        await run_stream(api.factory, token=ALICE_TOKEN, resume_from=last_seen, polls=1)
+    )
+
+    first_ids = [f["id"] for f in first]
+    second_ids = [f["id"] for f in second]
+    assert set(first_ids) & set(second_ids) == set(), "an acknowledged event was delivered twice"
+
+    everything = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()["items"]
+    assert first_ids + second_ids == [item["id"] for item in everything], (
+        "the two connections together must be the whole log, in order, once each"
+    )
+
+
+async def test_the_same_position_replayed_twice_delivers_the_same_events(api) -> None:
+    """Resume is a pure function of the position, so a duplicated reconnect is safe.
+
+    A mobile client that reconnects twice — a race between the OS waking it and
+    its own retry timer — must not be punished with a partial second view. `id >
+    position` makes replay idempotent, and this pins that it is.
+    """
+    task = await make_task(api.factory, "p1")
+    for state in ("queued", "running", "succeeded"):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": state})
+
+    once = entity_frames(await run_stream(api.factory, token=ALICE_TOKEN, resume_from=1, polls=1))
+    twice = entity_frames(await run_stream(api.factory, token=ALICE_TOKEN, resume_from=1, polls=1))
+
+    assert [f["id"] for f in once] == [f["id"] for f in twice]
+    assert [f["data"] for f in once] == [f["data"] for f in twice]
+
+
+async def test_a_position_the_log_has_moved_past_is_announced_before_anything_is_delivered(api) -> None:
+    """A gap is signalled, never papered over — and signalled *first*.
+
+    Delivering events and mentioning the gap afterwards would let a client act
+    on a partial view believing it was continuous. Note what is being simulated:
+    this build's retention sweep deletes authentication rows only, so no domain
+    event has ever been purged in production. The check exists so that a future
+    retention policy over domain rows cannot cause a silent loss the day an
+    operator enables it.
+    """
+    task = await make_task(api.factory, "p1")
+    for state in ("queued", "running", "succeeded"):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": state})
+
+    async with api.factory() as s:
+        from sqlalchemy import delete, func, select
+
+        from gateway.app.models.entities import AuditEventModel
+
+        oldest = (await s.execute(select(func.min(AuditEventModel.id)))).scalar()
+        await s.execute(delete(AuditEventModel).where(AuditEventModel.id == oldest))
+        await s.commit()
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, resume_from=oldest, polls=1)
+
+    assert frames[0]["event"] == event_types.STREAM_OPEN
+    gap = frames[1]
+    assert gap["event"] == event_types.STREAM_GAP
+    assert "id" not in gap, "a gap frame must not advance Last-Event-ID"
+    assert gap["data"]["reason"] == store.CURSOR_BEYOND_RETENTION
+    assert gap["data"]["from"] == oldest
+    assert gap["data"]["oldestAvailableId"] == oldest + 1
+    assert gap["data"]["oldestAvailableId"] is not None
+
+    delivered = entity_frames(frames)
+    assert delivered, "the stream still delivers what survives"
+    assert frames.index(gap) < frames.index(delivered[0])
+
+
+async def test_a_position_ahead_of_the_log_is_a_gap_too(api) -> None:
+    """The mirror case: a cursor from another deployment, or a restored backup.
+
+    Left unsignalled the stream would simply never deliver again — the same
+    silence in the other direction, and the harder one to diagnose from a phone.
+    """
+    task = await make_task(api.factory, "p1")
+    await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+    newest = await newest_audit_id(api.factory)
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, resume_from=newest + 500, polls=1)
+
+    gap = frames[1]
+    assert gap["event"] == event_types.STREAM_GAP
+    assert gap["data"]["reason"] == store.CURSOR_AHEAD
+    assert entity_frames(frames) == []
+
+
+async def test_a_continuous_position_produces_no_gap_frame(api) -> None:
+    """The signal is only worth having if it stays quiet when nothing was lost."""
+    task = await make_task(api.factory, "p1")
+    first = await newest_audit_id(api.factory)
+    await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, resume_from=first, polls=1)
+
+    assert [f.get("event") for f in frames].count(event_types.STREAM_GAP) == 0
+
+
+async def test_the_polling_fallback_reports_the_same_gap(api) -> None:
+    """"No silent loss" is a property of the events, not of one transport.
+
+    A client living on the polling fallback — a background app, a network that
+    kills long connections — would otherwise be handed a page starting wherever
+    the log now begins, with nothing to distinguish it from continuity.
+    """
+    task = await make_task(api.factory, "p1")
+    for state in ("queued", "running"):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": state})
+
+    async with api.factory() as s:
+        from sqlalchemy import delete, func, select
+
+        from gateway.app.models.entities import AuditEventModel
+
+        oldest = (await s.execute(select(func.min(AuditEventModel.id)))).scalar()
+        await s.execute(delete(AuditEventModel).where(AuditEventModel.id == oldest))
+        await s.commit()
+
+    body = api.get(f"/api/v1/events?after={oldest}", headers=auth(ALICE_TOKEN)).json()
+    assert body["gap"]["reason"] == store.CURSOR_BEYOND_RETENTION
+    assert body["gap"]["from"] == oldest
+
+    fine = api.get(f"/api/v1/events?after={oldest + 1}", headers=auth(ALICE_TOKEN)).json()
+    assert "gap" not in fine, "a continuous position must not be reported as a gap"
+
+
+# --------------------------------------------------------------------------
+# The stream: a credential that stops being usable
+# --------------------------------------------------------------------------
+
+
+async def test_a_revoked_token_stops_the_stream_it_had_already_opened(api) -> None:
+    """Authorization is re-checked on every poll, not once at `GET`.
+
+    A stream opened at 09:00 and still running at 17:00 authorized once, and
+    every event after that was delivered on an eight-hour-old decision. Revoking
+    a credential has to stop the delivery it authorizes, or revocation is
+    advice.
+    """
+    task = await make_task(api.factory, "p1")
+    revoked = False
+
+    async def on_poll():
+        nonlocal revoked
+        if not revoked:
+            revoked = True
+            async with api.factory() as s:
+                await store.revoke_access_token(s, token=ALICE_TOKEN, user_id="alice", reason="test")
+        else:
+            await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=8, on_poll=on_poll)
+
+    assert frames[-1]["event"] == event_types.STREAM_CLOSED
+    assert frames[-1]["data"]["reason"] == "unauthenticated"
+    delivered = [f["data"]["type"] for f in entity_frames(frames)]
+    assert delivered == ["session.created"], (
+        "events recorded after the revocation must not be delivered"
+    )
+
+
+async def test_an_expired_token_stops_the_stream(api) -> None:
+    """Expiry is the same failure as revocation and must end the stream too.
+
+    Separate from the revocation test on purpose: they are two different columns
+    checked in one place, and a regression that dropped the expiry comparison
+    would leave the revocation test green.
+    """
+    task = await make_task(api.factory, "p1")
+
+    async def on_poll():
+        async with api.factory() as s:
+            from gateway.app.models.entities import OAuthAccessTokenModel
+            from shared.security import hash_token
+
+            row = await s.get(OAuthAccessTokenModel, hash_token(ALICE_TOKEN))
+            row.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            await s.commit()
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=8, on_poll=on_poll)
+
+    assert frames[-1]["data"]["reason"] == "unauthenticated"
+    assert [f["data"]["type"] for f in entity_frames(frames)] == ["session.created"]
+
+
+async def test_a_project_removed_from_the_actor_stops_reaching_them(api, users_file) -> None:
+    """`allowed_projects` is re-read per poll, not captured when the stream opened.
+
+    Revocation is not the only way authorization changes. An operator who
+    removes a project from an account expects that to take effect, and a stream
+    holding a principal from an hour ago would keep delivering that project's
+    events until the connection happened to drop.
+    """
+    task = await make_task(api.factory, "p1")
+    narrowed = False
+
+    async def on_poll():
+        nonlocal narrowed
+        if not narrowed:
+            narrowed = True
+            registry = json.loads(pathlib.Path(users_file).read_text(encoding="utf-8"))
+            for user in registry["users"]:
+                if user["user_id"] == "alice":
+                    user["allowed_projects"] = ["p2"]
+            pathlib.Path(users_file).write_text(json.dumps(registry), encoding="utf-8")
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": "running"})
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=6, on_poll=on_poll)
+
+    assert [f["data"]["type"] for f in entity_frames(frames)] == ["session.created"]
+    assert frames[-1]["data"]["reason"] == "max_duration", (
+        "narrowing projects is not a credential failure; the stream stays open and empty"
+    )
+
+
+async def test_a_disconnected_client_ends_the_stream_without_a_closing_frame(api) -> None:
+    """Nothing is listening, so there is nothing to tell.
+
+    Asserted because the alternative — yielding a frame into a closed
+    connection — is where a streaming endpoint leaks a task that never finishes.
+    """
+    await make_task(api.factory, "p1")
+    calls = {"n": 0}
+
+    async def is_disconnected():
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    frames = await run_stream(
+        api.factory, token=ALICE_TOKEN, polls=6, is_disconnected=is_disconnected
+    )
+
+    assert event_types.STREAM_CLOSED not in [f.get("event") for f in frames]
+    assert entity_frames(frames), "the first poll still delivered before the client went away"
+
+
+# --------------------------------------------------------------------------
+# The stream: keep-alive, filters and the slot ceiling
+# --------------------------------------------------------------------------
+
+
+async def test_an_idle_stream_sends_a_comment_not_an_event(api) -> None:
+    """A heartbeat keeps a proxy from timing out an idle connection.
+
+    A comment rather than a frame, because a frame would reach the client's
+    `onmessage` as an event of an unknown type and — if it carried `id:` — would
+    move the resume position past nothing.
+    """
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=4, heartbeat_seconds=1.0)
+
+    heartbeats = [f for f in frames if "comment" in f]
+    assert heartbeats, "an idle stream must be kept warm"
+    assert all("id" not in f and "event" not in f for f in heartbeats)
+    assert heartbeats[0]["comment"] == "keep-alive"
+
+
+async def test_a_newline_in_stored_text_cannot_split_one_frame_into_two(api) -> None:
+    """SSE is a line protocol: a raw newline inside `data:` ends the frame early.
+
+    That is frame injection, and the injected half would be parsed by the client
+    as an event of the attacker's choosing — including one carrying an `id:`
+    that moves the resume position. The values reaching a frame are
+    server-generated today, but "today" is not a guard: `entity_id` and
+    `summary` both trace back to stored text, and the defence is that every
+    frame is serialized as one line of ASCII rather than that no input ever
+    contains a newline.
+    """
+    task = await make_task(api.factory, "p1")
+    await emit(
+        api.factory, "task", task.id, "task.stopped_by_actor",
+        {"state": "cancelled", "reason": "line one\ndata: {\"id\": 999}\nevent: session.completed\n"},
+    )
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=1)
+
+    delivered = entity_frames(frames)
+    assert [f["data"]["type"] for f in delivered] == ["session.created", "session.stopped"]
+    assert 999 not in [f["id"] for f in frames if "id" in f]
+    raw = events_routes._frame(event="x", data={"summary": "a\nb"}, event_id=1)
+    assert raw.count("\n\n") == 1 and raw.endswith("\n\n")
+    assert len(raw.strip().split("\n")) == 3, "id, event and exactly one data line"
+
+
+async def test_a_stream_type_filter_narrows_delivery_without_stalling_the_cursor(api) -> None:
+    task = await make_task(api.factory, "p1")
+    for state in ("queued", "running"):
+        await emit(api.factory, "task", task.id, "task.state_changed", {"state": state})
+    wanted = await emit(api.factory, "task", task.id, "task.result", {"state": "succeeded"})
+
+    frames = await run_stream(
+        api.factory, token=ALICE_TOKEN, polls=3, types=["session.completed"]
+    )
+
+    delivered = entity_frames(frames)
+    assert [f["id"] for f in delivered] == [wanted]
+
+
+async def test_the_slot_ceiling_refuses_rather_than_degrading_the_shared_pool(api) -> None:
+    """The rate limiter bounds requests per window, not connections held open.
+
+    One accepted request here becomes a connection that takes a database session
+    every poll, so the endpoint that is cheapest per request is the one that can
+    exhaust the pool the rest of the API shares.
+    """
+    events_routes.stream_slots = events_routes.StreamSlots(0)
+
+    response = api.get("/api/v1/events/stream", headers=auth(ALICE_TOKEN))
+
+    assert response.status_code == 503
+    assert response.json()["code"] == "dependency_unavailable"
+    assert response.headers["Retry-After"] == "5"
+
+
+async def test_a_finished_stream_gives_its_slot_back(api) -> None:
+    """A slot that is not returned is gone for good, and the ceiling ratchets down.
+
+    Both release paths are exercised: the generator's `finally` here, and — for
+    a connection that dies before the body ever starts — the response's
+    background task, which is why `StreamSlot.release` is idempotent.
+    """
+    slots = events_routes.StreamSlots(2)
+    slot = slots.acquire()
+    assert slots.active == 1
+    slot.release()
+    slot.release()
+    assert slots.active == 0, "a double release must not push the counter below zero"
+
+    async for _ in events_routes.event_stream(
+        factory=api.factory, token=ALICE_TOKEN, resume_from=0,
+        requested_projects=None, requested_types=[], poll_interval=0.0,
+        heartbeat_seconds=1e9, max_duration_seconds=0.0, batch_limit=10,
+        on_close=slots.acquire().release, monotonic=FakeClock(), sleep=stepping_sleep(FakeClock()),
+    ):
+        pass
+    assert slots.active == 0
+
+
+# --------------------------------------------------------------------------
+# The route around the generator
+# --------------------------------------------------------------------------
+
+
+async def test_the_stream_is_served_as_an_event_stream_that_a_proxy_will_not_buffer(api, monkeypatch) -> None:
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "event_stream_max_duration_seconds", 0.0)
+    monkeypatch.setattr(settings, "event_stream_poll_interval_seconds", 0.01)
+    monkeypatch.setattr("gateway.app.db.session.SessionLocal", api.factory)
+
+    task = await make_task(api.factory, "p1")
+
+    response = api.get("/api/v1/events/stream", headers=auth(ALICE_TOKEN))
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["x-accel-buffering"] == "no"
+
+    frames = parse_frames([response.text])
+    assert frames[0]["event"] == event_types.STREAM_OPEN
+    assert [f["data"]["entity"]["id"] for f in entity_frames(frames)] == [task.id]
+
+
+async def test_last_event_id_resumes_and_beats_the_query_parameter(api, monkeypatch) -> None:
+    """The header is what a reconnecting `EventSource` sends by itself.
+
+    It wins over `?after=` because it is the more recent of the two by
+    construction: the query parameter is whatever the client first opened with,
+    while the header is where it actually got to.
+    """
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "event_stream_max_duration_seconds", 0.0)
+    monkeypatch.setattr(settings, "event_stream_poll_interval_seconds", 0.01)
+    monkeypatch.setattr("gateway.app.db.session.SessionLocal", api.factory)
+
+    task = await make_task(api.factory, "p1")
+    seen = await newest_audit_id(api.factory)
+    await emit(api.factory, "task", task.id, "task.result", {"state": "succeeded"})
+
+    response = api.get(
+        "/api/v1/events/stream?after=0",
+        headers={**auth(ALICE_TOKEN), "Last-Event-ID": str(seen)},
+    )
+
+    frames = parse_frames([response.text])
+    assert [f["data"]["type"] for f in entity_frames(frames)] == ["session.completed"]
+    assert frames[0]["data"]["from"] == seen
+
+
+async def test_a_malformed_last_event_id_is_ignored_rather_than_refused(api) -> None:
+    """The user agent sets that header, not the application.
+
+    Refusing the connection over a value the client cannot control would strand
+    it with no way to reconnect.
+    """
+    assert events_routes._resume_from("not-a-number", 7) == 7
+    assert events_routes._resume_from("-4", 7) == 7
+    assert events_routes._resume_from(None, None) == 0
+    assert events_routes._resume_from(" 12 ", 3) == 12
+
+
+async def test_a_bad_type_filter_fails_before_the_body_starts(api, monkeypatch) -> None:
+    """Once an event-stream body has started there is no status code left to change.
+
+    A filter validated inside the stream would have to be reported as a frame,
+    and a client that asked for a type it misspelled would see an open, empty,
+    permanently silent connection instead of a `400`.
+    """
+    monkeypatch.setattr("gateway.app.db.session.SessionLocal", api.factory)
+
+    response = api.get("/api/v1/events/stream?type=nope", headers=auth(ALICE_TOKEN))
+
+    assert response.status_code == 400
+    assert response.json()["details"][0]["code"] == "unknown_event_type"
+    assert events_routes.stream_slots.active == 0, "a refused stream must not hold a slot"
+
+
+# --------------------------------------------------------------------------
+# Notification preferences
+# --------------------------------------------------------------------------
+
+
+async def test_preferences_round_trip(api) -> None:
+    empty = api.get("/api/v1/notifications/preferences", headers=auth(ALICE_TOKEN))
+    assert empty.status_code == 200
+    assert empty.json() == {
+        "eventTypes": [],
+        "pushEnabled": False,
+        "updatedAt": None,
+        "pushDeliveryAvailable": False,
+    }
+
+    saved = api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["session.completed", "decision.requested", "decision.requested"],
+              "pushEnabled": True},
+    )
+    assert saved.status_code == 200
+    body = saved.json()
+    assert body["eventTypes"] == ["decision.requested", "session.completed"], "sorted and de-duplicated"
+    assert body["pushEnabled"] is True
+    assert body["updatedAt"].endswith("Z")
+    assert body["pushDeliveryAvailable"] is False, (
+        "there is no push transport in this build; a client must be able to say so"
+    )
+
+    assert api.get("/api/v1/notifications/preferences", headers=auth(ALICE_TOKEN)).json() == body
+
+
+async def test_a_put_replaces_the_document_rather_than_merging_into_it(api) -> None:
+    """`PUT`, not `PATCH`: an absent field takes its default.
+
+    A merge would need a `PATCH` and a way to say "remove this", and would make
+    the endpoint's name a lie.
+    """
+    api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["session.completed"], "pushEnabled": True},
+    )
+
+    replaced = api.put(
+        "/api/v1/notifications/preferences", headers=auth(ALICE_TOKEN), json={}
+    ).json()
+
+    assert replaced["eventTypes"] == []
+    assert replaced["pushEnabled"] is False
+
+
+async def test_preferences_are_per_actor_and_never_another_accounts(api) -> None:
+    api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["session.completed"], "pushEnabled": True},
+    )
+
+    admin = api.get("/api/v1/notifications/preferences", headers=auth(ADMIN_TOKEN)).json()
+    assert admin["eventTypes"] == [], (
+        "an administrator reads their own preferences; there is no endpoint for anyone else's"
+    )
+
+
+async def test_an_unknown_event_type_is_refused_with_the_field_named(api) -> None:
+    response = api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["session.exploded"], "pushEnabled": False},
+    )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["code"] == "validation_failed"
+    assert body["details"][0]["field"] == "eventTypes"
+    assert "session.exploded" in body["details"][0]["message"]
+
+
+async def test_writing_preferences_needs_a_scope_reading_them_does_not(api) -> None:
+    """Two actions, because an operator may grant one without the other.
+
+    A phone allowed to watch the stream is not automatically a phone allowed to
+    rewrite what the account gets notified about.
+    """
+    assert api.get("/api/v1/notifications/preferences", headers=auth(READER_TOKEN)).status_code == 200
+
+    refused = api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(READER_TOKEN),
+        json={"eventTypes": [], "pushEnabled": False},
+    )
+    assert refused.status_code == 403
+    assert refused.json()["code"] == "permission_denied"
+
+
+def test_the_manage_scope_is_one_a_signed_in_client_can_actually_be_granted() -> None:
+    """A scope outside `oauth_default_scopes` can never be granted to anyone.
+
+    `POST /api/v1/auth/sign-in` issues `user.scopes & settings.oauth_scopes()`,
+    and the browser OAuth flow caps grants the same way. A new scope added to
+    the catalogue but not to that default set produces an endpoint every mobile
+    user is permanently refused from — a `403` naming a permission the operator
+    cannot grant from `users.json` however they edit it. Nothing else in this
+    file would catch it: every other test mints its tokens directly and so
+    never crosses the cap.
+
+    Asserted for this delivery's scope only, deliberately, rather than for the
+    whole catalogue. `codexbridge.task.approve` is outside the default set **on
+    purpose** — approving a sensitive session is a capability an operator raises
+    the deployment default to grant, not one every signed-in phone gets — so a
+    catalogue-wide version of this assertion would be asserting that a
+    deliberate policy is a bug.
+    """
+    from gateway.app.core.config import settings
+
+    from gateway.app.api import permissions
+
+    granted = settings.oauth_scopes()
+    assert permissions.NOTIFICATIONS_MANAGE.scope in granted
+    assert permissions.EVENTS_READ.scope in granted
+    assert permissions.NOTIFICATIONS_READ.scope in granted
+
+
+async def test_a_stored_type_that_no_longer_exists_is_dropped_on_the_way_out(api) -> None:
+    """A stored preference can outlive the type it names.
+
+    Handing a client a subscription to a retired type would have it echo the
+    value back on its next `PUT` and be rejected for something it never chose.
+    """
+    async with api.factory() as s:
+        await store.set_notification_preference(
+            s, user_id="alice", event_types=["session.completed"], push_enabled=False
+        )
+        from gateway.app.models.entities import NotificationPreferenceModel
+
+        row = await s.get(NotificationPreferenceModel, "alice")
+        row.event_types_json = json.dumps(["session.completed", "session.retired_in_2027"])
+        await s.commit()
+
+    body = api.get("/api/v1/notifications/preferences", headers=auth(ALICE_TOKEN)).json()
+    assert body["eventTypes"] == ["session.completed"]
+
+
+async def test_preferences_do_not_filter_the_stream(api) -> None:
+    """A documented decision, not an omission — so it is pinned as behaviour.
+
+    A client that opened the stream asked for the stream. Withholding events
+    from it because of a preference set on another device is how a phone
+    silently misses the decision its operator was waiting for, and the failure
+    would be indistinguishable from a quiet system.
+    """
+    api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["androidBuild.status_changed"], "pushEnabled": True},
+    )
+    task = await make_task(api.factory, "p1")
+
+    frames = await run_stream(api.factory, token=ALICE_TOKEN, polls=1)
+
+    assert [f["data"]["entity"]["id"] for f in entity_frames(frames)] == [task.id]
+
+
+# --------------------------------------------------------------------------
+# Store-level invariants the endpoints rely on
+# --------------------------------------------------------------------------
+
+
+async def test_an_empty_project_list_matches_nothing_and_is_not_no_restriction(api) -> None:
+    """The one-character mistake: `if project_ids:` instead of `is not None`.
+
+    A principal with no projects must see nothing. Reading an empty list as "no
+    restriction" turns the least privileged account into the most privileged
+    one, and every other test in this file would still pass.
+    """
+    await make_task(api.factory, "p1")
+
+    async with api.factory() as s:
+        none_allowed = await store.list_mobile_events_page(
+            s, project_ids=[], entity_types=sorted(event_types.DELIVERABLE_ENTITY_TYPES),
+            audit_event_types=sorted(event_types.TRANSLATED_AUDIT_EVENT_TYPES),
+            after=None, limit=50,
+        )
+        unrestricted = await store.list_mobile_events_page(
+            s, project_ids=None, entity_types=sorted(event_types.DELIVERABLE_ENTITY_TYPES),
+            audit_event_types=sorted(event_types.TRANSLATED_AUDIT_EVENT_TYPES),
+            after=None, limit=50,
+        )
+
+    assert none_allowed == []
+    assert unrestricted, "the precondition: there is something to see"
+
+
+async def test_task_created_forks_on_the_state_it_was_created_in(api) -> None:
+    """One audit row, two mobile meanings, resolved from the payload.
+
+    A submission held for approval is a *decision being requested* — the event
+    issue #13 names — while every other submission is a session starting. Both
+    are `task.created`, so the fork lives in `classify` rather than in a second
+    writer nobody would remember to call.
+    """
+    assert event_types.classify("task.created", {"state": "awaiting_approval"}) == (
+        event_types.DECISION_REQUESTED, event_types.ENTITY_KIND_DECISION
+    )
+    assert event_types.classify("task.created", {"state": "queued"}) == (
+        event_types.SESSION_CREATED, event_types.ENTITY_KIND_SESSION
+    )
+    assert event_types.classify("task.created", {}) == (
+        event_types.SESSION_CREATED, event_types.ENTITY_KIND_SESSION
+    )
+    assert event_types.classify("auth.signed_in", {}) is None
+
+
+async def test_epics_issues_and_conversations_all_resolve_to_their_project(api) -> None:
+    """Every deliverable entity type must have a working project derivation.
+
+    A type whose `CASE` arm was wrong or missing would yield NULL and be dropped
+    by the fail-closed guard — invisibly, and only for that entity type.
+    """
+    async with api.factory() as s:
+        epic = await store.create_epic(
+            s, project_id="p1", title="E", description=None, status=None,
+            actor_user_id="alice", actor_email=None,
+        )
+    async with api.factory() as s:
+        issue = await store.create_issue(
+            s, project_id="p1", epic_id=None, title="I", description=None, status=None,
+            priority=None, labels=None, assignee_user_id=None, assignee_email=None,
+            dependencies=None, blocked_reason=None, actor_user_id="alice", actor_email=None,
+        )
+
+    body = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()
+    kinds = {item["entity"]["kind"]: item["projectId"] for item in body["items"]}
+
+    assert kinds.get("epic") == "p1"
+    assert kinds.get("issue") == "p1"
+    assert {item["entity"]["id"] for item in body["items"]} >= {epic.id, issue.id}
+
+
+def test_the_poll_interval_is_floored_rather_than_honoured() -> None:
+    """A zero interval is a busy loop against the pool every endpoint shares."""
+    from gateway.app.core.config import Settings
+
+    assert Settings(event_stream_poll_interval_seconds=0).effective_event_stream_poll_interval() > 0
+    assert Settings(event_stream_poll_interval_seconds=-5).effective_event_stream_poll_interval() > 0
+    assert Settings(event_stream_batch_limit=0).effective_event_stream_batch_limit() >= 1
+    assert Settings(event_stream_batch_limit=100000).effective_event_stream_batch_limit() <= 500

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -36,9 +36,11 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from gateway.app.api.errors import ApiError
 from gateway.app.api.routes import events as events_routes
 from gateway.app.api.routes import notifications as notifications_routes
 from gateway.app.api.setup import install_api_conventions
+from gateway.app.core.users import AuthenticatedPrincipal
 from gateway.app.db.base import Base
 from gateway.app.db.session import get_session
 from gateway.app.services import event_types, store
@@ -291,6 +293,13 @@ async def run_stream(factory, *, token: str, resume_from: int = 0, polls: int = 
     return parse_frames(frames)
 
 
+def redact_for_test(value: str | None) -> str | None:
+    """The real redactor, imported through the route module the code injects."""
+    from gateway.app.api.routes.sessions import redact
+
+    return redact(value)
+
+
 def entity_frames(frames: list[dict]) -> list[dict]:
     """Only the frames that carry an event — control frames and heartbeats out."""
     return [f for f in frames if "id" in f]
@@ -501,7 +510,7 @@ async def test_reading_events_requires_the_read_scope(api) -> None:
 
 
 async def test_no_stored_payload_key_is_passed_through_to_a_client(api) -> None:
-    """The audit payload is written by eleven call sites and is not a response.
+    """The audit payload is written by thirty-one call sites and is not a response.
 
     It carries `actor_email`, `requested_by_email` and free-text `context`
     blobs. A translation that spread the payload into the event — or that
@@ -553,7 +562,202 @@ async def test_free_text_in_a_summary_is_redacted_and_bounded(api) -> None:
     summary = body["items"][-1]["summary"]
 
     assert "sk-abcdefghijklmnop" not in summary
-    assert len(summary) < 400, "a notification line must not be an unbounded traceback"
+    # The contract publishes `MobileEvent.summary` as `maxLength: 300`, so that
+    # is the number to assert. The first cut said 400, which would have let a
+    # regression past the contract without failing (council round 1, a recorded
+    # question from the claim auditor).
+    assert len(summary) <= 300, "a notification line must not be an unbounded traceback"
+
+    # Asserted across every emitted type, not just this one: the bound belongs
+    # to the contract, and one type's builder is not evidence about the others.
+    for mobile_type in event_types.EMITTED_EVENT_TYPES:
+        built = event_types.summarize(
+            mobile_type,
+            {"error": "e" * 5000, "reason": "r" * 5000, "state": "running", "control": "pause"},
+            redact_for_test,
+        )
+        assert len(built) <= 300, f"{mobile_type} can exceed the contract's maxLength"
+
+
+
+async def test_an_executors_control_and_state_strings_cannot_reach_a_notification_line(api) -> None:
+    """Council round 1, the adversarial user — the whitelist's premise was false.
+
+    `_ENUM_KEYS` admitted `control` and `state` on the stated grounds that their
+    values "are server-generated enums rather than free text". They are not:
+    `gateway/app/main.py` reads both straight out of an executor's `task.ack`
+    frame with no validation, and the `invalid_state` branch records the very
+    string it just refused *because* it is not a `TaskState`. A connected
+    executor could therefore put a filesystem path, an internal `host:port`, a
+    `Bearer` value and a 200 KB blob into a mobile notification line, past every
+    guard in `event_types.py`.
+
+    Membership in a closed vocabulary is the fix, not redaction: `redact` strips
+    the patterns it knows, while a closed set admits only values this system
+    defines — whatever the rejected one contains, and however long it is.
+    """
+    task = await make_task(api.factory, "p1")
+    hostile = (
+        "/etc/codex-bridge/users.json on db.internal 10.0.0.7:5432 "
+        "Authorization: Bearer abc123 sk-SECRETSECRETSECRET " + ("x" * 5000)
+    )
+    await emit(
+        api.factory, "task", task.id, "task.control_acknowledged",
+        {"accepted": False, "control": hostile, "state": hostile},
+    )
+    await emit(
+        api.factory, "task", task.id, "task.ack_refused",
+        {"reason": "invalid_state", "state": hostile},
+    )
+
+    body = api.get("/api/v1/events", headers=auth(ALICE_TOKEN)).json()
+    serialized = json.dumps(body)
+
+    for secret in ("/etc/codex-bridge", "db.internal", "10.0.0.7:5432", "Bearer abc123", "sk-SECRET"):
+        assert secret not in serialized, f"{secret!r} reached a mobile client"
+    assert "xxxx" not in serialized
+
+    acknowledged = next(i for i in body["items"] if i["type"] == "session.control_acknowledged")
+    assert acknowledged["summary"] == "The executor refused a control."
+    assert "state" not in acknowledged, (
+        "a state outside TaskState is omitted, not echoed: a client switches on this enum"
+    )
+
+
+def test_every_echoed_payload_value_comes_from_a_closed_vocabulary() -> None:
+    """The guard behind the test above, asserted directly.
+
+    Two properties. Every key `_enum` will answer for has a vocabulary — so a
+    key added to a summary builder without one silently yields the default
+    rather than echoing. And the guard is not an `assert`: `python -O` strips
+    those, and a defence that vanishes under an interpreter flag is not one.
+    """
+    for key, allowed in event_types._ENUM_VOCABULARIES.items():
+        assert allowed, f"{key} has an empty vocabulary"
+        assert all(isinstance(value, str) and value for value in allowed)
+        assert event_types._enum({key: "definitely-not-a-member"}, key) == "unknown"
+        assert event_types._enum({key: next(iter(allowed))}, key) == next(iter(allowed))
+
+    # An unknown key falls back rather than raising, and does so with -O too.
+    assert event_types._enum({"nope": "value"}, "nope") == "unknown"
+    assert event_types.state_of({"state": "not-a-state"}) is None
+    assert event_types.state_of({"state": "running"}) == "running"
+
+
+async def test_the_gap_signal_cannot_report_on_events_the_caller_may_not_see(api) -> None:
+    """Council round 1 — the `gap` block was a one-bit oracle over the whole log.
+
+    `audit_cursor_status` and `oldest_audit_event_id` queried `audit_events`
+    unscoped while the page beside them was correctly scoped. A project-limited
+    token could therefore poll `?after=<newest+1>`, watch `gap` disappear the
+    instant *any* row was written anywhere — an operator's sign-in, a
+    revocation, another tenant's task — and binary-search `?after=` for the
+    global newest id, with `items` empty throughout. Every one of those is an
+    event this surface excludes by construction.
+    """
+    await make_task(api.factory, "p1")
+    ahead = await newest_audit_id(api.factory) + 1
+
+    before = api.get(f"/api/v1/events?after={ahead}", headers=auth(ALICE_TOKEN)).json()
+    assert before["gap"]["reason"] == store.CURSOR_AHEAD
+
+    # Three rows alice may never see: two auth, one another project's.
+    async with api.factory() as s:
+        await store.record_auth_event(
+            s, user_id="admin", event_type="auth.signed_in", payload={"reason": "password"}
+        )
+    await make_task(api.factory, "p2")
+
+    after = api.get(f"/api/v1/events?after={ahead}", headers=auth(ALICE_TOKEN)).json()
+    assert after["items"] == []
+    assert after["gap"] == before["gap"], (
+        "the gap signal moved because of rows the caller may not see — an oracle "
+        "over the audit log, including sign-in activity"
+    )
+
+    # And it still moves for a row alice *may* see, or the signal would be inert.
+    await make_task(api.factory, "p1")
+    visible = api.get(f"/api/v1/events?after={ahead}", headers=auth(ALICE_TOKEN)).json()
+    assert visible["items"], "precondition: the new row is one alice can see"
+
+
+async def test_the_oldest_available_id_is_the_callers_own_oldest(api) -> None:
+    """`oldestAvailableId` returned the global minimum audit id to any reader.
+
+    A client that fell behind needs somewhere to restart from — its own feed's
+    oldest position, not the first row the gateway ever wrote for anyone.
+    """
+    async with api.factory() as s:
+        await store.record_auth_event(
+            s, user_id="admin", event_type="auth.signed_in", payload={"reason": "password"}
+        )
+    await make_task(api.factory, "p2")
+    p1_task = await make_task(api.factory, "p1")
+
+    async with api.factory() as s:
+        p1_first = (await store.list_mobile_events_page(
+            s, project_ids=["p1"],
+            entity_types=sorted(event_types.DELIVERABLE_ENTITY_TYPES),
+            audit_event_types=sorted(event_types.TRANSLATED_AUDIT_EVENT_TYPES),
+            after=None, limit=5,
+        ))[0][0].id
+
+    body = api.get(f"/api/v1/events?after={p1_first + 10_000}", headers=auth(ALICE_TOKEN)).json()
+
+    assert body["gap"]["oldestAvailableId"] == p1_first
+    assert body["gap"]["oldestAvailableId"] != 1, (
+        "the global minimum belongs to an auth row alice may not know exists"
+    )
+    assert p1_task is not None
+
+
+async def test_a_resume_position_beyond_the_id_range_is_refused_not_a_500(api) -> None:
+    """Council round 1 — `?after=2**63+1` was an authenticated 500.
+
+    `ge=0` bounded the low end only, and the value went straight into the query,
+    where the driver raised `OverflowError` and the caller got
+    `500 internal_error`. An unbounded integer parameter is unbounded in both
+    directions.
+    """
+    response = api.get(f"/api/v1/events?after={2**63 + 1}", headers=auth(ALICE_TOKEN))
+
+    # 422 rather than 400: this is FastAPI's own parameter validation, and
+    # `errors.py` maps it to the same `validation_failed` envelope every other
+    # endpoint's bad parameter produces. What matters is that it is the caller's
+    # error and not an unhandled `OverflowError` reported as `internal_error`.
+    assert response.status_code == 422
+    assert response.json()["code"] == "validation_failed"
+
+    stream = api.get(f"/api/v1/events/stream?after={2**63 + 1}", headers=auth(ALICE_TOKEN))
+    assert stream.status_code == 422, (
+        "refused before the body commits to 200 text/event-stream, where no "
+        "status code is left to change"
+    )
+    assert events_routes.stream_slots.active == 0, "a refused stream must not hold a slot"
+
+
+async def test_an_out_of_range_last_event_id_is_clamped_not_replayed(api) -> None:
+    """The same overflow on the stream, where a 500 is not even available.
+
+    Once the body has committed to `200 text/event-stream` there is no status
+    code left to change: the unbounded version emitted `stream.open` and then
+    the generator died inside the cursor check, so the body simply ended — no
+    `stream.gap`, no `stream.closed`, indistinguishable from a quiet feed.
+
+    Clamped rather than discarded: discarding would fall back to `after`, or to
+    0, and replay the entire feed to a client that asked to *resume*.
+    """
+    assert events_routes._resume_from(str(2**63 + 5), None) == events_routes.MAX_EVENT_ID
+    assert events_routes._resume_from(None, 2**70) == events_routes.MAX_EVENT_ID
+
+    await make_task(api.factory, "p1")
+    frames = await run_stream(
+        api.factory, token=ALICE_TOKEN, resume_from=events_routes.MAX_EVENT_ID, polls=1
+    )
+
+    assert [f.get("event") for f in frames].count(event_types.STREAM_GAP) == 1
+    assert frames[-1]["event"] == event_types.STREAM_CLOSED
+    assert entity_frames(frames) == [], "a clamped position must not replay the feed"
 
 
 def test_every_emitted_event_type_has_a_summary_builder() -> None:
@@ -983,6 +1187,39 @@ async def test_a_newline_in_stored_text_cannot_split_one_frame_into_two(api) -> 
     assert raw.count("\n\n") == 1 and raw.endswith("\n\n")
     assert len(raw.strip().split("\n")) == 3, "id, event and exactly one data line"
 
+    # `\r` too. SSE terminates a line on CR, LF *or* CRLF, so a test that only
+    # covers `\n` leaves the other half of the line protocol unasserted.
+    carriage = events_routes._frame(
+        event="x", data={"summary": "a\rid: 999\revent: forged"}, event_id=1
+    )
+    assert "\r" not in carriage
+    assert len(carriage.strip().split("\n")) == 3
+
+    # And the mechanism is `json.dumps` escaping CR and LF, which it does
+    # whatever `ensure_ascii` says. The comment on `_frame` used to credit
+    # `ensure_ascii` with frame integrity, which would tell a reader that
+    # turning it off breaks a security property (council round 1, the claim
+    # auditor). For the SSE line terminators it does not:
+    hostile = "a\r\nid: 999\revent: forged"
+    for ensure_ascii in (True, False):
+        dumped = json.dumps({"summary": hostile}, ensure_ascii=ensure_ascii)
+        assert "\n" not in dumped and "\r" not in dumped, (
+            f"CR/LF escaping is not conditional on ensure_ascii={ensure_ascii}"
+        )
+
+    # `ensure_ascii` is not decorative either, and the difference is worth
+    # pinning so nobody "simplifies" it away: with it off, Python leaves U+2028
+    # and U+2029 raw. Neither is an SSE line terminator - the frame survives -
+    # but they are JavaScript line terminators, so a client that evaluates a
+    # payload instead of parsing it would see a different program. Keeping the
+    # body pure ASCII costs nothing and removes the question.
+    separator = "before\u2028after"
+    assert "\u2028" in json.dumps(separator, ensure_ascii=False)
+    assert "\u2028" not in json.dumps(separator, ensure_ascii=True)
+    assert "\u2028" not in events_routes._frame(
+        event="x", data={"summary": separator}, event_id=1
+    )
+
 
 async def test_a_stream_type_filter_narrows_delivery_without_stalling_the_cursor(api) -> None:
     task = await make_task(api.factory, "p1")
@@ -1017,25 +1254,131 @@ async def test_the_slot_ceiling_refuses_rather_than_degrading_the_shared_pool(ap
 async def test_a_finished_stream_gives_its_slot_back(api) -> None:
     """A slot that is not returned is gone for good, and the ceiling ratchets down.
 
-    Both release paths are exercised: the generator's `finally` here, and — for
-    a connection that dies before the body ever starts — the response's
-    background task, which is why `StreamSlot.release` is idempotent.
+    This is the generator's `finally` path. The other release path — the
+    response's background task, for a connection that dies before the body ever
+    starts — is
+    `test_a_connection_that_dies_before_the_body_starts_still_returns_its_slot`.
     """
     slots = events_routes.StreamSlots(2)
-    slot = slots.acquire()
+    slot = slots.acquire("alice")
     assert slots.active == 1
     slot.release()
     slot.release()
     assert slots.active == 0, "a double release must not push the counter below zero"
+    assert slots.active_for("alice") == 0
 
     async for _ in events_routes.event_stream(
         factory=api.factory, token=ALICE_TOKEN, resume_from=0,
         requested_projects=None, requested_types=[], poll_interval=0.0,
         heartbeat_seconds=1e9, max_duration_seconds=0.0, batch_limit=10,
-        on_close=slots.acquire().release, monotonic=FakeClock(), sleep=stepping_sleep(FakeClock()),
+        on_close=slots.acquire("alice").release,
+        monotonic=FakeClock(), sleep=stepping_sleep(FakeClock()),
     ):
         pass
     assert slots.active == 0
+
+
+async def test_a_connection_that_dies_before_the_body_starts_still_returns_its_slot(api) -> None:
+    """The release path the generator's `finally` cannot reach — council round 1.
+
+    `stream_events` takes the slot, then hands back a `StreamingResponse` whose
+    body is an async generator. An async generator that is never iterated has no
+    `finally` to run, so if the connection dies between the route returning and
+    the first `__anext__`, the `finally` never fires and the slot is leaked
+    permanently — the ceiling ratchets down until the endpoint answers 503
+    forever. `background=BackgroundTask(slot.release)` is what covers it, and the
+    claim auditor found that nothing in the suite touched that path: deleting
+    the argument left all 600 tests green.
+
+    Driven at the route, not through a client, because the failure is precisely
+    "the body was never started" and a test client always starts it.
+    """
+    slots = events_routes.StreamSlots(2)
+    events_routes.stream_slots = slots
+
+    class _Request:
+        headers = {"Authorization": f"Bearer {ALICE_TOKEN}"}
+
+        async def is_disconnected(self):
+            return True
+
+    principal = AuthenticatedPrincipal(
+        user_id="alice", email="alice@example.com", roles=[], allowed_projects=["p1"],
+        scopes=["codexbridge.read"], can_approve_sensitive=False, auth_scheme="oauth",
+    )
+    response = await events_routes.stream_events(
+        request=_Request(), after=None, project=None, type=None,
+        last_event_id=None, principal=principal,
+    )
+
+    assert slots.active == 1, "the route holds the slot while the response is in flight"
+    # The connection dies here: the body is never iterated, so the generator
+    # never starts and its `finally` never runs. Starlette runs the background
+    # task once the response is done either way.
+    await response.background()
+    assert slots.active == 0, (
+        "a connection dropped before the body started leaked its slot forever"
+    )
+    assert slots.active_for("alice") == 0
+
+
+async def test_one_account_cannot_take_every_stream_slot(api) -> None:
+    """A global ceiling is not a share — council round 1, the adversarial user.
+
+    Without a per-actor ceiling, one read-only token holding every slot answers
+    `503` to every other principal, an administrator included, for as long as it
+    keeps its connections (up to `event_stream_max_duration_seconds`, 15
+    minutes). The process ceiling protects the gateway; this protects everyone
+    else from whoever got there first.
+    """
+    slots = events_routes.StreamSlots(4, per_actor=2)
+
+    held = [slots.acquire("alice"), slots.acquire("alice")]
+    assert slots.active_for("alice") == 2
+
+    with pytest.raises(ApiError) as refused:
+        slots.acquire("alice")
+    assert refused.value.status_code == 503
+    assert refused.value.headers["Retry-After"] == "5"
+
+    # The process still has room, and it is room somebody else can use.
+    other = slots.acquire("bob")
+    assert slots.active == 3
+
+    held[0].release()
+    assert slots.acquire("alice") is not None, "releasing frees the actor's own share"
+    other.release()
+
+
+def test_the_per_actor_ceiling_can_never_exceed_the_process_ceiling() -> None:
+    """A per-actor ceiling above the global one reads as a share and is not one."""
+    assert events_routes.StreamSlots(4, per_actor=99).per_actor == 4
+    assert events_routes.StreamSlots(4).per_actor == 4
+
+
+def test_the_stream_ceiling_fits_inside_the_connection_pool() -> None:
+    """32 streams against a 15-connection pool is the incident `probes.py` records.
+
+    Each poll of each open stream takes a session from the pool every other
+    endpoint shares. A ceiling above the pool's own capacity means a slow poll
+    exhausts it, real requests block for `pool_timeout`, and the resulting
+    TimeoutError is reported as `database: unavailable` — the gateway asks to be
+    pulled from rotation and blames the database. Council round 1, the second
+    caller, measured the pool at 15 while this ceiling was 32.
+    """
+    from sqlalchemy.pool import QueuePool
+
+    from gateway.app.core.config import settings
+    from gateway.app.db.session import engine
+
+    pool = engine.pool
+    if not isinstance(pool, QueuePool):  # pragma: no cover - sqlite in some setups
+        pytest.skip("engine is not pooled in this configuration")
+    capacity = pool.size() + pool._max_overflow
+    assert settings.event_stream_max_concurrent <= capacity, (
+        f"{settings.event_stream_max_concurrent} concurrent streams against a "
+        f"{capacity}-connection pool; raising one means raising the other"
+    )
 
 
 # --------------------------------------------------------------------------
@@ -1244,6 +1587,85 @@ def test_the_manage_scope_is_one_a_signed_in_client_can_actually_be_granted() ->
     assert permissions.NOTIFICATIONS_READ.scope in granted
 
 
+def test_the_env_template_can_grant_every_scope_the_catalogue_needs() -> None:
+    """The allowlist has two sources, and production reads the one nobody edits.
+
+    Council round 1, the second caller: `CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES` in
+    `.env.example` **replaces** `Settings.oauth_default_scopes` wholesale rather
+    than merging, and `docs/installation.md` tells the operator to build
+    `/etc/codex-bridge/env` from that template. Issues #8, #10 and #13 each added
+    a scope to `config.py` and not to the template, so a deployment built the
+    documented way had `issues.write`, `conversations.write` and
+    `notifications.manage` permanently ungrantable — `403` for every non-admin,
+    however `users.json` was edited.
+
+    The sibling test above pinned this against `settings.oauth_scopes()`, which
+    is the code default — the source production overrides. It therefore passed
+    while the endpoint was unreachable. This one reads the template.
+
+    `codexbridge.task.approve` is exempt and named as such: withholding it from
+    the deployment default is a deliberate operator decision, not drift.
+    """
+    from gateway.app.api import permissions
+
+    template = (REPO_ROOT / ".env.example").read_text(encoding="utf-8")
+    line = next(
+        (row for row in template.splitlines() if row.startswith("CODEX_BRIDGE_OAUTH_DEFAULT_SCOPES=")),
+        None,
+    )
+    assert line is not None, ".env.example no longer sets the scope allowlist"
+    templated = set(line.partition("=")[2].split())
+
+    deliberately_withheld = {permissions.APPROVE_SCOPE}
+    needed = {
+        action.scope
+        for action in permissions.CATALOGUE
+        if action.scope not in {permissions.ADMIN_SCOPE} | deliberately_withheld
+    }
+    missing = sorted(needed - templated)
+    assert not missing, (
+        f".env.example cannot grant {missing}; a deployment built from the template "
+        "answers 403 for every non-admin on the endpoints those scopes guard"
+    )
+
+
+async def test_a_rejected_subscription_list_cannot_amplify_the_response(api) -> None:
+    """Council round 1 — the count was bounded, the bytes were not.
+
+    `MAX_SUBSCRIBED_TYPES` capped the list at 64 entries, and `put_preferences`
+    then quoted every rejected value back at full length in `details[]`: 64
+    strings of 100,000 characters turned a 6.4 MB request into a 6.4 MB error
+    response. A bound on how many items there are is not a bound on how much
+    data they carry.
+    """
+    payload = {"eventTypes": ["z" * 100_000] * 64, "pushEnabled": False}
+    response = api.put("/api/v1/notifications/preferences", headers=auth(ALICE_TOKEN), json=payload)
+
+    assert response.status_code == 422, "an over-long value is refused by the model"
+    assert len(response.content) < 100_000, (
+        f"the error envelope was {len(response.content)} bytes for a rejected request"
+    )
+
+    # And a *plausible* mistake still tells the client what it got wrong.
+    readable = api.put(
+        "/api/v1/notifications/preferences",
+        headers=auth(ALICE_TOKEN),
+        json={"eventTypes": ["session.completedd"], "pushEnabled": False},
+    )
+    assert readable.status_code == 400
+    assert "session.completedd" in readable.json()["details"][0]["message"]
+
+
+async def test_a_rejected_type_filter_cannot_amplify_the_response(api) -> None:
+    """The same reflection on the query side, where the URL is the only limit."""
+    query = "&".join(f"type={'q' * 200}{index}" for index in range(200))
+    response = api.get(f"/api/v1/events?{query}", headers=auth(ALICE_TOKEN))
+
+    assert response.status_code == 400
+    assert len(response.json()["details"]) <= events_routes.MAX_ECHOED_DETAILS
+    assert len(response.content) < 10_000
+
+
 async def test_a_stored_type_that_no_longer_exists_is_dropped_on_the_way_out(api) -> None:
     """A stored preference can outlive the type it names.
 
@@ -1358,6 +1780,27 @@ async def test_epics_issues_and_conversations_all_resolve_to_their_project(api) 
     assert kinds.get("epic") == "p1"
     assert kinds.get("issue") == "p1"
     assert {item["entity"]["id"] for item in body["items"]} >= {epic.id, issue.id}
+
+
+def test_the_audit_index_exists_on_a_fresh_install_as_well_as_an_upgraded_one() -> None:
+    """An index declared only in SQL is missing on every new database.
+
+    `main.py` bootstraps a new database with `Base.metadata.create_all`, which
+    knows nothing about `migrations/`. An upgraded deployment runs 0009 and gets
+    the index; a fresh one never would — and that is the harder half to notice,
+    because nobody skipped a migration (council round 1, the second caller).
+    Both halves are needed: `create_all(checkfirst=True)` will not add an index
+    to a table that already exists, so the migration cannot be dropped either.
+    """
+    from gateway.app.models.entities import AuditEventModel
+
+    name = "audit_events_entity_type_id_idx"
+    declared = {index.name: index for index in AuditEventModel.__table__.indexes}
+    assert name in declared, "a fresh install would not get the index"
+    assert [column.name for column in declared[name].columns] == ["entity_type", "id"]
+
+    migration = (REPO_ROOT / "migrations" / "0009_event_subscriptions.sql").read_text(encoding="utf-8")
+    assert name in migration, "an existing deployment would not get the index"
 
 
 def test_the_poll_interval_is_floored_rather_than_honoured() -> None:

--- a/tests/integration/test_events.py
+++ b/tests/integration/test_events.py
@@ -1356,6 +1356,25 @@ def test_the_per_actor_ceiling_can_never_exceed_the_process_ceiling() -> None:
     assert events_routes.StreamSlots(4).per_actor == 4
 
 
+def test_the_module_level_slots_carry_the_configured_per_actor_ceiling() -> None:
+    """The ceiling the deployment actually uses is wired from settings.
+
+    Council round 2, the claim auditor: `StreamSlots` is tested in isolation and
+    the `api` fixture replaces the module-level object with one built from
+    `limit` alone, so no route test observes the real ceiling. Dropping
+    `settings.event_stream_max_per_actor` from the construction at
+    `events.py` would leave `per_actor` defaulting to `limit` (8) and every route
+    test green. This pins the wiring: the object the request handler holds carries
+    the configured per-actor value (2), not the process ceiling.
+    """
+    from gateway.app.core.config import settings
+
+    assert events_routes.stream_slots.per_actor == settings.event_stream_max_per_actor
+    assert settings.event_stream_max_per_actor < settings.event_stream_max_concurrent, (
+        "if these were equal the wiring test could not distinguish a dropped argument"
+    )
+
+
 def test_the_stream_ceiling_fits_inside_the_connection_pool() -> None:
     """32 streams against a 15-connection pool is the incident `probes.py` records.
 

--- a/tests/unit/test_apply_migrations.py
+++ b/tests/unit/test_apply_migrations.py
@@ -73,6 +73,21 @@ def legacy_db(tmp_path: Path) -> Path:
         "  ('code-old', 'chatgpt-codexbridge', 'https://chatgpt.com/cb', 'esteban',"
         "   'e@example.com', '[]', 'chal', 'S256', '2099-01-01 00:00:00', null,"
         "   '2026-01-01 00:00:00');"
+        # 0001 created this and 0009 indexes it. Every migration after the
+        # adoption point runs against whatever `--mark-applied 0001_init.sql`
+        # says is already there, so a table a later migration touches has to be
+        # in this fixture or the runner is being tested against a schema no
+        # adopted deployment has — the same reason the two OAuth tables above
+        # are here. No row: 0009 adds an index, and what an index does to
+        # existing data is nothing.
+        "create table audit_events ("
+        "  id integer primary key autoincrement,"
+        "  entity_type varchar(64) not null,"
+        "  entity_id varchar(128) not null,"
+        "  event_type varchar(128) not null,"
+        "  payload_json text not null,"
+        "  created_at timestamp with time zone not null"
+        ");"
     )
     connection.commit()
     connection.close()


### PR DESCRIPTION
Implements issue #13: a near-real-time mobile event stream + notification-subscription preferences. Contract **1.8.0** (`probes.API_CONTRACT_VERSION` matched).

## Transport & shape

- **SSE** (`GET /api/v1/events/stream`) chosen over WebSocket: it rides the existing bearer auth on a GET and has native `Last-Event-ID` reconnect. Polling/backlog fallback: `GET /api/v1/events`.
- Events are projected from `audit_events` (monotonic `id` = resume cursor). Auth/security events excluded; a project-scoped principal sees only its own projects' events (fail-closed on an underivable project); payloads pass a **closed vocabulary**, never raw `payload_json`. Resume from an id older than retention returns a typed `stream.gap` (no silent loss).
- Notification preferences: `GET`/`PUT /api/v1/notifications/preferences` (migration `0009`). New permissions `events.read`, `notifications.manage` reported by `/auth/me`.

## Council (two rounds, recorded in `docs/issues/013-.../RESUME.md` + napkin)

- R1 (claim auditor / second caller / adversarial user): **11 raised / 11 survived §2 / 11 became tests / 0 questions**. Closed a payload-whitelist leak (executor-controlled `control`/`state` reaching a mobile line), a gap-signal oracle over the whole audit log, and unbounded-input 500s / slot exhaustion.
- R2: **7 raised / 7 survived §2 / 1 became test / 2 questions**. Mutation-proved 6 of 7 R1 fixes genuinely pinned; **cross-project isolation, token-expiry/revocation ending the stream within one poll, and resume with no off-by-one confirmed closed**. Closed here: the per-actor slot ceiling had no test against the wired object (pinned now). Findings 2–7 (slot arithmetic/503-fallback; gap doc semantics; unguarded `actorId` [not reproduced]; `redact` pattern-list limit; quiet-project O(n) rescan; malformed `Last-Event-ID` replay) are recorded for the **operator** per `.docs/agents/council.md` §4 — none is a live security regression.

## Checks

Full suite **618 passed, 3 skipped** (project `.venv`; system python can't collect `tests/contract` — pre-existing `iter_route_contexts` ImportError). Every new test verified failing first.

Not validated: Postgres; any deployment; multi-worker uvicorn; nginx buffering of a long-lived SSE connection; push delivery (preferences are future hooks). Migration `0009` NOT applied. Contract 1.8.0 — re-bump on merge order if #11 (1.7.0) lands first; run `scripts/publish_contract.py` after merge (#14 gate).

Do not merge / do not close #13 — operator merges and closes.
