### PR TITLE
feat(gh-73): control-plane domain — nodes, bindings, SCM associations, authorization (Stage 1)

### DIFF
--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,17 +1,16 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-08-30 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge map`
+> Generated: 2026-09-01 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control map`
 
 ## Summary
 
-- 125 file(s) · 1159 symbol(s) indexed
-- Languages: config (2), python (121), shell (2)
+- 126 file(s) · 1181 symbol(s) indexed
+- Languages: config (2), python (122), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
 
-- `AGENTS.md`
 - `docs/required-reading.md`
 - `docs/project-rules.md`
 - `docs/software-overview.md`
@@ -157,6 +156,7 @@ tests/
     test_agent_auto_project.py  — "`agent.codex_bridge_agent.config.resolve_auto_project` -- the opt-in"
     test_agent_service.py
     test_apply_migrations.py  — "The migration runner, exercised against real throwaway databases."
+    test_capability_vocabulary.py  — "The capability vocabulary issue #73's authorization plane is built on."
     test_claude_runner.py  — "ClaudeRunner's pure logic: command assembly, NDJSON extraction, sandbox mapping."
     test_codex_runner.py  — "CodexRunner's pause/resume/restart/cancel state machine — issue #16 council."
     test_config_settings.py  — "issue #17 council round 1, "the second caller": `cancel_replay_max_age_seconds`"
@@ -607,6 +607,11 @@ tests/
 ### `gateway/app/models/entities.py`
 
 - **`ExecutorModel`** *(class)*
+- **`NodeModel`** *(class)* — "A registered CodexBridge installation — issue #73's Bridge Node."
+- **`WorkspaceBindingModel`** *(class)* — "A logical Project as it exists on one Node's disk (issue #73)."
+- **`ScmAssociationModel`** *(class)* — "Project <-> source-control repository, as an association rather than an"
+- **`ProjectAuthorizationModel`** *(class)* — "What a node may actually do to a project (issue #73's authorization plane)."
+- **`DiscoveredResourceModel`** *(class)* — "Something a node can see that Control has not necessarily adopted."
 - **`ProjectModel`** *(class)*
 - **`TaskModel`** *(class)*
 - **`EpicModel`** *(class)*
@@ -805,11 +810,17 @@ tests/
 
 - **`AgentEngine`** *(class)* — "Which development-agent CLI runs a task's instruction."
 - **`TaskMode`** *(class)*
+- **`Capability`** *(class)* — "What a node is authorized to do to a project, per issue #73."
+- `capabilities_to_modes(capabilities)` — "The task modes a capability set permits. Unknown values are ignored."
 - **`TaskState`** *(class)*
 - **`PolicyLevel`** *(class)*
 - **`TaskPriority`** *(class)*
 - **`AgentMessageType`** *(class)*
 - **`ApprovalDecision`** *(class)*
+- **`DiscoveredState`** *(class)* — "Lifecycle of something a node can see, per issue #73."
+- **`BindingState`** *(class)* — "Whether a Project-on-a-Node workspace is usable right now."
+- **`NodeHealth`** *(class)* — "A Bridge Node's operational condition, derived at read time."
+- **`DiscoveryRoot`** *(class)* — "One directory tree a node is configured to scan, and what that grants."
 - **`ProjectRegistration`** *(class)*
 - **`ExecutorRegistration`** *(class)*
 - **`DeliveryRequest`** *(class)* — "What the requester authorized the executor to do with git, once a task"
@@ -1566,6 +1577,22 @@ tests/
 - `test_dry_run_changes_nothing(legacy_db)`
 - `test_unknown_migration_name_is_refused(legacy_db)`
 - `test_engine_and_delivery_columns_default_existing_rows_to_codex(legacy_db)` — "0008: an existing row must read back as what it always was -- a plain"
+- `test_control_plane_seeds_one_node_per_existing_executor(legacy_db)` — "0009: an existing deployment must come up with its fleet already"
+- `test_control_plane_grants_nothing_by_existing_alone(legacy_db)` — "0009 must create the authorization plane EMPTY."
+- `test_control_plane_refuses_a_database_without_executors_before_touching_it(tmp_path)` — "A wrong database must be left untouched, not half-migrated."
+
+### `tests/unit/test_capability_vocabulary.py`
+
+> The capability vocabulary issue #73's authorization plane is built on.
+
+- `test_every_task_mode_is_reachable_through_some_capability()` — "A mode no capability grants is a mode no authorization can ever permit."
+- `test_read_grants_no_mode_that_can_modify_a_file()` — "The load-bearing claim of the whole read-only tier."
+- `test_deliver_grants_no_mode()` — "Delivery is not a mode, and must not become one by accident."
+- `test_an_unknown_capability_grants_nothing()` — "Forward compatibility must narrow, never widen."
+- `test_a_discovery_root_cannot_grant_write_capabilities()` — "#73: "A node cannot grant itself project authorization merely by"
+- `test_auto_authorizable_capabilities_never_reach_a_file()` — "Guards the constant itself, not just the validator that reads it."
+- `test_a_root_grants_nothing_unless_it_says_so()` — "Scanning a tree and authorizing it are different acts."
+- `test_the_five_discovered_states_are_all_distinct_values()` — "#73: "Do not collapse these into a single `enabled` boolean.""
 
 ### `tests/unit/test_claude_runner.py`
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -1,0 +1,126 @@
+# Plano de controle — nós, projetos, bindings e autorização
+
+Modelo de domínio da issue **#73** ("CodexBridge Control: fleet, nodes, project
+adoption and authorization plane"), Stage 1. Este arquivo descreve **o que as
+entidades significam e por que são separadas**. O protocolo pelo fio está em
+`docs/protocol.md`; as camadas de autorização em ordem de execução continuam em
+`docs/project-onboarding.md`.
+
+## As três regras da #73 que decidiram o formato
+
+Cada uma descarta a mudança menor que teria sido tentadora.
+
+**1. "A project MUST NOT be structurally owned by a node or by GitHub."**
+Por isso a relação Projeto↔máquina é uma tabela própria (`workspace_bindings`) e
+a relação Projeto↔repositório é outra (`scm_associations`). Uma coluna em
+`projects` teria privilegiado estruturalmente um nó e um remote — e tornaria
+inexprimível "o mesmo projeto no `frida` e no `devel3`, em caminhos diferentes",
+que é justamente o caso que a #73 desenha.
+
+**2. "Discovery is not authorization."**
+O que um nó **relata** cai em `discovered_resources`; o que ele **pode fazer**
+vive em `project_authorizations`. Duas tabelas porque são escritas por dois
+atores diferentes — o nó anuncia, o operador (ou uma concessão permanente de
+raiz) autoriza. Confundir as duas é exatamente a falha que a #73 nomeia:
+*"a node cannot grant itself project authorization merely by reporting a
+discovery."*
+
+**3. "Do not collapse these into a single `enabled` boolean."**
+`discovered_resources.state` carrega os cinco valores de
+`shared.protocol.DiscoveredState`. Cada par que alguém se sentiria tentado a
+fundir perde uma distinção real:
+
+| par fundido | o que se perde |
+|---|---|
+| `denied` + `discovered` | candidato recusado volta à fila de adoção a cada reconexão |
+| `stale` + ausência | projeto que mudou de lugar perde linha e histórico |
+| `adopted` + `authorized` | some a diferença entre "aceitei este projeto" e "concedi capacidade sobre ele" — que a #73 separa explicitamente |
+
+## Entidades
+
+| Tabela | O que é | O que **não** é |
+|---|---|---|
+| `nodes` | uma instalação CodexBridge (máquina + capacidades) | não é a conexão; não é o executor |
+| `executors` | a conexão autenticada que leva trabalho a um nó | não é a máquina |
+| `projects` | o projeto lógico | não é um diretório, não é um repositório |
+| `workspace_bindings` | o projeto **naquele** nó, no disco dele | não é autorização |
+| `scm_associations` | o projeto ↔ um repositório remoto | não é identidade do projeto |
+| `project_authorizations` | o que aquele nó pode fazer àquele projeto | não é "o workspace existe" |
+| `discovered_resources` | o que o nó vê, adotado ou não | não é permissão |
+
+`nodes` e `executors` são 1:1 hoje — `0009_control_plane.sql` semeia um nó por
+executor existente — e o schema não exige que continuem sendo. A separação existe
+porque a #73 alerta contra *"conflating `node`, `executor`, `engine` and
+`project` into one entity"*, e renomear o executor para nó teria feito a mesma
+confusão na direção oposta.
+
+## Capacidades
+
+O vocabulário (`shared.protocol.Capability`) é **derivado** de `TaskMode`, nunca
+paralelo a ele. `CAPABILITY_MODES` é o mapa inteiro, e `allowed_modes` segue
+sendo o único ponto de enforcement:
+
+| capacidade | modos |
+|---|---|
+| `read` | `analyze`, `review` |
+| `test` | `test` |
+| `modify` | `edit`, `implement` |
+| `deliver` | *(nenhum)* |
+
+`deliver` não mapeia modo porque entrega não é modo: é
+`SubmitTaskRequest.delivery`, gateada por `PUSHABLE_BRANCH_PATTERN` e pelo escopo
+`codexbridge.task.approve`. Está nomeada para que uma autorização possa
+**negá-la**, não para mover esse portão.
+
+Introduzir um segundo vocabulário de permissão independente seria o
+"parallel concepts" que a #73 desaconselha: exigiria enforcement próprio, testes
+próprios e teria drift próprio.
+
+## Raízes de descoberta e a concessão automática
+
+Um nó só varre as `discovery_roots` configuradas no seu registro — a #73 é
+explícita: *"No recursive whole-machine discovery by default."* Sem raiz
+configurada, nada é descoberto, que é o comportamento de hoje.
+
+`DiscoveryRoot.auto_authorize` é a concessão permanente e auditável do operador
+para tudo sob **uma** árvore. A decisão é tomada uma vez por árvore em vez de uma
+vez por projeto — é esse o atrito que este trabalho remove. Ela é limitada por
+`AUTO_AUTHORIZABLE_CAPABILITIES` a `read` e `test`, **validado no parse**, antes
+de qualquer nó conectar: `modify` e `deliver` nunca são obteníveis por anúncio,
+só por concessão explícita que nomeia uma pessoa (`granted_by` distingue
+`root-config:<path>` de `operator:<user_id>`).
+
+Uma raiz sem `auto_authorize` — o padrão — varre e enfileira candidatos para
+adoção, concedendo nada.
+
+## Caminho absoluto: dado operacional sensível
+
+`workspace_bindings.local_path` existe porque a #73 precisa dele para responder
+"esse workspace é usável?" e "onde este projeto roda?". Ela também limita onde
+ele pode aparecer: *"must only be returned to appropriately authorized operator
+surfaces; they must not leak through public/client contexts that do not need
+them."*
+
+Isso **reverte** o invariante que `docs/architecture.md` afirmava — o gateway
+passa a aprender o caminho. A contenção mudou de "o gateway nunca sabe" para "o
+gateway sabe e só conta a quem tem escopo de operador". Registrado aqui, e em
+`docs/threat-model.md`, porque uma reversão de invariante silenciosa é pior que a
+reversão.
+
+Nunca sai em `ProjectStatus`, `Session`, `Mission` nem em ferramenta MCP alguma —
+ver `docs/api/README.md`, "Fields that must never ship".
+
+## O que a 0009 deliberadamente **não** faz
+
+- **Não concede nada.** A tabela de autorização nasce vazia. Adotar o schema não
+  pode, por si, dar a nenhum nó capacidade sobre nenhum projeto — nem sobre os
+  projetos que ele já rodava, cujo acesso continua fluindo pelo
+  `allowed_projects` pré-existente. Uma migration que pré-preenchesse isso "para
+  preservar comportamento" estaria inventando concessões que ninguém fez.
+- **Não remove `projects.path`.** Ele deixa de ser autoritativo assim que
+  `workspace_bindings` é populado, mas removê-lo na mesma migration que cria seu
+  substituto destruiria a única cópia do caminho de qualquer projeto ausente do
+  `registry.json` atual. O backfill vive em `store.upsert_registry` (onde a
+  associação executor↔projeto de fato mora, dentro de `executors.metadata_json`)
+  e não é exprimível em SQL portável. A remoção é migration posterior, depois de
+  bindings verificados em produção.

--- a/docs/required-reading.md
+++ b/docs/required-reading.md
@@ -38,6 +38,9 @@ Documentos específicos deste repositório. Esta seção é 100% do projeto: nen
 a toca. Use `- (none)` se genuinamente não houver nenhum.
 
 - `docs/project-rules.md` — regras específicas deste projeto (também na tabela acima)
+- `docs/control-plane.md` — **obrigatório** ao tocar em nó, projeto lógico,
+  binding de workspace, associação SCM ou autorização (issue #73). Explica por que
+  essas entidades são separadas e o que se perde ao fundi-las.
 - `docs/napkin-lessons.md` — lições curtas; leia ao retomar trabalho relacionado
 
 ## Fontes locais — fora do checkout

--- a/gateway/app/db/schema_guard.py
+++ b/gateway/app/db/schema_guard.py
@@ -45,6 +45,13 @@ REQUIRED_TABLES: dict[str, str] = {
     "conversations": "0007_conversations.sql",
     "conversation_messages": "0007_conversations.sql",
     "conversation_read_states": "0007_conversations.sql",
+    # Issue #73's control plane. Registered as a block: the five arrived in one
+    # migration and a database missing any one of them is missing all of them.
+    "nodes": "0009_control_plane.sql",
+    "workspace_bindings": "0009_control_plane.sql",
+    "scm_associations": "0009_control_plane.sql",
+    "project_authorizations": "0009_control_plane.sql",
+    "discovered_resources": "0009_control_plane.sql",
 }
 
 REQUIRED_COLUMNS: dict[str, dict[str, str]] = {
@@ -62,6 +69,13 @@ REQUIRED_COLUMNS: dict[str, dict[str, str]] = {
     "oauth_access_tokens": {
         "revoked_at": "0003_mobile_auth.sql",
         "grant_id": "0003_mobile_auth.sql",
+    },
+    # Without this, a gateway upgraded past 0009 without running it would
+    # create `nodes` (a brand-new table `create_all` does add) while
+    # `executors` silently kept no `node_id` — so every node lookup would find
+    # a fleet of one project-less machines and report it as normal.
+    "executors": {
+        "node_id": "0009_control_plane.sql",
     },
 }
 

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -17,6 +17,162 @@ class ExecutorModel(Base):
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     connected: Mapped[bool] = mapped_column(Boolean, default=False)
     metadata_json: Mapped[str] = mapped_column(Text, default="{}")
+    # Which Bridge Node this connection belongs to (issue #73). Nullable so
+    # `0009_control_plane.sql`'s ALTER stays portable; every row is backfilled
+    # by that same migration, and the application treats a null as a pre-#73
+    # row to repair at startup rather than as "no node".
+    node_id: Mapped[str | None] = mapped_column(String(128), ForeignKey("nodes.id"), nullable=True)
+
+
+class NodeModel(Base):
+    """A registered CodexBridge installation — issue #73's Bridge Node.
+
+    Distinct from `ExecutorModel` on purpose. #73 warns against "conflating
+    `node`, `executor`, `engine` and `project` into one entity": the node is
+    the machine and its capabilities, the executor is the authenticated
+    connection that carries work to it. They are 1:1 today (seeded that way by
+    `0009_control_plane.sql`) and the schema does not require them to stay so.
+
+    `capabilities_observed_at` and `inventory_observed_at` exist because #42
+    requires last-known capabilities to be persisted "with freshness
+    timestamp" and stale data to be "visibly marked". Freshness is derived
+    from these at read time — the same posture `store.executor_is_live` takes
+    toward `ExecutorModel.connected`, and for the same reason: a stored
+    boolean survives a restart that invalidated it.
+    """
+
+    __tablename__ = "nodes"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    display_name: Mapped[str] = mapped_column(String(255))
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    os: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    arch: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    agent_version: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    capabilities_json: Mapped[str] = mapped_column(Text, default="{}")
+    capabilities_observed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    inventory_observed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    health_reason: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
+class WorkspaceBindingModel(Base):
+    """A logical Project as it exists on one Node's disk (issue #73).
+
+    This is what makes "the same project on two machines at two paths"
+    representable, which a column on `projects` could not be — #73: "A project
+    MUST NOT be structurally owned by a node or by GitHub."
+
+    `local_path` is sensitive operational data. #73 allows it only on
+    "appropriately authorized operator surfaces"; it must never reach
+    `ProjectStatus`, `Session`, `Mission` or any MCP tool
+    (`docs/api/README.md`, "Fields that must never ship").
+
+    `state` is the OBSERVED world (is this workspace usable right now), which
+    is not the same question as the operator's decision — that one lives in
+    `DiscoveredResourceModel.state`. Collapsing the two would lose the
+    difference between "I revoked this" and "the disk went away".
+    """
+
+    __tablename__ = "workspace_bindings"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    node_id: Mapped[str] = mapped_column(String(128), ForeignKey("nodes.id"))
+    project_id: Mapped[str] = mapped_column(String(128), ForeignKey("projects.id"))
+    local_path: Mapped[str] = mapped_column(String(2048))
+    head: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    dirty: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    state: Mapped[str] = mapped_column(String(32), default="active")
+    last_scan_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
+class ScmAssociationModel(Base):
+    """Project <-> source-control repository, as an association rather than an
+
+    attribute. #73 requires GitHub to be "an external project/repository
+    source and association, not the owner of the project model", and requires
+    a local project with no remote to be "represented honestly as
+    unassociated rather than rejected" — which a non-null column on `projects`
+    would make impossible.
+
+    `confidence` is the direct consequence of #73's "Do not silently infer a
+    trusted association only because directory and repository names happen to
+    match": an unconfirmed guess is recorded as `observed`, never as
+    `confirmed`, and only an operator moves it.
+    """
+
+    __tablename__ = "scm_associations"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    project_id: Mapped[str] = mapped_column(String(128), ForeignKey("projects.id"))
+    provider: Mapped[str] = mapped_column(String(32), default="github")
+    remote_url: Mapped[str] = mapped_column(String(2048))
+    repo_identity: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    confidence: Mapped[str] = mapped_column(String(32), default="observed")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
+class ProjectAuthorizationModel(Base):
+    """What a node may actually do to a project (issue #73's authorization plane).
+
+    Separate from the binding because the two are written by different actors:
+    a node announces a binding, an operator (or a standing discovery-root
+    grant) writes an authorization. #73: "A node cannot grant itself project
+    authorization merely by reporting a discovery."
+
+    `granted_by` is what keeps the automatic half auditable: `root-config:
+    <path>` for a capability that came from a discovery root's
+    `auto_authorize` (revoked by editing that root), `operator:<user_id>` for
+    an explicit decision. A grant with no attributable origin is not a grant.
+    """
+
+    __tablename__ = "project_authorizations"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    node_id: Mapped[str] = mapped_column(String(128), ForeignKey("nodes.id"))
+    project_id: Mapped[str] = mapped_column(String(128), ForeignKey("projects.id"))
+    capabilities_json: Mapped[str] = mapped_column(Text, default="[]")
+    granted_by: Mapped[str] = mapped_column(String(255))
+    granted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class DiscoveredResourceModel(Base):
+    """Something a node can see that Control has not necessarily adopted.
+
+    The entity that makes "Discovery is not authorization" structural rather
+    than a convention: a node writes rows here and nothing else, so reporting
+    a directory can never, by construction, produce the right to operate it.
+
+    `state` carries all five values of `shared.protocol.DiscoveredState`.
+    #73 forbids collapsing them into one boolean, and each pair it would merge
+    loses a real distinction — notably `denied` vs `discovered` (without it a
+    refused candidate returns to the adoption queue on every reconnect) and
+    `stale` vs absent (the row and its history survive a project that moved).
+
+    `resource_key` is the node's own identifier for the candidate and is
+    deliberately NOT a foreign key: a candidate exists precisely before there
+    is a `projects` row to point at. `kind` leaves room for the
+    processes/services #73 anticipates without a schema change.
+    """
+
+    __tablename__ = "discovered_resources"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    node_id: Mapped[str] = mapped_column(String(128), ForeignKey("nodes.id"))
+    kind: Mapped[str] = mapped_column(String(32), default="project")
+    resource_key: Mapped[str] = mapped_column(String(255))
+    project_id: Mapped[str | None] = mapped_column(String(128), ForeignKey("projects.id"), nullable=True)
+    evidence_json: Mapped[str] = mapped_column(Text, default="{}")
+    state: Mapped[str] = mapped_column(String(32), default="discovered")
+    root_path: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    first_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    decided_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class ProjectModel(Base):

--- a/migrations/0009_control_plane.sql
+++ b/migrations/0009_control_plane.sql
@@ -1,0 +1,193 @@
+-- WK-20260901-control-plane-nodes-and-engines / issue #73, Stage 1
+--
+-- The domain the "CodexBridge Control" epic (#73) needs, added alongside the
+-- existing entities rather than on top of them. Three of #73's rules decided
+-- the shape here, and each one rules out the smaller change that would
+-- otherwise have been tempting:
+--
+--   1. "A project MUST NOT be structurally owned by a node or by GitHub."
+--      So the Project<->machine relation is its own table (`workspace_bindings`)
+--      and the Project<->repository relation is another (`scm_associations`).
+--      A column on `projects` would have made one node and one remote
+--      structurally privileged, which is exactly what #73 forbids and what
+--      makes "the same project on Frida and on T610 at different paths"
+--      unrepresentable.
+--
+--   2. "Discovery is not authorization" / "a node cannot grant itself project
+--      authorization merely by reporting a discovery." So what a node reports
+--      lands in `discovered_resources`, and what it may DO lives in
+--      `project_authorizations` — two tables, because they are written by two
+--      different actors (the node announces; the operator, or a standing
+--      root-config grant, authorizes) and confusing them is the whole failure
+--      mode #73 names.
+--
+--   3. "Do not collapse these into a single `enabled` boolean." So
+--      `discovered_resources.state` carries all five values from
+--      `shared.protocol.DiscoveredState`, and `workspace_bindings.state`
+--      tracks the observed world separately from the operator's decision.
+--
+-- `nodes` is seeded 1:1 from `executors` at the bottom of this file, so every
+-- existing deployment comes up with its fleet already described and no
+-- operator action. `executors` keeps its identity, its machine token and its
+-- foreign key from `tasks` — #73 warns against "conflating node, executor,
+-- engine and project into one entity", and renaming the executor into a node
+-- would have done the conflation in the other direction.
+--
+-- NOT dropped here: `projects.path`. It stops being authoritative the moment
+-- `workspace_bindings` is populated, but dropping it in the same migration
+-- that creates its replacement would destroy the only copy of a path for any
+-- project no longer present in `registry.json` — the backfill runs in
+-- `store.upsert_registry` (which is where the executor/project association
+-- actually lives, inside `executors.metadata_json`) and cannot be expressed
+-- in portable SQL. Removal is a follow-up migration once bindings are
+-- verified in production. Recorded here so nobody reads its survival as an
+-- oversight.
+--
+-- Portability: `alter table ... add column` with a constant default, plain
+-- `create table`/`create index`, and one `insert ... select` — all valid on
+-- both SQLite and PostgreSQL. Style follows 0005/0008, not 0001 (which is
+-- Postgres-only by accident).
+--
+-- Apply with `python3 scripts/apply_migrations.py`.
+
+-- FIRST statement on purpose. `alter table` on a table that does not exist is
+-- the most likely way this file meets a database it does not belong to, and
+-- SQLite does not roll back DDL — so putting it first means such a failure
+-- leaves the schema untouched instead of half-created. The runner's own
+-- "PARTIALLY APPLIED" warning is the failure mode being avoided here.
+--
+-- One connection identity per node today, but the column is deliberately not
+-- unique: #73's model must allow a node to run more than one executor process
+-- later without a schema change.
+alter table executors add column node_id varchar(128);
+
+create index if not exists executors_node_id_idx on executors (node_id);
+
+-- A registered CodexBridge installation. Identity is the operator-assigned
+-- label, never a hostname or IP: #73 requires node identity to "survive
+-- reconnects and must not be inferred from mutable hostname/IP alone".
+create table if not exists nodes (
+  id varchar(128) primary key,
+  display_name varchar(255) not null,
+  enabled boolean not null default true,
+  -- Coarse platform facts only (`platform.system()`/`platform.machine()`).
+  -- Never `platform.node()`: `docs/api/README.md`'s "fields that must never
+  -- ship" excludes executor hostnames from every response.
+  os varchar(64) null,
+  arch varchar(64) null,
+  agent_version varchar(64) null,
+  -- Last announced engine capability set and when it was observed. Freshness
+  -- is derived from the timestamp at read time (#42: "persist last-known
+  -- capabilities with freshness timestamp"; "stale capability data is
+  -- visibly marked"), never stored as a boolean that a restart would strand.
+  capabilities_json text not null default '{}',
+  capabilities_observed_at timestamptz null,
+  inventory_observed_at timestamptz null,
+  health_reason varchar(255) null,
+  created_at timestamptz not null
+);
+
+-- A logical Project as it exists on one node's disk. This is the entity that
+-- answers #73's "on which nodes can project X run right now?".
+create table if not exists workspace_bindings (
+  id varchar(128) primary key,
+  node_id varchar(128) not null references nodes(id),
+  project_id varchar(128) not null references projects(id),
+  -- Sensitive operational data. #73: absolute paths "must only be returned to
+  -- appropriately authorized operator surfaces; they must not leak through
+  -- public/client contexts that do not need them." Exposed only by the
+  -- admin-scoped node/binding endpoints; never by ProjectStatus, Session,
+  -- Mission or any MCP tool.
+  local_path varchar(2048) not null,
+  head varchar(255) null,
+  dirty boolean null,
+  state varchar(32) not null default 'active',
+  last_scan_at timestamptz null,
+  created_at timestamptz not null,
+  updated_at timestamptz not null
+);
+
+create unique index if not exists workspace_bindings_node_project_idx
+  on workspace_bindings (node_id, project_id);
+create index if not exists workspace_bindings_project_idx
+  on workspace_bindings (project_id);
+
+-- Project <-> source-control association. `provider` is the seam that keeps
+-- #73's "the domain model must permit GitLab, other SCMs, and local-only
+-- projects later" true without a breaking change; `confidence` exists because
+-- #73 forbids inferring a trusted association from a coincidental name match,
+-- so an unconfirmed guess has somewhere to live that is not "associated".
+create table if not exists scm_associations (
+  id varchar(128) primary key,
+  project_id varchar(128) not null references projects(id),
+  provider varchar(32) not null default 'github',
+  remote_url varchar(2048) not null,
+  repo_identity varchar(512) null,
+  confidence varchar(32) not null default 'observed',
+  created_at timestamptz not null,
+  updated_at timestamptz not null
+);
+
+create unique index if not exists scm_associations_project_remote_idx
+  on scm_associations (project_id, remote_url);
+
+-- What a node may actually do to a project. Separate from the binding on
+-- purpose: a binding says "this workspace exists here", an authorization says
+-- "and this is what may be done to it". `granted_by` distinguishes a standing
+-- grant from a discovery root (`root-config:<path>`, revoked by editing that
+-- root) from an explicit operator decision (`operator:<user_id>`), which is
+-- what makes the automatic half auditable rather than invisible.
+create table if not exists project_authorizations (
+  id varchar(128) primary key,
+  node_id varchar(128) not null references nodes(id),
+  project_id varchar(128) not null references projects(id),
+  capabilities_json text not null default '[]',
+  granted_by varchar(255) not null,
+  granted_at timestamptz not null,
+  revoked_at timestamptz null
+);
+
+create unique index if not exists project_authorizations_node_project_idx
+  on project_authorizations (node_id, project_id);
+
+-- Something a node can see that Control has not necessarily adopted. `kind`
+-- is varchar rather than a two-value check because #73 explicitly leaves room
+-- for "processes/services and other machine-local resources" beyond project
+-- candidates.
+create table if not exists discovered_resources (
+  id varchar(128) primary key,
+  node_id varchar(128) not null references nodes(id),
+  kind varchar(32) not null default 'project',
+  -- The node's own identifier for the candidate (a suggested project_id for a
+  -- project candidate). Not a foreign key: a candidate exists precisely
+  -- BEFORE there is a `projects` row to point at.
+  resource_key varchar(255) not null,
+  project_id varchar(128) null references projects(id),
+  -- Evidence, not conclusion: path, HEAD, dirty flag, observed remote. What
+  -- the node saw, so an operator can decide rather than be told.
+  evidence_json text not null default '{}',
+  state varchar(32) not null default 'discovered',
+  root_path varchar(2048) null,
+  first_seen_at timestamptz not null,
+  last_seen_at timestamptz not null,
+  decided_by varchar(255) null,
+  decided_at timestamptz null
+);
+
+create unique index if not exists discovered_resources_node_kind_key_idx
+  on discovered_resources (node_id, kind, resource_key);
+create index if not exists discovered_resources_state_idx
+  on discovered_resources (state);
+
+-- Seed one node per existing executor, preserving the executor's own id as the
+-- node id. Every deployment therefore boots with its fleet already described,
+-- and `executors.node_id` is never null in practice after this migration even
+-- though the column is nullable (nullable so this ALTER is portable; the
+-- application treats a null node_id as "pre-#73 row" and repairs it at
+-- startup).
+insert into nodes (id, display_name, enabled, created_at)
+select e.id, e.display_name, e.enabled, current_timestamp
+from executors e
+where not exists (select 1 from nodes n where n.id = e.id);
+
+update executors set node_id = id where node_id is null;

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Iterable
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 EXECUTOR_TOKEN_HEADER = "X-Executor-Token"
@@ -58,6 +58,78 @@ class TaskMode(str, Enum):
     EDIT = "edit"
     TEST = "test"
     IMPLEMENT = "implement"
+
+
+class Capability(str, Enum):
+    """What a node is authorized to do to a project, per issue #73.
+
+    #73 requires the authorization model to be "capability-oriented rather
+    than assuming blanket filesystem access", and says the vocabulary should
+    be established "by the implementation issues and existing security
+    contracts". So this is DERIVED from `TaskMode`, never parallel to it:
+    `CAPABILITY_MODES` below is the whole mapping, and `allowed_modes` stays
+    the single enforcement point it already is
+    (`gateway/app/services/store.py:create_task`, and -- new in this work --
+    the executor's own `_handle_dispatch`).
+
+    Introducing a second, independent permission vocabulary is exactly the
+    "parallel concepts" #73 warns against: it would need its own enforcement,
+    its own tests, and its own drift.
+
+    `DELIVER` is the one value with no `TaskMode` behind it, because delivery
+    is not a mode -- it is `SubmitTaskRequest.delivery`
+    (`shared.protocol.DeliveryRequest`), gated separately by
+    `PUSHABLE_BRANCH_PATTERN` and the `codexbridge.task.approve` scope. It is
+    named here so an authorization can withhold it, not to move that gate.
+    """
+
+    READ = "read"
+    TEST = "test"
+    MODIFY = "modify"
+    DELIVER = "deliver"
+
+
+# The only definition of which capability grants which task modes. Imported by
+# the gateway (`services/store.py`) and by the executor
+# (`agent/codex_bridge_agent/service.py`) so the two sides cannot drift on
+# what a capability means -- the same "one definition, several importers"
+# shape `STOPPABLE_TASK_STATES` and `PUSHABLE_BRANCH_PATTERN` already have.
+#
+# `DELIVER` maps to no mode on purpose (see `Capability.DELIVER`).
+CAPABILITY_MODES: dict[Capability, frozenset[TaskMode]] = {
+    Capability.READ: frozenset({TaskMode.ANALYZE, TaskMode.REVIEW}),
+    Capability.TEST: frozenset({TaskMode.TEST}),
+    Capability.MODIFY: frozenset({TaskMode.EDIT, TaskMode.IMPLEMENT}),
+    Capability.DELIVER: frozenset(),
+}
+
+
+def capabilities_to_modes(capabilities: Iterable[Capability | str]) -> frozenset[TaskMode]:
+    """The task modes a capability set permits. Unknown values are ignored.
+
+    Ignoring rather than raising is deliberate and safe in this direction: an
+    unknown capability grants nothing, so a newer gateway announcing a
+    capability an older executor has never heard of narrows the executor's
+    behaviour instead of crashing its dispatch loop. The reverse direction
+    (an unknown value WIDENING access) cannot happen here, because a value
+    absent from `CAPABILITY_MODES` contributes no modes.
+    """
+    modes: set[TaskMode] = set()
+    for capability in capabilities:
+        try:
+            key = Capability(capability)
+        except ValueError:
+            continue
+        modes |= CAPABILITY_MODES[key]
+    return frozenset(modes)
+
+
+# What a discovery root grants automatically, when it grants anything at all
+# (`DiscoveryRoot.auto_authorize`). Never more than this by announcement:
+# `MODIFY` and `DELIVER` require an explicit, audited operator grant, because
+# #73 is unambiguous that "a node cannot grant itself project authorization
+# merely by reporting a discovery".
+AUTO_AUTHORIZABLE_CAPABILITIES = frozenset({Capability.READ, Capability.TEST})
 
 
 class TaskState(str, Enum):
@@ -157,6 +229,105 @@ class ApprovalDecision(str, Enum):
     REVISION_REQUESTED = "revision_requested"
 
 
+class DiscoveredState(str, Enum):
+    """Lifecycle of something a node can see, per issue #73.
+
+    #73 is explicit: "Do not collapse these into a single `enabled` boolean."
+    The point of five values rather than two is that they answer different
+    operator questions, and merging any pair loses one of them:
+
+    * `DISCOVERED` -- the node reported it; Control has done nothing. This is
+      NOT permission to operate it ("Discovery is not authorization").
+    * `ADOPTED` -- the operator accepted it as a known project and bound it to
+      a node, but granted no capability yet ("Adoption does not automatically
+      grant every operational capability").
+    * `AUTHORIZED` -- at least one capability is granted for this node.
+    * `DENIED` -- the operator refused it. Distinct from `DISCOVERED` so a
+      re-announcement does not resurrect it into the adoption queue every
+      time the node reconnects.
+    * `STALE` -- last seen in an earlier inventory, absent from the current
+      one. Distinct from `DENIED` (nobody decided anything) and from
+      absence (the row and its history survive; #73: "Offline/stale
+      information must be visibly distinguished from current observations").
+    """
+
+    DISCOVERED = "discovered"
+    ADOPTED = "adopted"
+    AUTHORIZED = "authorized"
+    DENIED = "denied"
+    STALE = "stale"
+
+
+class BindingState(str, Enum):
+    """Whether a Project-on-a-Node workspace is usable right now.
+
+    Separate from `DiscoveredState`, which tracks the operator's decision.
+    This tracks the observed world: a binding the operator authorized months
+    ago is `UNAVAILABLE` the moment the directory stops being a readable git
+    repository, without any decision changing.
+    """
+
+    ACTIVE = "active"
+    UNAVAILABLE = "unavailable"
+    STALE = "stale"
+
+
+class NodeHealth(str, Enum):
+    """A Bridge Node's operational condition, derived at read time.
+
+    Mirrors the shape `ProjectHealth` already has in
+    `docs/api/codex-bridge.openapi.yaml` — derived, never stored, so a
+    gateway restart cannot leave a node asserting health nobody re-measured.
+    """
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    OFFLINE = "offline"
+    UNKNOWN = "unknown"
+
+
+class DiscoveryRoot(BaseModel):
+    """One directory tree a node is configured to scan, and what that grants.
+
+    Issue #73: "No recursive whole-machine discovery by default. Discovery
+    roots must themselves be explicitly configured." There is no default
+    root; a node with no configured roots discovers nothing.
+
+    `auto_authorize` is the operator's standing, auditable grant for
+    everything under this one tree — the decision is made once per tree
+    instead of once per project, which is the friction this work removes. It
+    is capped at `AUTO_AUTHORIZABLE_CAPABILITIES` by the validator below:
+    `MODIFY` and `DELIVER` are never obtainable by announcement, only by an
+    explicit per-project grant that names an operator. Empty (the default)
+    means the tree is scanned and its candidates queue for adoption, granting
+    nothing at all.
+
+    `path` is compared as a STRING against what the node announces, never
+    resolved — the gateway runs on a different host and cannot see the node's
+    disk, so it has no path to canonicalize. Canonicalization and ancestry
+    are enforced where they can be: on the node
+    (`agent/codex_bridge_agent/config.py:resolve_auto_project`, and
+    `shared/project_discovery.py`, which never follows a symlink and never
+    ascends).
+    """
+
+    path: str = Field(min_length=1, max_length=2048)
+    auto_authorize: list[Capability] = Field(default_factory=list)
+
+    @field_validator("auto_authorize")
+    @classmethod
+    def _refuse_non_auto_authorizable(cls, value: list[Capability]) -> list[Capability]:
+        forbidden = [c for c in value if c not in AUTO_AUTHORIZABLE_CAPABILITIES]
+        if forbidden:
+            raise ValueError(
+                "auto_authorize may only grant "
+                f"{sorted(c.value for c in AUTO_AUTHORIZABLE_CAPABILITIES)}; "
+                f"{sorted(c.value for c in forbidden)} require an explicit per-project grant "
+                "(issue #73: a node cannot grant itself project authorization by reporting a discovery)"
+            )
+        return value
+
+
 class ProjectRegistration(BaseModel):
     project_id: str
     name: str
@@ -176,6 +347,15 @@ class ExecutorRegistration(BaseModel):
     enabled: bool = True
     expected_timezone: str = "America/Sao_Paulo"
     expected_online_windows: list[str] = Field(default_factory=list)
+    # WK-20260901-control-plane-nodes-and-engines, issue #73 Stage 2. The
+    # directory trees this node may scan, and what each tree grants standing.
+    # Empty (the default) preserves today's behaviour exactly: no discovery,
+    # no announcement, only the hand-registered `allowed_projects` above.
+    #
+    # Deliberately on the executor's registration rather than a global
+    # setting: #73 requires the model to support a fleet, and two nodes of the
+    # same fleet legitimately hold different trees at different paths.
+    discovery_roots: list[DiscoveryRoot] = Field(default_factory=list)
 
 
 # A branch a pre-authorized push may target. `development` by name, or any

--- a/tests/unit/test_apply_migrations.py
+++ b/tests/unit/test_apply_migrations.py
@@ -73,6 +73,29 @@ def legacy_db(tmp_path: Path) -> Path:
         "  ('code-old', 'chatgpt-codexbridge', 'https://chatgpt.com/cb', 'esteban',"
         "   'e@example.com', '[]', 'chal', 'S256', '2099-01-01 00:00:00', null,"
         "   '2026-01-01 00:00:00');"
+        # `executors` and `projects` for the same reason the two OAuth tables
+        # are here: 0009 alters the first and references the second, and a
+        # fixture that omits a table a migration touches tests the runner
+        # against a schema no deployment has. Both carry a row so the node
+        # seeding 0009 performs has something real to seed from.
+        "create table executors ("
+        "  id varchar(128) primary key,"
+        "  display_name varchar(255) not null,"
+        "  enabled boolean not null default 1,"
+        "  last_seen_at timestamp with time zone,"
+        "  connected boolean not null default 0,"
+        "  metadata_json text not null default '{}'"
+        ");"
+        "insert into executors (id, display_name) values ('devel3', 'devel3');"
+        "create table projects ("
+        "  id varchar(128) primary key,"
+        "  name varchar(255) not null,"
+        "  path varchar(2048) not null,"
+        "  enabled boolean not null default 1,"
+        "  config_json text not null default '{}'"
+        ");"
+        "insert into projects (id, name, path) values"
+        "  ('codexbridge', 'CodexBridge', '/srv/projects/codexbridge');"
     )
     connection.commit()
     connection.close()
@@ -290,3 +313,80 @@ def test_engine_and_delivery_columns_default_existing_rows_to_codex(legacy_db: P
         "select engine, issue_ref, delivery_json, delivery_result_json from tasks where id = 't-old'"
     ).fetchone()
     assert row == ("codex", None, None, None)
+
+
+def test_control_plane_seeds_one_node_per_existing_executor(legacy_db: Path) -> None:
+    """0009: an existing deployment must come up with its fleet already
+
+    described. Issue #73 makes the Bridge Node a first-class entity, but every
+    database that predates it already knows which machines exist -- they are
+    its `executors` rows. Seeding from them means no operator has to hand-write
+    a fleet that the system can derive, and `executors.node_id` is never null
+    in practice even though the column is nullable (nullable only so the ALTER
+    stays portable).
+    """
+    adopted = run(legacy_db, "--mark-applied", "0001_init.sql")
+    assert adopted.returncode == 0, adopted.stderr
+    applied = run(legacy_db)
+    assert applied.returncode == 0, applied.stderr
+
+    assert {
+        "nodes",
+        "workspace_bindings",
+        "scm_associations",
+        "project_authorizations",
+        "discovered_resources",
+    } <= tables(legacy_db)
+
+    connection = sqlite3.connect(legacy_db)
+    assert connection.execute("select id, display_name from nodes").fetchall() == [("devel3", "devel3")]
+    assert connection.execute("select id, node_id from executors").fetchall() == [("devel3", "devel3")]
+
+
+def test_control_plane_grants_nothing_by_existing_alone(legacy_db: Path) -> None:
+    """0009 must create the authorization plane EMPTY.
+
+    Issue #73: "Discovery is not authorization." The mirror of that rule at
+    migration time is that adopting the new schema cannot, by itself, hand any
+    node a capability over any project -- not even over the projects it was
+    already allowed to run, whose access keeps flowing through the pre-existing
+    `allowed_projects` path until an authorization is granted deliberately.
+    A migration that pre-filled this table "to preserve behaviour" would be
+    inventing grants nobody made.
+    """
+    run(legacy_db, "--mark-applied", "0001_init.sql")
+    applied = run(legacy_db)
+    assert applied.returncode == 0, applied.stderr
+
+    connection = sqlite3.connect(legacy_db)
+    assert connection.execute("select count(*) from project_authorizations").fetchone() == (0,)
+    assert connection.execute("select count(*) from discovered_resources").fetchone() == (0,)
+    assert connection.execute("select count(*) from workspace_bindings").fetchone() == (0,)
+
+
+def test_control_plane_refuses_a_database_without_executors_before_touching_it(tmp_path: Path) -> None:
+    """A wrong database must be left untouched, not half-migrated.
+
+    SQLite does not roll back DDL, so a migration that creates five tables and
+    only then discovers the table it must ALTER is missing leaves the file
+    PARTIALLY APPLIED -- the state the runner's own error text warns about at
+    length. 0009 therefore puts its `alter table executors` first. This test
+    pins that ordering: without it the assertion below finds `nodes` already
+    created.
+    """
+    db = tmp_path / "wrong.db"
+    sqlite3.connect(db).executescript("create table unrelated (id integer primary key);")
+
+    # Every earlier migration is marked applied so 0009 is the one that
+    # actually runs. Without this the runner stops at 0002 (no `tasks` table)
+    # and never reaches the file under test -- which would make this test pass
+    # for the wrong reason.
+    for name in sorted(path.name for path in (REPO_ROOT / "migrations").glob("*.sql")):
+        if name == "0009_control_plane.sql":
+            break
+        run(db, "--mark-applied", name)
+    result = run(db)
+
+    assert result.returncode != 0
+    assert "no such table: executors" in (result.stdout + result.stderr)
+    assert "nodes" not in tables(db)

--- a/tests/unit/test_capability_vocabulary.py
+++ b/tests/unit/test_capability_vocabulary.py
@@ -1,0 +1,116 @@
+"""The capability vocabulary issue #73's authorization plane is built on.
+
+#73 requires authorization to be "capability-oriented rather than assuming
+blanket filesystem access", and requires the vocabulary to come from "existing
+security contracts" rather than being invented alongside them. These tests pin
+the two properties that make that true: capabilities are a VIEW of `TaskMode`
+(so `allowed_modes` stays the single enforcement point), and no capability that
+grants writing can ever be obtained by a node announcing a directory.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from shared.protocol import (
+    AUTO_AUTHORIZABLE_CAPABILITIES,
+    CAPABILITY_MODES,
+    Capability,
+    DiscoveredState,
+    DiscoveryRoot,
+    TaskMode,
+    capabilities_to_modes,
+)
+
+
+def test_every_task_mode_is_reachable_through_some_capability() -> None:
+    """A mode no capability grants is a mode no authorization can ever permit.
+
+    Written as a total check rather than five separate assertions because the
+    failure it guards against is additive: someone adds a sixth `TaskMode` and
+    the authorization plane silently cannot express it, which surfaces much
+    later as "why can this project never run that".
+    """
+    granted = set().union(*CAPABILITY_MODES.values())
+    assert granted == set(TaskMode)
+
+
+def test_read_grants_no_mode_that_can_modify_a_file() -> None:
+    """The load-bearing claim of the whole read-only tier.
+
+    If `edit` or `implement` ever appears under `READ`, every "announced
+    projects are read-only" guarantee in this codebase becomes false at once,
+    on both the gateway and the executor, because both derive their check from
+    this one mapping.
+    """
+    read_modes = capabilities_to_modes([Capability.READ])
+    assert TaskMode.EDIT not in read_modes
+    assert TaskMode.IMPLEMENT not in read_modes
+    assert read_modes == frozenset({TaskMode.ANALYZE, TaskMode.REVIEW})
+
+
+def test_deliver_grants_no_mode() -> None:
+    """Delivery is not a mode, and must not become one by accident.
+
+    Pushing is `SubmitTaskRequest.delivery`, gated by
+    `PUSHABLE_BRANCH_PATTERN` and the approval scope. `Capability.DELIVER`
+    exists so an authorization can WITHHOLD it -- if it started granting a
+    mode, it would quietly widen what a task may do on top of that.
+    """
+    assert capabilities_to_modes([Capability.DELIVER]) == frozenset()
+
+
+def test_an_unknown_capability_grants_nothing() -> None:
+    """Forward compatibility must narrow, never widen.
+
+    A newer gateway naming a capability an older executor has never heard of
+    must leave the executor stricter, not crash its dispatch loop and not
+    grant something it cannot reason about.
+    """
+    assert capabilities_to_modes(["telepathy"]) == frozenset()
+    assert capabilities_to_modes(["read", "telepathy"]) == capabilities_to_modes(["read"])
+
+
+def test_a_discovery_root_cannot_grant_write_capabilities() -> None:
+    """#73: "A node cannot grant itself project authorization merely by
+
+    reporting a discovery." The operator configures a root once and that is a
+    real, auditable grant -- but only of the capabilities that cannot change a
+    repository. `modify` and `deliver` require a per-project decision that
+    names a person, so they are refused at the point the root is parsed,
+    before any node has connected.
+    """
+    for capability in (Capability.MODIFY, Capability.DELIVER):
+        with pytest.raises(ValidationError) as excinfo:
+            DiscoveryRoot(path="/home/esteban/Sync/Projects/AI", auto_authorize=[capability])
+        assert "explicit per-project grant" in str(excinfo.value)
+
+
+def test_auto_authorizable_capabilities_never_reach_a_file() -> None:
+    """Guards the constant itself, not just the validator that reads it.
+
+    The validator would keep passing if someone widened
+    `AUTO_AUTHORIZABLE_CAPABILITIES`; this is the assertion that notices.
+    """
+    assert not (capabilities_to_modes(AUTO_AUTHORIZABLE_CAPABILITIES) & {TaskMode.EDIT, TaskMode.IMPLEMENT})
+
+
+def test_a_root_grants_nothing_unless_it_says_so() -> None:
+    """Scanning a tree and authorizing it are different acts.
+
+    The default must be the strict one: a root with no `auto_authorize`
+    produces adoption candidates and no access at all.
+    """
+    assert DiscoveryRoot(path="/home/esteban/Sync/Projects").auto_authorize == []
+
+
+def test_the_five_discovered_states_are_all_distinct_values() -> None:
+    """#73: "Do not collapse these into a single `enabled` boolean."
+
+    Pinned as a test because the pressure to collapse is real and arrives as a
+    refactor: `denied` merged into `discovered` makes a refused candidate
+    reappear in the adoption queue on every reconnect, and `stale` merged into
+    absence loses a project's history when its directory moves.
+    """
+    assert len({state.value for state in DiscoveredState}) == 5


### PR DESCRIPTION
Stage 1 (**Domain and contracts**) of epic #73. No runtime behaviour changes yet:
this adds the schema, the entities and the capability vocabulary that Stages 2–7
will consume. Nothing in the gateway or the agent reads the new tables so far.

## Why the shape is this shape

Three rules from the issue decided it, and each one discarded the smaller change
that would have been tempting:

| Rule from #73 | Structural consequence |
|---|---|
| a project is owned neither by a node nor by GitHub | `workspace_bindings` and `scm_associations` are tables, not columns on `projects` |
| discovery is not authorization | the node only ever writes `discovered_resources`; capability lives in `project_authorizations` |
| do not collapse into a single boolean | `discovered_resources.state` carries the five `DiscoveredState` values |

`Capability` is **derived** from `TaskMode` (`CAPABILITY_MODES`), never parallel to
it, so `allowed_modes` remains the single enforcement point. `DiscoveryRoot`'s
`auto_authorize` refuses `modify`/`deliver` at parse time, before any node connects.

`docs/control-plane.md` explains what each entity means and — more usefully for
review — what it is *not*, plus what is lost by each merge someone might propose.

## Three decisions taken against or beyond the plan

1. **`projects.path` was kept**, though the plan said to drop it. Removing it in
   the same migration that creates the replacement destroys the only copy of the
   path for any project absent from today's `registry.json`; the backfill depends
   on `executors.metadata_json` and is not expressible in portable SQL. The reason
   is written into the migration file; the removal belongs in a later migration
   with the backfill done in code.
2. **`alter table executors` runs first** in `0009`: SQLite does not roll back DDL,
   so hitting the wrong database leaves the schema intact rather than half-built.
3. **The migration grants nothing.** `project_authorizations` is born empty, including
   for projects a node already runs today. Pre-filling it "to preserve behaviour"
   would invent grants nobody made.

## Checks

- `pytest -q` → **757 passed, 7 skipped** (branch baseline: 746/7).
- `0009_control_plane.sql` applies on **SQLite** and on a **real PostgreSQL 16**
  (throwaway container, removed afterwards; no other project's Postgres touched).
- Three mutations proved the new tests bite: widening `Capability.READ` to include
  `edit`; widening `AUTO_AUTHORIZABLE_CAPABILITIES` to include `modify`; reversing
  the migration's statement order. Each drops the corresponding test.

## Not validated

`0009` has never been applied to a real gateway database. No deploy. No multi-worker
run. Stages 2–7 not started.

Refs #73. work_id: `WK-20260901-gh73-control-plane-domain`.
Session-close notes: `docs/issues/073-codexbridge-control/RESUME.md` (on `development`).

https://claude.ai/code/session_013ZzDZZA8uAnKjackPX49VA
