### PR TITLE
feat(gh-73): fleet visibility — node announcement, engine probe, /api/v1/nodes (Stage 2)

### DIFF
--- a/agent/codex_bridge_agent/runners/base.py
+++ b/agent/codex_bridge_agent/runners/base.py
@@ -46,6 +46,30 @@ class RunningTask:
 
 
 @dataclass(frozen=True)
+class EngineProbe:
+    """The runtime answer to "is this engine's binary actually here, right now".
+
+    Issue #73 Stage 2. `capabilities()` is a compile-time claim -- "this code
+    knows how to drive engine X" -- true identically on every node running
+    the same build. `probe()` is the opposite kind of fact: it shells out to
+    the configured binary on THIS machine and reports what actually
+    answered. A node can be `implemented` (a `Runner` exists) and still not
+    `available` (the CLI was never installed here), or vice versa in theory
+    -- the two questions are independent, which is exactly why
+    `EngineAvailability` (`shared/protocol.py`) carries both instead of one
+    collapsed boolean.
+
+    `detail` never carries a filesystem path -- `shared/protocol.py`'s own
+    `EngineAvailability.detail` docstring says the same: a probe's job is to
+    answer "is it here", not to leak where "here" is.
+    """
+
+    available: bool
+    version: str | None = None
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
 class RunnerCapabilities:
     """What a provider can and cannot do, declared rather than assumed.
 
@@ -88,6 +112,8 @@ class Runner(Protocol):
     """
 
     def capabilities(self) -> RunnerCapabilities: ...
+
+    async def probe(self) -> EngineProbe: ...
 
     def is_known(self, task_id: str) -> bool: ...
 

--- a/agent/codex_bridge_agent/runners/claude.py
+++ b/agent/codex_bridge_agent/runners/claude.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 import signal
 import time
 from datetime import datetime, timezone
@@ -64,9 +65,13 @@ from uuid import uuid4
 
 from agent.codex_bridge_agent.config import AgentSettings
 from agent.codex_bridge_agent.git_tools import collect_git_snapshot
-from agent.codex_bridge_agent.runners.base import LogSender, RunnerCapabilities, RunningTask
+from agent.codex_bridge_agent.runners.base import EngineProbe, LogSender, RunnerCapabilities, RunningTask
 from shared.protocol import AgentEngine, TaskState
 from shared.security import filtered_environment, sanitize_log_line
+
+# Issue #73 Stage 2, same rationale as `runners/codex.py`'s own constant of
+# this name: bounds how long `probe()` waits for `<bin> --version`.
+_PROBE_TIMEOUT_SECONDS = 5
 
 
 SANDBOX_READ_ONLY = "read-only"
@@ -156,6 +161,36 @@ class ClaudeRunner:
             cost_class="subscription",
             env_allowlist=CLAUDE_ENV_ALLOWLIST,
         )
+
+    async def probe(self) -> EngineProbe:
+        """Issue #73 Stage 2: is `self.settings.claude_bin` actually here, right now.
+
+        Mirrors `runners.codex.CodexRunner.probe` -- see that method's
+        docstring for why this never raises and why `detail` never carries a
+        filesystem path.
+        """
+        try:
+            resolved = shutil.which(self.settings.claude_bin)
+            if resolved is None:
+                return EngineProbe(available=False, detail="not found on PATH")
+            process = await asyncio.create_subprocess_exec(
+                self.settings.claude_bin,
+                "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(process.communicate(), timeout=_PROBE_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                return EngineProbe(available=False, detail="probe timed out")
+            first_line = stdout.decode("utf-8", errors="replace").splitlines()[0] if stdout else ""
+            return EngineProbe(available=True, version=first_line.strip()[:200] or None)
+        except Exception:
+            # Deliberately everything, not just `OSError`: see this method's
+            # docstring. A probe that escapes costs the connection.
+            return EngineProbe(available=False, detail="probe failed")
 
     def is_known(self, task_id: str) -> bool:
         return task_id in self.known_tasks

--- a/agent/codex_bridge_agent/runners/codex.py
+++ b/agent/codex_bridge_agent/runners/codex.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 import signal
 import time
 from datetime import datetime, timezone
@@ -10,9 +11,15 @@ from tempfile import NamedTemporaryFile
 
 from agent.codex_bridge_agent.config import AgentSettings
 from agent.codex_bridge_agent.git_tools import collect_git_snapshot
-from agent.codex_bridge_agent.runners.base import LogSender, RunnerCapabilities, RunningTask
+from agent.codex_bridge_agent.runners.base import EngineProbe, LogSender, RunnerCapabilities, RunningTask
 from shared.protocol import AgentEngine, TaskState
 from shared.security import filtered_environment, sanitize_log_line
+
+# Issue #73 Stage 2: how long `probe()` waits for `<bin> --version` before
+# giving up. Short and fixed -- a probe runs on every reconnect
+# (`AgentService._build_announcement`), so a hung or misbehaving binary must
+# not delay the HELLO handshake by more than a few seconds.
+_PROBE_TIMEOUT_SECONDS = 5
 
 # codex-cli 0.147.0's `codex exec -s/--sandbox <MODE>` (confirmed via
 # `codex exec --help`, issue #34): `read-only`, `workspace-write`,
@@ -56,6 +63,43 @@ class CodexRunner:
             cost_class="subscription",
             env_allowlist=CODEX_ENV_ALLOWLIST,
         )
+
+    async def probe(self) -> EngineProbe:
+        """Issue #73 Stage 2: is `self.settings.codex_bin` actually here, right now.
+
+        Deliberately never raises -- a node whose probe raised would fail to
+        build its `NodeAnnouncement` and, per `AgentService._build_announcement`,
+        fall back to a minimal payload rather than connect with full fleet
+        detail. Reporting `available=False` with a `detail` string is always
+        the better trade than losing the connection.
+
+        `detail` never carries the resolved path (`shutil.which`'s return
+        value) or `self.settings.codex_bin` itself -- both are filesystem
+        paths, which `shared/protocol.py:EngineAvailability.detail` documents
+        as sensitive.
+        """
+        try:
+            resolved = shutil.which(self.settings.codex_bin)
+            if resolved is None:
+                return EngineProbe(available=False, detail="not found on PATH")
+            process = await asyncio.create_subprocess_exec(
+                self.settings.codex_bin,
+                "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, _ = await asyncio.wait_for(process.communicate(), timeout=_PROBE_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                return EngineProbe(available=False, detail="probe timed out")
+            first_line = stdout.decode("utf-8", errors="replace").splitlines()[0] if stdout else ""
+            return EngineProbe(available=True, version=first_line.strip()[:200] or None)
+        except Exception:
+            # Deliberately everything, not just `OSError`: see this method's
+            # docstring. A probe that escapes costs the connection.
+            return EngineProbe(available=False, detail="probe failed")
 
     def is_known(self, task_id: str) -> bool:
         """Whether this runner has any record of the task at all.

--- a/agent/codex_bridge_agent/runners/pool.py
+++ b/agent/codex_bridge_agent/runners/pool.py
@@ -18,9 +18,12 @@ centralized across more than one instance.
 
 from __future__ import annotations
 
+import asyncio
+
 from agent.codex_bridge_agent.config import AgentSettings
 from agent.codex_bridge_agent.runners.base import EngineNotImplementedError, Runner
 from agent.codex_bridge_agent.runners.registry import KNOWN_ENGINES
+from shared.protocol import EngineAvailability
 
 
 class RunnerPool:
@@ -74,3 +77,59 @@ class RunnerPool:
         if engine is None:
             return False
         return await self._runners[engine].restart(task_id)
+
+    async def probe_all(self) -> list[EngineAvailability]:
+        """Issue #73 Stage 2: one `EngineAvailability` for every `KNOWN_ENGINES`
+
+        entry, not just the ones this pool instantiated a `Runner` for. A
+        candidate engine with `implemented=False` (no `Runner` exists in this
+        codebase) is reported unavailable with a reason rather than omitted
+        entirely -- the fleet surface needs to answer "what could this build
+        ever run" as well as "what can it run today"
+        (`runners/registry.py`'s own docstring makes the same point about
+        `KNOWN_ENGINES` itself).
+
+        The implemented engines are probed concurrently
+        (`asyncio.gather(..., return_exceptions=True)`) so one runner's probe
+        raising cannot take down the whole announcement -- an exception here
+        becomes `available=False, detail="probe failed"` rather than
+        propagating, mirroring the same "never let one bad part break the
+        rest" posture `Runner.probe()` itself takes toward its own
+        subprocess.
+        """
+        implemented_names = [name for name, runner in self._runners.items()]
+        results = await asyncio.gather(
+            *(self._runners[name].probe() for name in implemented_names),
+            return_exceptions=True,
+        )
+        probes: dict[str, EngineAvailability] = {}
+        for name, outcome in zip(implemented_names, results):
+            if isinstance(outcome, BaseException):
+                probes[name] = EngineAvailability(
+                    engine=name,
+                    implemented=True,
+                    available=False,
+                    detail="probe failed",
+                )
+            else:
+                probes[name] = EngineAvailability(
+                    engine=name,
+                    implemented=True,
+                    available=outcome.available,
+                    version=outcome.version,
+                    detail=outcome.detail,
+                )
+        availabilities: list[EngineAvailability] = []
+        for name, registration in KNOWN_ENGINES.items():
+            if name in probes:
+                availabilities.append(probes[name])
+            else:
+                availabilities.append(
+                    EngineAvailability(
+                        engine=name,
+                        implemented=False,
+                        available=False,
+                        detail="no runner implemented",
+                    )
+                )
+        return availabilities

--- a/agent/codex_bridge_agent/service.py
+++ b/agent/codex_bridge_agent/service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import platform
 import random
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -20,7 +22,9 @@ from shared.protocol import (
     EXECUTOR_TOKEN_HEADER,
     AgentEnvelope,
     AgentMessageType,
+    Capability,
     DeliveryRequest,
+    NodeAnnouncement,
     PolicyLevel,
     SubmitTaskRequest,
     TaskMode,
@@ -28,6 +32,16 @@ from shared.protocol import (
     TaskState,
 )
 from shared.security import ensure_within_root
+
+
+logger = logging.getLogger(__name__)
+
+# Sent as `NodeAnnouncement.agent_version` (the `hello` payload) -- the same
+# literal `_run_once` always sent before issue #73 Stage 2, now single-sourced
+# here rather than inlined at the send site. No dependency on the gateway
+# package is introduced to get this value: it stays a plain constant local to
+# the agent, exactly as it always was.
+AGENT_VERSION = "0.1.0"
 
 
 BASE_PROMPT = (
@@ -100,7 +114,10 @@ class AgentService:
         # caught it because every existing test replaces
         # `websockets.connect` with a fake before this line runs.
         async with websockets.connect(url, max_size=2_000_000, additional_headers=headers) as websocket:
-            await websocket.send(self._envelope(AgentMessageType.HELLO, {"version": "0.1.0"}).model_dump_json())
+            announcement = await self._build_announcement()
+            await websocket.send(
+                self._envelope(AgentMessageType.HELLO, announcement.model_dump(mode="json")).model_dump_json()
+            )
             heartbeat_task = asyncio.create_task(self._heartbeat_loop(websocket))
             try:
                 async for raw in websocket:
@@ -344,6 +361,53 @@ class AgentService:
             await websocket.send(self._envelope(AgentMessageType.TASK_RESULT, result).model_dump_json())
         finally:
             self.runners.forget(task_id)
+
+    async def _build_announcement(self) -> NodeAnnouncement:
+        """Issue #73 Stage 2: the `hello` payload's real content.
+
+        `capabilities` here is derived from this node's OWN configuration --
+        what it is set up to *permit* -- never a grant. Per-project
+        authorization still lives entirely server-side, in
+        `project_authorizations` (see `shared/protocol.py:NodeAnnouncement`'s
+        own docstring); a node claiming `MODIFY` here only means "if
+        authorized, I am configured to attempt writes", not "I may write to
+        anything".
+
+        `discovery_root_count`: the agent has no local `DiscoveryRoot` list to
+        count (`auto_project_root` is a single optional path, not a list --
+        see `AgentSettings.auto_project_root`'s own docstring), so this
+        reports 1 when that single opt-in root is set and 0 otherwise, rather
+        than inventing a new setting to carry a count `AgentSettings` does not
+        otherwise track.
+
+        Never allowed to raise past this method: building the announcement
+        must not cost the connection. Any exception here (a runner's `probe`
+        somehow escaping `RunnerPool.probe_all`'s own `return_exceptions`
+        guard, or anything else) is caught and logged, and a minimal
+        announcement is returned instead -- `_run_once` always gets something
+        it can send.
+        """
+        try:
+            capabilities = [Capability.READ, Capability.TEST]
+            if self.settings.allow_workspace_write:
+                capabilities.append(Capability.MODIFY)
+            if self.settings.allow_git_delivery:
+                capabilities.append(Capability.DELIVER)
+            return NodeAnnouncement(
+                agent_version=AGENT_VERSION,
+                os=platform.system(),
+                arch=platform.machine(),
+                engines=await self.runners.probe_all(),
+                capabilities=capabilities,
+                max_concurrent_tasks=self.settings.max_concurrent_tasks,
+                # See this method's own docstring: no local list of discovery
+                # roots exists to count, so the single opt-in
+                # `auto_project_root` collapses to 0 or 1.
+                discovery_root_count=1 if self.settings.auto_project_root else 0,
+            )
+        except Exception:
+            logger.warning("Failed to build full node announcement; sending minimal fallback", exc_info=True)
+            return NodeAnnouncement(agent_version=AGENT_VERSION)
 
     def _envelope(self, message_type: AgentMessageType, payload: dict) -> AgentEnvelope:
         return AgentEnvelope(

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.6.0
+  version: 1.9.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -471,6 +471,82 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectSummary'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/nodes:
+    get:
+      operationId: listNodes
+      tags: [nodes]
+      summary: Every Bridge Node in the fleet
+      description: |
+        Issue #73 Stage 2. A **node** is a registered CodexBridge installation,
+        distinct from the executor connection that carries work to it. Fleet-wide
+        and administrative: unlike `/api/v1/projects`, there is no per-caller
+        project scope to filter by, so this requires the `nodes.read` action
+        (`codexbridge.admin`) rather than the plain read scope.
+
+        Not paginated — the fleet, like the executor registry it is seeded
+        from, is operator-curated and expected to hold a handful of machines.
+
+        `capabilities`, `engines`, `maxConcurrentTasks` and
+        `discoveryRootCount` are what the node last reported about itself in
+        its own HELLO — an **observation**, never a grant. What a node may
+        actually do to a given project is authorized separately and is not
+        exposed by this endpoint (issue #73: "a node cannot grant itself
+        project authorization merely by reporting a discovery").
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Every node.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/NodeStatus'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/nodes/{nodeId}:
+    get:
+      operationId: getNode
+      tags: [nodes]
+      summary: One Bridge Node's fleet status
+      description: |
+        See `GET /api/v1/nodes` for what this reports and why it is
+        administrative rather than project-scoped.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/NodeId'
+      responses:
+        '200':
+          description: The node's fleet status.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeStatus'
         '401': {$ref: '#/components/responses/Unauthenticated'}
         '403': {$ref: '#/components/responses/PermissionDenied'}
         '404': {$ref: '#/components/responses/NotFound'}
@@ -2953,6 +3029,137 @@ components:
                 $ref: '#/components/schemas/ProjectExecutorStatus'
             generatedAt:
               $ref: '#/components/schemas/Timestamp'
+
+    NodeId:
+      allOf:
+        - $ref: '#/components/schemas/Id'
+      description: |
+        Identifier of a registered Bridge Node (issue #73). Today this is
+        1:1 with an `ExecutorId` — every node is seeded from an executor — but
+        clients must treat the two as different identifier spaces, since the
+        schema does not require them to stay 1:1.
+
+    Capability:
+      type: string
+      enum: [read, test, modify, deliver]
+      description: |
+        What a node is authorized to do to a project. `deliver` has no
+        corresponding session mode of its own — it gates
+        `SubmitTaskRequest.delivery` separately. `capabilities` on `NodeStatus`
+        is what the node's own configuration would *permit*; it is not a
+        grant. What a node may actually do to a given project is authorized
+        separately and is not reported by this endpoint.
+
+    EngineAvailability:
+      type: object
+      description: |
+        Whether one execution engine can actually run on this node, right
+        now. Three different facts, kept separate on purpose: `implemented`
+        is a build-time claim (a runner exists in this codebase for the
+        engine), `available` is a runtime fact (the binary answered when
+        probed on this machine), and neither implies the other — an engine
+        this build supports but this machine lacks needs installing;
+        an engine present on the machine that no runner drives is a code gap,
+        not an ops one.
+      required: [engine, implemented, available]
+      properties:
+        engine:
+          type: string
+          maxLength: 64
+        implemented:
+          type: boolean
+        available:
+          type: boolean
+        version:
+          type: [string, 'null']
+          maxLength: 200
+        detail:
+          type: [string, 'null']
+          maxLength: 400
+          description: Why a probe failed, when it did. Never a path or a stack trace.
+
+    NodeHealth:
+      type: string
+      enum: [ok, degraded, offline, unknown]
+      description: |
+        Derived at read time, never stored. `unknown` — this node has never
+        connected, which is a different situation from `offline` and calls
+        for a different response. `offline` — it connected before but is not
+        live right now. `degraded` — it is live but disabled, or flagged with
+        a `healthReason`. `ok` — live, enabled, no flag.
+
+    NodeStatus:
+      type: object
+      description: |
+        A Bridge Node (issue #73 Stage 2): a registered CodexBridge
+        installation, distinct from the executor connection that carries work
+        to it. Never carries a filesystem path or a hostname — see
+        `docs/api/README.md` "Fields that must never ship".
+
+        `capabilities`, `engines`, `maxConcurrentTasks` and
+        `discoveryRootCount` reflect the node's most recent HELLO
+        announcement — an observation with a freshness timestamp
+        (`capabilitiesObservedAt`), not a live query and not an authorization.
+      required: [id, displayName, enabled, health, inventoryStale]
+      properties:
+        id:
+          $ref: '#/components/schemas/NodeId'
+        displayName:
+          type: string
+          maxLength: 255
+        enabled:
+          type: boolean
+        health:
+          $ref: '#/components/schemas/NodeHealth'
+        healthReason:
+          type: [string, 'null']
+          maxLength: 255
+          description: Operator- or node-supplied reason behind a `degraded` health.
+        lastSeenAt:
+          type: [string, 'null']
+          format: date-time
+          description: Most recent heartbeat/HELLO from this node's executor, or `null` if it has never connected.
+        agentVersion:
+          type: [string, 'null']
+          maxLength: 64
+        os:
+          type: [string, 'null']
+          maxLength: 120
+        arch:
+          type: [string, 'null']
+          maxLength: 60
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Capability'
+          description: What this node's own configuration would permit it to do. Not a grant — see the schema description above.
+        engines:
+          type: array
+          items:
+            $ref: '#/components/schemas/EngineAvailability'
+        maxConcurrentTasks:
+          type: [integer, 'null']
+        discoveryRootCount:
+          type: [integer, 'null']
+          description: |
+            How many discovery roots this node is configured to scan. A
+            count, never the paths themselves — absolute paths are sensitive
+            operational data and are excluded from every response on this
+            contract.
+        capabilitiesObservedAt:
+          type: [string, 'null']
+          format: date-time
+          description: When this node's inventory (capabilities/engines/etc.) was last observed via HELLO. `null` before the first announcement.
+        inventoryObservedAt:
+          type: [string, 'null']
+          format: date-time
+          description: Reserved for the discovery-inventory surface issue #73 anticipates; not written by this build.
+        inventoryStale:
+          type: boolean
+          description: |
+            `true` when `capabilitiesObservedAt` is `null`, or older than the
+            gateway's inventory freshness window. A client should render stale
+            inventory as visibly stale rather than as current fact.
 
     Session:
       type: object

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,8 +5,8 @@
 
 ## Summary
 
-- 126 file(s) · 1181 symbol(s) indexed
-- Languages: config (2), python (122), shell (2)
+- 132 file(s) · 1246 symbol(s) indexed
+- Languages: config (2), python (128), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -73,6 +73,7 @@ gateway/
         epics.py  — "Epics — issue #8."
         issues.py  — "Issues — issue #8."
         missions.py  — "Missions: the mission-control view of the same run Sessions exposes — issue #7."
+        nodes.py  — "Bridge Nodes — the fleet visibility surface of issue #73, Stage 2."
         probes.py  — "Liveness, readiness and version — what a client asks before anything else."
         projects.py  — "Projects and the project operational dashboard — issue #5."
         sessions.py  — "Agent sessions, their logs, and lifecycle control."
@@ -132,6 +133,7 @@ tests/
     test_agent_ack_handling.py  — "`task.ack` handling in the `/agent/ws` message loop — issue #16 council."
     test_agent_hub.py
     test_agent_ws_handshake.py  — "The `/agent/ws` handshake stops carrying the token in the URL — issue #15."
+    test_agent_ws_identity.py  — "An envelope's `executor_id` is a claim; the handshake's is the fact."
     test_api_conventions.py  — "Representative-endpoint compliance for the cross-cutting API rules (issue #12)."
     test_auth.py  — "The mobile credential lifecycle — issue #4."
     test_claude_runner_real_process.py  — "ClaudeRunner against a REAL `claude` subprocess — not the fakes used elsewhere."
@@ -142,6 +144,7 @@ tests/
     test_epics_issues.py  — "Epics and issues — issue #8."
     test_mcp_reminders.py  — "The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
+    test_nodes.py  — "Bridge Node fleet visibility — issue #73 Stage 2."
     test_oauth_authorize.py  — "The browser OAuth form — the *other* caller of the password check."
     test_probes.py  — "Health, readiness and version — issue #3."
     test_project_and_eta_resolution.py  — "`resolve_project_reference` and `estimate_task_duration_seconds`."
@@ -152,6 +155,7 @@ tests/
     test_start_development_task.py  — "The `start_development_task` MCP tool -- the conversational entry point."
     test_store_and_mcp.py
   unit/
+    test_agent_announcement.py  — "The `hello` payload's real content -- issue #73 Stage 2."
     test_agent_auth.py  — "Credential resolution for the `/agent/ws` handshake — issue #15."
     test_agent_auto_project.py  — "`agent.codex_bridge_agent.config.resolve_auto_project` -- the opt-in"
     test_agent_service.py
@@ -166,10 +170,12 @@ tests/
     test_google_calendar.py  — "`gateway.app.services.google_calendar`, without ever touching Google."
     test_instructions.py  — "`resolve_issue_text` and `build_task_instruction`."
     test_main_import.py
+    test_node_store.py  — "`store.ensure_node_for_executor` / `upsert_registry` / `record_node_announcement`"
     test_notify.py  — "`gateway.app.services.notify` -- the task-finished completion email."
     test_policy.py
     test_rate_limiter_bounds.py  — "The limiter's key space must be bounded, or it becomes the resource exhausted."
     test_register_projects.py  — "`scripts/register_projects.py` -- diff-only, never applies anything."
+    test_runner_probe.py  — "`Runner.probe()` and `RunnerPool.probe_all()` -- issue #73 Stage 2."
     test_runner_registry.py  — "The runner abstraction itself: capability declarations and the pool's"
     test_schema_guard.py  — "The guard that refuses to serve a database the code has outgrown."
     test_security.py
@@ -213,9 +219,11 @@ tests/
 > The provider-neutral surface the executor dispatches a task through.
 
 - **`RunningTask`** *(class)* — "A live subprocess plus the control flags `pause`/`cancel`/`restart`"
+- **`EngineProbe`** *(class)* — "The runtime answer to "is this engine's binary actually here, right now"."
 - **`RunnerCapabilities`** *(class)* — "What a provider can and cannot do, declared rather than assumed."
 - **`Runner`** *(class)* — "One provider's implementation of "run this instruction, report back"."
   - `capabilities(self)` *(method)*
+  - `probe(self)` *(async method)*
   - `is_known(self, task_id)` *(method)*
   - `mark_dispatched(self, task_id)` *(method)*
   - `forget(self, task_id)` *(method)*
@@ -234,6 +242,7 @@ tests/
 - **`ClaudeRunner`** *(class)* — "Mirrors `runners.codex.CodexRunner`'s public surface method for method"
   - `__init__(self, settings)` *(method)*
   - `capabilities(self)` *(method)*
+  - `probe(self)` *(async method)* — "Issue #73 Stage 2: is `self.settings.claude_bin` actually here, right now."
   - `is_known(self, task_id)` *(method)*
   - `mark_dispatched(self, task_id)` *(method)*
   - `forget(self, task_id)` *(method)*
@@ -248,6 +257,7 @@ tests/
 - **`CodexRunner`** *(class)*
   - `__init__(self, settings)` *(method)*
   - `capabilities(self)` *(method)*
+  - `probe(self)` *(async method)* — "Issue #73 Stage 2: is `self.settings.codex_bin` actually here, right now."
   - `is_known(self, task_id)` *(method)* — "Whether this runner has any record of the task at all."
   - `mark_dispatched(self, task_id)` *(method)*
   - `forget(self, task_id)` *(method)*
@@ -271,6 +281,7 @@ tests/
   - `pause(self, task_id)` *(async method)*
   - `resume(self, task_id)` *(async method)*
   - `restart(self, task_id)` *(async method)*
+  - `probe_all(self)` *(async method)* — "Issue #73 Stage 2: one `EngineAvailability` for every `KNOWN_ENGINES`"
 
 ### `agent/codex_bridge_agent/runners/registry.py`
 
@@ -443,6 +454,13 @@ tests/
 - `get_mission_timeline(mission_id, response, cursor, limit, principal, session)` *(async function)* — "The mission's recorded events, oldest first — the order a narrative reads in."
 - `cancel_mission(mission_id, response, if_match, idempotency_key, body, principal, session)` *(async function)* — "Cancel a mission that is queued, waiting, running or awaiting approval."
 - `explain_mission(mission_id, principal, session)` *(async function)* — "A structured account of a mission's current state, assembled server-side."
+
+### `gateway/app/api/routes/nodes.py`
+
+> Bridge Nodes — the fleet visibility surface of issue #73, Stage 2.
+
+- `list_nodes_endpoint(principal, session)` *(async function)* — "Every Bridge Node in the fleet, ordered by id."
+- `get_node_detail(node_id, principal, session)` *(async function)* — "One node's fleet status."
 
 ### `gateway/app/api/routes/probes.py`
 
@@ -710,6 +728,10 @@ tests/
 - `create_task(session, request, executor_online, continue_session_id, requested_by_user_id, requested_by_email, can_approve_push)` *(async function)*
 - `mark_executor_connected(session, executor_id, connected)` *(async function)*
 - `executor_is_live(executor)` — "Whether an executor should be presented as connected right now."
+- `ensure_node_for_executor(session, executor)` *(async function)* — "The Bridge Node bound to `executor`, creating and binding one if needed."
+- `record_node_announcement(session, executor, announcement)` *(async function)* — "Persist a HELLO's `NodeAnnouncement` onto the node bound to `executor`."
+- `list_nodes(session)` *(async function)* — "Every Bridge Node, ordered by id, paired with the executor bound to it."
+- `get_node(session, node_id)` *(async function)* — "One Bridge Node and its bound executor, or None if the node does not exist."
 - `next_dispatchable_task(session, executor_id)` *(async function)*
 - `update_task_state(session, task_id, state, error)` *(async function)*
 - `append_log(session, task_id, offset, stream, line)` *(async function)*
@@ -821,6 +843,9 @@ tests/
 - **`BindingState`** *(class)* — "Whether a Project-on-a-Node workspace is usable right now."
 - **`NodeHealth`** *(class)* — "A Bridge Node's operational condition, derived at read time."
 - **`DiscoveryRoot`** *(class)* — "One directory tree a node is configured to scan, and what that grants."
+- **`EngineAvailability`** *(class)* — "Whether one `AgentEngine` can actually run on this node, right now."
+- **`NodeAnnouncement`** *(class)* — "What a node reports about itself when it connects (`hello` payload)."
+- `node_health()` — "Derive a node's health from facts, at read time, never from a column."
 - **`ProjectRegistration`** *(class)*
 - **`ExecutorRegistration`** *(class)*
 - **`DeliveryRequest`** *(class)* — "What the requester authorized the executor to do with git, once a task"
@@ -918,6 +943,23 @@ tests/
 - `test_the_query_parameter_still_works_and_warns(client, caplog)`
 - `test_the_deprecation_warning_does_not_print_the_token(client, caplog)` — "A warning about a leaked credential must not leak it again."
 - `test_the_header_path_logs_no_deprecation_warning(client, caplog)`
+
+### `tests/integration/test_agent_ws_identity.py`
+
+> An envelope's `executor_id` is a claim; the handshake's is the fact.
+
+- **`FakeSocket`** *(class)* — "Just enough `WebSocket` for `agent_ws`: it accepts, sends, and runs dry."
+  - `__init__(self, incoming)` *(method)*
+  - `accept(self)` *(async method)*
+  - `close(self, code)` *(async method)*
+  - `send_json(self, payload)` *(async method)*
+  - `receive_json(self)` *(async method)*
+- `wired(monkeypatch)` *(async function)*
+- `test_a_node_announcing_itself_is_recorded(wired)` *(async function)* — "The honest path, so every refusal below is not passing for want of wiring."
+- `test_a_node_cannot_announce_on_another_nodes_behalf(wired)` *(async function)* — "The exploit: authenticate as one node, claim to be another."
+- `test_the_forged_envelope_is_dropped_not_redirected(wired)` *(async function)* — "Rewriting the claimed id to the authenticated one would be worse."
+- `test_a_forged_heartbeat_does_not_refresh_another_nodes_liveness(wired)` *(async function)* — "Liveness feeds `node_health`, so forging it forges the fleet's health."
+- `test_the_connection_survives_a_forged_envelope(wired)` *(async function)* — "Dropping the message must not drop the socket."
 
 ### `tests/integration/test_api_conventions.py`
 
@@ -1260,6 +1302,34 @@ tests/
 - `test_explain_on_a_blocked_mission_reports_it(api)` *(async function)*
 - `test_explain_of_an_invisible_mission_is_not_found(api)` *(async function)*
 
+### `tests/integration/test_nodes.py`
+
+> Bridge Node fleet visibility — issue #73 Stage 2.
+
+- `users_file(tmp_path)`
+- `api(users_file, monkeypatch)` *(async function)* — "A real app over a real database, seeded with one executor -> one node."
+- `mark_live(factory, executor_id)` *(async function)*
+- `set_last_seen(factory, executor_id, when)` *(async function)*
+- `set_node_enabled(factory, node_id, enabled)` *(async function)*
+- `set_capabilities_observed_at(factory, node_id, when)` *(async function)*
+- `announce(factory, executor_id, **overrides)` *(async function)*
+- `auth(token)`
+- `test_nodes_require_a_token(api)` *(async function)*
+- `test_an_expired_token_is_refused(api)` *(async function)*
+- `test_a_token_without_the_admin_scope_is_forbidden(api)` *(async function)*
+- `test_a_token_with_no_scopes_at_all_is_forbidden(api)` *(async function)*
+- `test_an_unknown_node_id_is_not_found(api)` *(async function)*
+- `test_list_returns_the_seeded_node(api)` *(async function)*
+- `test_detail_returns_the_seeded_node(api)` *(async function)*
+- `test_health_is_unknown_when_the_node_has_never_been_seen(api)` *(async function)*
+- `test_health_is_offline_when_last_seen_is_older_than_the_reconnect_grace(api)` *(async function)*
+- `test_health_is_degraded_when_live_but_disabled(api)` *(async function)*
+- `test_health_is_ok_when_live_and_enabled(api)` *(async function)*
+- `test_inventory_is_stale_before_any_announcement(api)` *(async function)*
+- `test_inventory_is_not_stale_right_after_an_announcement(api)` *(async function)*
+- `test_a_stale_capabilities_observed_at_is_reported_stale(api)` *(async function)*
+- `test_no_absolute_path_leaks_after_an_announcement(api)` *(async function)* — "`docs/api/README.md` "fields that must never ship" excludes absolute"
+
 ### `tests/integration/test_oauth_authorize.py`
 
 > The browser OAuth form — the *other* caller of the password check.
@@ -1500,6 +1570,14 @@ tests/
 - `test_mcp_continue_codex_session_dispatches_to_a_connected_idle_executor(mcp_hub_factory)` *(async function)* — "Issue #24: unlike its sibling `submit_codex_task` (same file), this"
 - `test_mcp_continue_codex_session_leaves_task_queued_when_the_executor_is_offline(mcp_hub_factory)` *(async function)* — "No regression on the pre-existing (disconnected) case: an offline"
 - `test_mcp_continue_codex_session_at_capacity_does_not_dispatch(mcp_hub_factory)` *(async function)* — "A connected executor already at its concurrency limit must not be sent"
+
+### `tests/unit/test_agent_announcement.py`
+
+> The `hello` payload's real content -- issue #73 Stage 2.
+
+- `test_hello_envelope_validates_as_node_announcement_with_derived_capabilities(monkeypatch, allow_workspace_write, allow_git_delivery, expected_present, expected_absent)` *(async function)*
+- `test_hello_envelope_carries_os_and_arch_but_never_the_hostname(monkeypatch)` *(async function)* — "Issue #73: node identity must not be inferred from mutable hostname --"
+- `test_build_announcement_falls_back_to_minimal_payload_when_probing_raises(monkeypatch)` *(async function)* — "`_build_announcement` must never cost the connection. If anything"
 
 ### `tests/unit/test_agent_auth.py`
 
@@ -1745,6 +1823,17 @@ tests/
 
 - `test_main_app_imports()`
 
+### `tests/unit/test_node_store.py`
+
+> `store.ensure_node_for_executor` / `upsert_registry` / `record_node_announcement`
+
+- `db_session()` *(async function)*
+- `test_ensure_node_for_executor_creates_and_binds_when_node_id_is_null(db_session)` *(async function)*
+- `test_ensure_node_for_executor_is_idempotent(db_session)` *(async function)*
+- `test_upsert_registry_produces_a_node_for_a_newly_added_executor(db_session)` *(async function)*
+- `test_record_node_announcement_writes_observation_fields(db_session)` *(async function)*
+- `test_record_node_announcement_leaves_enabled_health_reason_and_authorizations_untouched(db_session)` *(async function)* — "An announcement is an observation, never a grant (issue #73)."
+
 ### `tests/unit/test_notify.py`
 
 > `gateway.app.services.notify` -- the task-finished completion email.
@@ -1796,6 +1885,18 @@ tests/
 - `test_cli_writes_only_the_report_when_out_is_given(tmp_path)`
 - `test_cli_requires_at_least_one_target_file(tmp_path)`
 - `test_cli_rejects_user_id_without_user_registry_file(tmp_path)`
+
+### `tests/unit/test_runner_probe.py`
+
+> `Runner.probe()` and `RunnerPool.probe_all()` -- issue #73 Stage 2.
+
+- `test_probe_reports_unavailable_when_binary_not_on_path(monkeypatch, runner_cls, bin_field)` *(async function)*
+- `test_probe_reports_available_and_the_parsed_version(monkeypatch, runner_cls, bin_field)` *(async function)*
+- `test_probe_survives_oserror_without_raising(monkeypatch, runner_cls, bin_field)` *(async function)*
+- `test_probe_survives_a_timeout_without_raising(monkeypatch, runner_cls, bin_field, timeout_module)` *(async function)*
+- `test_probe_detail_never_carries_the_configured_binary_path(monkeypatch, runner_cls, bin_field)` *(async function)* — "`detail` is meant to explain a probe failure to an operator, never to"
+- `test_probe_all_returns_one_entry_per_known_engine()` *(async function)*
+- `test_probe_all_survives_one_runner_raising()` *(async function)*
 
 ### `tests/unit/test_runner_registry.py`
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -124,3 +124,73 @@ ver `docs/api/README.md`, "Fields that must never ship".
   associação executor↔projeto de fato mora, dentro de `executors.metadata_json`)
   e não é exprimível em SQL portável. A remoção é migration posterior, depois de
   bindings verificados em produção.
+
+## Stage 2 — visibilidade de frota
+
+Stage 1 criou o vocabulário; a Stage 2 o preenche com observação. A pergunta que
+ela responde é a primeira da #73: *"que nós eu tenho, e quais estão utilizáveis?"*
+
+### O nó anuncia, o gateway observa
+
+Quando o agente conecta, o `hello` — que até aqui carregava `{"version":
+"0.1.0"}` e era **ignorado pelo gateway** — passa a carregar um
+`NodeAnnouncement`. O gateway o valida, carimba `capabilities_observed_at` e
+grava em `nodes`. Três propriedades desse desenho não são detalhe:
+
+**O anúncio não tem identidade.** Não existe campo `node_id` no payload. O nó é
+aquele para o qual o `executor_id` autenticado aponta. A #73 exige que a
+identidade *"sobreviva a reconexões e não seja inferida de hostname/IP
+mutáveis"*; aceitar um id declarado pelo próprio nó abriria, além disso, o
+caminho para um nó reivindicar a linha de outro — que é a falha
+anúncio-como-autorização que a issue nomeia.
+
+**O anúncio não concede nada.** `capabilities` no payload é o que a
+*configuração daquela máquina* permitiria (`allow_workspace_write`,
+`allow_git_delivery`), não o que ele pode fazer a um projeto. Isso continua em
+`project_authorizations`, escrito pelo operador. `record_node_announcement` não
+toca `enabled`, `health_reason` nem tabela de autorização alguma.
+
+**O anúncio é datado.** Fica gravado *quando* foi observado, e a rota devolve
+`inventory_stale`. A #73 pede que *"informação offline/obsoleta seja
+visivelmente distinguida de observação corrente"* — sem o carimbo, um inventário
+de três semanas atrás é indistinguível de um de agora.
+
+### Três fatos diferentes sob a palavra "engine"
+
+`EngineAvailability` separa o que seria tentador fundir:
+
+| campo | o que afirma | quando muda |
+|---|---|---|
+| `implemented` | existe um `Runner` no código para esse engine | numa release |
+| `available` | o binário respondeu **nesta** máquina | ao instalar/remover a CLI |
+| `version` | o que o binário disse de si | ao atualizar a CLI |
+
+Fundir os dois primeiros num só booleano apaga justamente os dois casos que o
+operador precisa ver: engine que este build suporta mas esta máquina não tem
+(*instale*) e engine presente na máquina que nenhum runner sabe dirigir (*falta
+código*). São problemas diferentes, com donos diferentes.
+
+`Runner.probe()` é medição, não declaração — e por isso **nunca levanta
+exceção**: um probe que estoura impediria o nó de conectar, e um nó invisível é
+pior que um nó com um engine marcado indisponível.
+
+### Saúde é derivada, nunca coluna
+
+`shared.protocol.node_health` é a única derivação, e a ordem dos testes importa:
+
+- nunca visto → `unknown` (não `offline`: "nunca conectou" e "esteve aqui e
+  sumiu" são problemas distintos, com correções distintas);
+- visto, mas fora da janela de graça → `offline`;
+- vivo, porém desabilitado ou com `health_reason` → `degraded`;
+- vivo e habilitado → `ok`.
+
+Um nó desligado lê `offline`, não `degraded`: chamar de degradada uma máquina
+que está simplesmente apagada inventa um incidente. Nada disso é persistido —
+reinício de gateway não pode deixar um nó afirmando saúde que ninguém remediu.
+
+### Caminho nenhum sai daqui
+
+O anúncio carrega `discovery_root_count`, um número, não as raízes. A pergunta
+de frota é *"este nó está configurado para descobrir alguma coisa?"*, e um
+contador a responde sem publicar o layout de disco da máquina em todo cliente.
+Vale a mesma regra da seção "Caminho absoluto" acima.

--- a/docs/issues/073-codexbridge-control/RESUME.md
+++ b/docs/issues/073-codexbridge-control/RESUME.md
@@ -1,21 +1,31 @@
-# RESUME — WK-20260901-gh73-control-plane-domain (epic #73)
+# RESUME — WK-20260901-gh73-fleet-visibility (epic #73)
 
-- work_id: WK-20260901-gh73-control-plane-domain
+- work_id: WK-20260901-gh73-fleet-visibility
 - data: 2026-09-01
-- branch: `feature/gh-73/control-plane-domain` (commit `13583f8`), worktree
-  `../CodexBridge--gh-73-control`. Pushed; **PR #74** open against
-  `development`. NOT merged.
+- Stage 1: **PR #74 merged** into `development` as `80e5d2f`.
+- Stage 2: branch `feature/gh-73/fleet-visibility` (commit `2ed550f`), worktree
+  `../CodexBridge--gh-73-control`. Pushed; **PR #75** open. NOT merged.
 
 ## Next Step (DO THIS FIRST)
 
-Start Stage 2 (fleet visibility: node discovery, `Runner.probe()`, gateway
-handshake, `/nodes` routes) on a branch cut from
-`feature/gh-73/control-plane-domain` — do not wait for PR #74 to merge, but
-rebase Stage 2 if review changes the Stage 1 schema.
+Start Stage 3 (project discovery and adoption: scan the configured roots,
+correlate candidates, write `discovered_resources`, and the adopt/ignore
+decision) on a branch cut from `feature/gh-73/fleet-visibility`. Stage 2 left
+the node reporting only a `discovery_root_count`; Stage 3 is what makes the
+roots produce rows.
 
 ## Current state
 
-- Stage 1 (domain and contracts) delivered on the branch: migration
+- Stage 2 (fleet visibility) delivered on `feature/gh-73/fleet-visibility`:
+  `NodeAnnouncement` on the `hello` message, `Runner.probe()` +
+  `RunnerPool.probe_all()`, `store.record_node_announcement`, and
+  `GET /api/v1/nodes` + `/{id}` with health derived by
+  `shared.protocol.node_health`. No migration — Stage 1's columns sufficed.
+- A **security fix** rode along: the websocket receive loop trusted
+  `AgentEnvelope.executor_id` (client-written) instead of the id authenticated
+  at the handshake, so a node could announce itself as another node or forge
+  another node's liveness. Guard now sits once, before the dispatch.
+- Stage 1 (domain and contracts) merged as `80e5d2f`: migration
   `0009_control_plane.sql`, entities, `schema_guard` entries, and the
   `Capability` vocabulary in `shared/protocol.py`, documented in
   `docs/control-plane.md`.
@@ -33,7 +43,10 @@ rebase Stage 2 if review changes the Stage 1 schema.
 
 ## Checks
 
-- `pytest -q` → 757 passed, 7 skipped (branch baseline was 746/7).
+- `pytest -q` → **799 passed, 7 skipped** (Stage 2; branch baseline 757/7).
+- The two identity-exploit tests were verified failing against the pre-fix
+  source (vulnerable lines restored by file copy, not `git stash`).
+- Stage 1: 757 passed, 7 skipped (baseline was 746/7).
 - `0009` applied against SQLite **and** a real PostgreSQL 16 (throwaway
   container, removed afterwards; no other project's Postgres touched).
 - Three mutations proved the tests bite: widening `Capability.READ` to include
@@ -55,5 +68,14 @@ rebase Stage 2 if review changes the Stage 1 schema.
 
 ## NOT validated
 
-No deploy. `0009` never applied to any real gateway database. No gateway/agent
-runtime code consumes the new tables yet. PR #74 not reviewed.
+No deploy. `0009` never applied to any real gateway database. No real agent has
+connected to a real gateway with the Stage 2 build. `inventoryObservedAt` is
+exposed but reserved for Stage 3 and stays `null`. `GET /api/v1/nodes` is
+unpaginated. Contract is at 1.9.0 and collides by design with PRs #61/#62.
+
+## Watch for
+
+Stage 2 was implemented by two subagents sharing ONE worktree; one ran `git
+stash` and transiently reverted the other's uncommitted work. Give each agent
+its own worktree, or forbid repository-wide git commands in the prompt — see
+`docs/napkin-lessons.md`, 2026-09-01.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1268,3 +1268,65 @@ estrita colidem por construção. Ao usar `awt` num projeto novo, rodar a suíte
 **antes** de escrever qualquer linha de código — o primeiro `pytest` verde é o
 que separa "quebrei agora" de "nasceu quebrado". E o conflito é do kit, não do
 projeto: vale ticket lá, não `extra="ignore"` aqui.
+
+## 2026-09-01 — a correção de confiança vive antes do despacho, não dentro de um branch
+
+A #16 já tinha corrigido, no `task.ack`, a confiança no `executor_id` que vem
+**dentro** do envelope em vez do autenticado no handshake. A correção ficou
+dentro daquele branch do `if/elif`. Todo tipo de mensagem acrescentado depois —
+`hello` da Stage 2 inclusive — herdou a confiança de novo, e a revisão
+adversarial reproduziu o exploit: um nó autenticado anunciando-se **como
+outro**, forjando capacidades alheias e renovando a liveness de um nó morto.
+
+Lição: quando a correção é "não confie neste campo", ela pertence ao ponto onde
+a mensagem entra, uma vez, antes do despacho — não ao branch onde o problema foi
+notado. Uma guarda por branch é uma guarda que o próximo branch não tem, e o
+próximo branch é escrito por quem não leu a issue que motivou a primeira. Vale o
+teste de leitura: *se eu acrescentar um tipo de mensagem amanhã, ele nasce
+seguro?* Se a resposta depender de alguém lembrar, a guarda está no lugar
+errado.
+
+Corolário sobre descartar vs. redirecionar: reescrever o id reivindicado para o
+autenticado "conserta" o sintoma e aceita, em silêncio, como declaração do
+remetente, uma mensagem que ele não fez sobre si. Descartar é a única leitura
+honesta — e descartar sem derrubar a conexão, porque derrubar transformaria
+agente com bug em interrupção.
+
+## 2026-09-01 — teste negativo que passa porque nada rodou
+
+Os primeiros testes de identidade no websocket passaram de cara. Passavam porque
+o handshake morria antes do laço de recepção: o `AgentHub` foi construído no
+import com a `SessionLocal` de produção e guarda a própria referência, então
+trocar `main.SessionLocal` não alcançava o `hub.register`, que estourava
+`unknown_executor`. A asserção "a linha da vítima não mudou" é verdadeira também
+quando **nenhuma** mensagem foi processada.
+
+Lição: todo teste negativo precisa de um controle positivo no mesmo arquivo —
+uma asserção que só passa se o caminho realmente executou. Aqui foi o teste do
+caminho honesto (`o nó anuncia a si mesmo e é gravado`) mais um `assert
+socket.accepted` no helper. Sem ele, cinco testes verdes provavam apenas que o
+código estava inalcançável.
+
+Segundo achado do mesmo episódio: `TestClient.websocket_connect` roda a app em
+outra thread e outro event loop; compartilhar um engine aiosqlite em memória
+entre os dois trava. Chamar `agent_ws` direto com um socket falso, no loop do
+próprio teste, é determinístico e ainda torna a espera desnecessária — quando o
+`await` volta, o laço acabou.
+
+## 2026-09-01 — dois subagentes num worktree só, e `git stash` como estado compartilhado
+
+Dois agentes implementaram metades da Stage 2 em paralelo **no mesmo worktree**,
+com listas de arquivos disjuntas — o que pareceu suficiente e não era. Um deles,
+para provar que seus testes falhavam contra o código original, rodou `git
+stash`: um comando de escopo *repositório*, não de escopo *arquivo*. Reverteu
+edições não-commitadas do outro agente e do próprio operador, e o `stash pop`
+deu conflito num arquivo já reescrito nesse meio-tempo. A recuperação foi
+manual, e o único motivo de nada ter se perdido é que o snapshot do stash ainda
+existia.
+
+Lição: paralelizar por arquivo só é seguro se as ferramentas também forem por
+arquivo. `git stash`, `git checkout .`, `git restore`, `git clean` agem no
+repositório inteiro e não têm como respeitar uma divisão de escopo que existe só
+no prompt. Ou se dá um worktree por agente, ou se proíbe explicitamente esses
+comandos no prompt e se verifica mutação copiando o arquivo (`cp` e restaura),
+que foi como a prova acabou sendo feita aqui.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -99,6 +99,39 @@ Mensagens (`AgentMessageType` em `shared/protocol.py`):
 Não existe mensagem `task.progress`. O progresso é inferido pelo fluxo de
 `task.log`, cada uma com `offset` incremental.
 
+### Payload do `hello`: `NodeAnnouncement`
+
+Até a Stage 2 da #73 o `hello` levava `{"version": "0.1.0"}` e o gateway **não
+tinha branch para ele** — a mensagem era persistida como recibo e descartada.
+Agora ela carrega um `NodeAnnouncement` (`shared/protocol.py`):
+
+```json
+{
+  "agent_version": "0.1.0",
+  "os": "Linux",
+  "arch": "x86_64",
+  "engines": [
+    {"engine": "codex",  "implemented": true,  "available": true,  "version": "codex-cli 1.4.2"},
+    {"engine": "claude", "implemented": true,  "available": false, "detail": "not found on PATH"},
+    {"engine": "gemini", "implemented": false, "available": false, "detail": "no runner implemented"}
+  ],
+  "capabilities": ["read", "test"],
+  "max_concurrent_tasks": 1,
+  "discovery_root_count": 1
+}
+```
+
+Sem `node_id`: o nó é aquele para o qual o `executor_id` autenticado aponta. Sem
+caminho: `discovery_root_count` é contagem, não as raízes. `capabilities` é o que
+a configuração da máquina permitiria, nunca uma concessão sobre projeto — ver
+`docs/control-plane.md`.
+
+**Compatibilidade:** um agente de release anterior segue enviando `{"version":
+...}`. O gateway lê essa forma como `agent_version` e um payload que não valide
+gera `WARNING` e **não derruba a conexão** — um gateway que desliga o agente da
+release anterior transforma deploy em interrupção.
+
+
 Campos comuns:
 
 * `message_id`
@@ -106,6 +139,27 @@ Campos comuns:
 * `sent_at`
 * `type`
 * `payload`
+
+## Identidade: o handshake manda, o envelope não
+
+`AgentEnvelope.executor_id` é campo que o **cliente escreve** no corpo da
+mensagem; o `executor_id` do `/agent/ws` é o que apresentou token de máquina no
+handshake. O laço de recepção compara os dois **antes** de despachar e descarta
+o envelope quando divergem, com `WARNING`.
+
+A verificação vive num ponto só, e não em cada branch, por histórico: a #16 já
+tinha corrigido isso para `task.ack` isoladamente, e todo tipo de mensagem
+acrescentado depois herdou a confiança de novo. Sem a guarda, um nó autenticado
+podia anunciar-se **como outro** — forjando as capacidades relatadas de uma
+máquina alheia, ou renovando a liveness dela para que um nó morto aparecesse
+saudável, que é exatamente a superfície de frota que a Stage 2 existe para
+tornar confiável.
+
+Descartar, não redirecionar: reescrever o id reivindicado para o autenticado
+aceitaria em silêncio, como declaração do remetente, uma mensagem que ele não
+fez sobre si. E descartar não derruba a conexão — derrubar transformaria um
+agente com bug em interrupção, e daria a um atacante um jeito de desconectar
+um nó.
 
 ## Idempotência
 

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -190,6 +190,17 @@ MISSIONS_READ_ALL_PROJECTS = Action(
     summary="See missions in every project, not only the actor's own.",
 )
 
+# Issue #73 Stage 2: Bridge Nodes are fleet-wide, not scoped to a project --
+# there is no per-node visible-projects filter the way `PROJECTS_READ` has, so
+# this follows `SESSIONS_READ_ALL_PROJECTS`/`MISSIONS_READ_ALL_PROJECTS` and is
+# administrative rather than a new scope of its own.
+NODES_READ = Action(
+    name="nodes.read",
+    category=ADMINISTRATIVE,
+    scope=ADMIN_SCOPE,
+    summary="List Bridge Nodes and read one, across the whole fleet.",
+)
+
 EPICS_READ = Action(
     name="epics.read",
     category=READ,
@@ -281,6 +292,7 @@ CATALOGUE: tuple[Action, ...] = (
     DECISIONS_READ,
     DECISIONS_DECIDE,
     MISSIONS_READ_ALL_PROJECTS,
+    NODES_READ,
 )
 
 

--- a/gateway/app/api/routes/nodes.py
+++ b/gateway/app/api/routes/nodes.py
@@ -1,0 +1,142 @@
+"""Bridge Nodes — the fleet visibility surface of issue #73, Stage 2.
+
+A **node** is a `NodeModel` row: a registered CodexBridge installation, distinct
+from the `ExecutorModel` connection that carries work to it (see `NodeModel`'s
+own docstring in `gateway/app/models/entities.py`). This module reports what a
+node last announced about itself plus the liveness of its bound executor —
+never the filesystem paths or hostnames `docs/api/README.md` ("Fields that must
+never ship") excludes from every response. `discovery_root_count` exists
+precisely so this surface can answer "does this node discover anything at all"
+without a single path ever crossing the wire.
+
+## Health is derived, not stored
+
+Same posture as `routes/projects.py`: `NodeModel` carries no health column.
+`health` is computed at read time by `shared.protocol.node_health`, fed by
+`store.executor_is_live` (liveness) and `executor.last_seen_at is not None`
+("ever seen"). See that function's docstring for why the ordering of its checks
+matters.
+
+## An announcement is an observation, not a grant
+
+`capabilities`/`engines`/`maxConcurrentTasks`/`discoveryRootCount` all come
+from the node's own last HELLO (`store.record_node_announcement`) and say only
+what the node *reports itself capable of* — never what it is authorized to do
+to any given project. That authorization lives in `project_authorizations`,
+which this surface does not read or expose (issue #73: "a node cannot grant
+itself project authorization merely by reporting a discovery").
+
+## Authorization
+
+Fleet-wide, not per-project — a node is not owned by one project the way a
+session or a mission is — so both routes are guarded by the one administrative
+`permissions.NODES_READ` action rather than the `visible_projects` scoping
+`routes/projects.py` applies. An unknown node id is `404 not_found`, the same
+"do not confirm what the caller cannot see" rule every other resource on this
+surface follows, even though here there is no project scope that could hide it
+— the id is simply not present.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.app.api import permissions, timestamps
+from gateway.app.api.auth import require_action
+from gateway.app.api.errors import NOT_FOUND, ApiError
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.session import get_session
+from gateway.app.models.entities import ExecutorModel, NodeModel
+from gateway.app.services import store
+from shared.protocol import node_health
+
+
+router = APIRouter(prefix="/api/v1")
+
+# Inventory freshness needs a longer window than connection liveness.
+# `settings.reconnect_grace_seconds` (120s) is sized to the agent's 15s
+# heartbeat interval and would mark a node's inventory stale between two
+# ordinary heartbeats — a `NodeAnnouncement` is sent once per connection (on
+# HELLO), not on every heartbeat the way `last_seen_at` is refreshed. Issue
+# #73/#42 ask only that stale inventory be "visibly marked", not for a
+# specific window, so this is a deliberately generous, module-level constant
+# rather than a new setting (the task explicitly rules that out — the operator
+# has no reason to tune this independently of the reconnect grace yet).
+INVENTORY_STALE_AFTER_SECONDS = 24 * 60 * 60
+
+
+def _not_found() -> ApiError:
+    return ApiError(status_code=404, code=NOT_FOUND, message="No such node.")
+
+
+def _iso(value: datetime | None) -> str | None:
+    return timestamps.utc_z(value)
+
+
+def _is_stale(observed_at: datetime | None, *, now: datetime) -> bool:
+    if observed_at is None:
+        return True
+    if observed_at.tzinfo is None:
+        observed_at = observed_at.replace(tzinfo=timezone.utc)
+    return (now - observed_at).total_seconds() > INVENTORY_STALE_AFTER_SECONDS
+
+
+def _node_dto(node: NodeModel, executor: ExecutorModel | None) -> dict:
+    """The fleet DTO for one node. Never a filesystem path — see module docstring."""
+    live = executor is not None and store.executor_is_live(executor)
+    ever_seen = executor is not None and executor.last_seen_at is not None
+    health = node_health(live=live, enabled=node.enabled, ever_seen=ever_seen, health_reason=node.health_reason)
+    inventory = json.loads(node.capabilities_json or "{}")
+    now = datetime.now(timezone.utc)
+    return {
+        "id": node.id,
+        "displayName": node.display_name,
+        "enabled": node.enabled,
+        "health": health.value,
+        "healthReason": node.health_reason,
+        "lastSeenAt": _iso(executor.last_seen_at) if executor is not None else None,
+        "agentVersion": node.agent_version,
+        "os": node.os,
+        "arch": node.arch,
+        "capabilities": inventory.get("capabilities", []),
+        "engines": inventory.get("engines", []),
+        "maxConcurrentTasks": inventory.get("max_concurrent_tasks"),
+        "discoveryRootCount": inventory.get("discovery_root_count"),
+        "capabilitiesObservedAt": _iso(node.capabilities_observed_at),
+        "inventoryObservedAt": _iso(node.inventory_observed_at),
+        "inventoryStale": _is_stale(node.capabilities_observed_at, now=now),
+    }
+
+
+@router.get("/nodes", tags=["nodes"])
+async def list_nodes_endpoint(
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Every Bridge Node in the fleet, ordered by id.
+
+    Not paginated: the fleet, like the executor registry it is seeded from, is
+    operator-curated and expected to hold a handful of machines, the same
+    reasoning `store.executors_by_project` documents for reading the whole
+    registry in one pass.
+    """
+    rows = await store.list_nodes(session)
+    return {"items": [_node_dto(node, executor) for node, executor in rows]}
+
+
+@router.get("/nodes/{node_id}", tags=["nodes"])
+async def get_node_detail(
+    node_id: str,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """One node's fleet status."""
+    row = await store.get_node(session, node_id)
+    if row is None:
+        raise _not_found()
+    node, executor = row
+    return _node_dto(node, executor)

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -67,7 +67,7 @@ version_router = APIRouter()
 # an optional `reason` field on its request body, recorded on the mission's
 # timeline. Additive only (new optional field; an existing client sending no
 # body is unaffected), so another minor bump.
-API_CONTRACT_VERSION = "1.6.0"
+API_CONTRACT_VERSION = "1.9.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -7,12 +7,13 @@ from datetime import datetime, timezone
 
 from fastapi import Depends, FastAPI, Form, Header, HTTPException, Request, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.app.api.idempotency import purge_expired
 from gateway.app.api.rate_limit import RateLimitDependency, client_key
 from gateway.app.api.routes import auth as auth_routes
-from gateway.app.api.routes import decisions, missions, probes, projects, sessions
+from gateway.app.api.routes import decisions, missions, nodes as nodes_routes, probes, projects, sessions
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
@@ -47,7 +48,7 @@ from gateway.app.services import metrics, store
 from gateway.app.services.audit import record_event
 from gateway.app.services.agent_hub import AgentHub
 from gateway.app.services.notify import notify_task_finished
-from shared.protocol import EXECUTOR_TOKEN_HEADER, AgentEnvelope, AgentMessageType, TaskState
+from shared.protocol import EXECUTOR_TOKEN_HEADER, AgentEnvelope, AgentMessageType, NodeAnnouncement, TaskState
 from shared.security import sanitize_log_line, secure_compare
 
 
@@ -137,6 +138,11 @@ app.include_router(issues_routes.router, dependencies=[Depends(RateLimitDependen
 # projects, sessions/decisions/missions and issues. Same limiter, same
 # authorization plumbing as epics and issues above.
 app.include_router(conversations_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# Bridge Node fleet visibility (issue #73, Stage 2). Same limiter; guarded by
+# the fleet-wide `permissions.NODES_READ` action rather than the
+# project-scoped `visible_projects` pattern the routers above use.
+app.include_router(nodes_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 
 
 def oauth_www_authenticate_header() -> str:
@@ -779,11 +785,62 @@ async def agent_ws(
         while True:
             raw = await websocket.receive_json()
             envelope = AgentEnvelope.model_validate(raw)
+            if envelope.executor_id != executor_id:
+                # `envelope.executor_id` is a field the CLIENT writes into the
+                # message body. `executor_id` is the one that presented a
+                # machine token at the handshake. Believing the first let any
+                # connected node write another node's row -- forging its
+                # reported capabilities, or refreshing its liveness so a dead
+                # node reads healthy -- which is precisely the fleet surface
+                # #73 Stage 2 exists to make trustworthy.
+                #
+                # The guard lives here, once, rather than in each branch: #16
+                # already fixed this for `task.ack` alone (`handle_task_ack`),
+                # and the branches added since inherited the same trust. One
+                # check before the dispatch means the next message type cannot
+                # reintroduce it.
+                logging.getLogger(__name__).warning(
+                    "executor %s sent an envelope claiming executor_id %s; dropping it",
+                    sanitize_log_line(executor_id),
+                    sanitize_log_line(envelope.executor_id),
+                )
+                continue
             async with SessionLocal() as session:
                 is_new = await store.store_message_receipt(session, envelope.message_id, envelope.executor_id, envelope.type.value)
                 if not is_new:
                     continue
-                if envelope.type == AgentMessageType.HEARTBEAT:
+                if envelope.type == AgentMessageType.HELLO:
+                    # Issue #73 Stage 2. Backward compatibility matters here: an
+                    # agent from before this change sends `{"version": "0.1.0"}`,
+                    # which validates as a `NodeAnnouncement` only by accident
+                    # (Pydantic ignores the unknown key and every field has a
+                    # default) -- so the old shape is handled explicitly rather
+                    # than left to that accident: `version` is read as
+                    # `agent_version` when the payload carries no `agent_version`
+                    # of its own. A HELLO that still fails validation after that
+                    # rewrite is logged and the loop CONTINUES: a gateway that
+                    # hangs up on the previous agent release turns a deploy into
+                    # an outage, so this branch must never close the socket or
+                    # raise out of the receive loop.
+                    payload = dict(envelope.payload)
+                    if "version" in payload and "agent_version" not in payload:
+                        payload["agent_version"] = payload.pop("version")
+                    try:
+                        announcement = NodeAnnouncement.model_validate(payload)
+                    except ValidationError:
+                        logging.getLogger(__name__).warning(
+                            "executor %s sent a HELLO payload that failed NodeAnnouncement "
+                            "validation; ignoring it and keeping the connection open",
+                            envelope.executor_id,
+                        )
+                    else:
+                        # The authenticated id, never the claimed one -- the
+                        # guard at the top of the loop has already refused any
+                        # envelope where they differ.
+                        hello_executor = await session.get(store.ExecutorModel, executor_id)
+                        if hello_executor is not None:
+                            await store.record_node_announcement(session, hello_executor, announcement)
+                elif envelope.type == AgentMessageType.HEARTBEAT:
                     await store.mark_executor_connected(session, envelope.executor_id, True)
                 elif envelope.type == AgentMessageType.TASK_ACK:
                     await handle_task_ack(session, envelope)

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -17,6 +17,7 @@ from gateway.app.models.entities import (
     ExecutorModel,
     IssueModel,
     MessageReceiptModel,
+    NodeModel,
     OAuthAccessTokenModel,
     OAuthAuthorizationCodeModel,
     OAuthRefreshTokenModel,
@@ -46,6 +47,7 @@ from shared.protocol import (
     DEFAULT_CANCEL_REPLAY_MAX_AGE_SECONDS,
     DEFAULT_CONTROL_REPLAY_MAX_AGE_SECONDS,
     ExecutorRegistration,
+    NodeAnnouncement,
     PolicyLevel,
     ProjectRegistration,
     STOPPABLE_TASK_STATES,
@@ -77,19 +79,24 @@ async def upsert_registry(
         current = await session.get(ExecutorModel, executor.executor_id)
         metadata_json = json.dumps(executor.model_dump(mode="json"), ensure_ascii=True)
         if current is None:
-            session.add(
-                ExecutorModel(
-                    id=executor.executor_id,
-                    display_name=executor.display_name,
-                    enabled=executor.enabled,
-                    connected=False,
-                    metadata_json=metadata_json,
-                )
+            current = ExecutorModel(
+                id=executor.executor_id,
+                display_name=executor.display_name,
+                enabled=executor.enabled,
+                connected=False,
+                metadata_json=metadata_json,
             )
+            session.add(current)
         else:
             current.display_name = executor.display_name
             current.enabled = executor.enabled
             current.metadata_json = metadata_json
+        # Issue #73 Stage 2: every registry executor gets a Bridge Node row.
+        # `0009_control_plane.sql` seeded one per executor that existed at
+        # migration time; without this call, an executor added to
+        # `registry.json` afterwards would have no node and be invisible to
+        # the fleet surface. See `ensure_node_for_executor`'s docstring.
+        await ensure_node_for_executor(session, current)
     for project in projects:
         current = await session.get(ProjectModel, project.project_id)
         config_json = json.dumps(project.model_dump(mode="json"), ensure_ascii=True)
@@ -497,6 +504,120 @@ def executor_is_live(
     grace = settings.reconnect_grace_seconds if grace_seconds is None else grace_seconds
     now = now or datetime.now(timezone.utc)
     return (now - _as_utc(executor.last_seen_at)) <= timedelta(seconds=grace)
+
+
+async def ensure_node_for_executor(session: AsyncSession, executor: ExecutorModel) -> NodeModel:
+    """The Bridge Node bound to `executor`, creating and binding one if needed.
+
+    `migrations/0009_control_plane.sql` seeded a node 1:1 for every executor
+    that existed *at migration time* and backfilled `executors.node_id` for
+    all of them. An executor added to `registry.json` afterwards has no such
+    row -- `upsert_registry` calls this for every executor on every reload so
+    a node added later is never invisible to the fleet surface (issue #73).
+
+    Mirrors exactly what that migration did for the rows it seeded: the
+    node's id is the executor's id, `display_name` and `enabled` start as the
+    executor's own. Idempotent -- an executor whose `node_id` is already set
+    returns that node unchanged, and calling this twice for the same executor
+    creates nothing the second time.
+
+    Does not commit. Callers (`upsert_registry`, `record_node_announcement`)
+    commit their own transaction; this only stages the insert/association so
+    it composes inside either one without an extra round trip.
+    """
+    if executor.node_id is not None:
+        node = await session.get(NodeModel, executor.node_id)
+        if node is not None:
+            return node
+    node = await session.get(NodeModel, executor.id)
+    if node is None:
+        node = NodeModel(
+            id=executor.id,
+            display_name=executor.display_name,
+            enabled=executor.enabled,
+            created_at=datetime.now(timezone.utc),
+        )
+        session.add(node)
+    executor.node_id = node.id
+    return node
+
+
+async def record_node_announcement(
+    session: AsyncSession,
+    executor: ExecutorModel,
+    announcement: NodeAnnouncement,
+    *,
+    now: datetime | None = None,
+) -> NodeModel:
+    """Persist a HELLO's `NodeAnnouncement` onto the node bound to `executor`.
+
+    This is an OBSERVATION, never a grant. It never touches `enabled`,
+    `health_reason`, or any row in `project_authorizations` -- issue #73 is
+    explicit that "a node cannot grant itself project authorization merely by
+    reporting a discovery", and those three are exactly the columns/tables an
+    operator (or a standing discovery-root grant) writes, not the node itself.
+
+    `capabilities_json` stores the announcement's `capabilities`, `engines`,
+    `max_concurrent_tasks` and `discovery_root_count` as one JSON object --
+    matching `NodeModel.capabilities_json`'s existing shape, no migration
+    needed. `capabilities_observed_at` is set to `now` so staleness can be
+    derived at read time the same way `executor_is_live` derives connection
+    staleness from `last_seen_at`.
+    """
+    node = await ensure_node_for_executor(session, executor)
+    now = now or datetime.now(timezone.utc)
+    node.os = announcement.os
+    node.arch = announcement.arch
+    node.agent_version = announcement.agent_version
+    node.capabilities_json = json.dumps(
+        {
+            "capabilities": [capability.value for capability in announcement.capabilities],
+            "engines": [engine.model_dump(mode="json") for engine in announcement.engines],
+            "max_concurrent_tasks": announcement.max_concurrent_tasks,
+            "discovery_root_count": announcement.discovery_root_count,
+        },
+        ensure_ascii=True,
+    )
+    node.capabilities_observed_at = now
+    await session.commit()
+    await session.refresh(node)
+    return node
+
+
+async def list_nodes(session: AsyncSession) -> list[tuple[NodeModel, ExecutorModel | None]]:
+    """Every Bridge Node, ordered by id, paired with the executor bound to it.
+
+    The executor is what `health` is derived from at the route layer
+    (`store.executor_is_live` for liveness, `executor.last_seen_at` for
+    "ever seen") -- neither lives on `NodeModel` itself, the same separation
+    `NodeModel`'s own docstring draws between the node (machine and
+    capabilities) and the executor (the authenticated connection). Two
+    queries total, not one per node: the fleet is operator-curated and small,
+    the same reasoning `executors_by_project` documents for grouping in
+    Python rather than joining in SQL.
+    """
+    nodes = list((await session.execute(select(NodeModel).order_by(NodeModel.id))).scalars())
+    executors = list(
+        (await session.execute(select(ExecutorModel).where(ExecutorModel.node_id.isnot(None)))).scalars()
+    )
+    by_node_id = {executor.node_id: executor for executor in executors}
+    return [(node, by_node_id.get(node.id)) for node in nodes]
+
+
+async def get_node(session: AsyncSession, node_id: str) -> tuple[NodeModel, ExecutorModel | None] | None:
+    """One Bridge Node and its bound executor, or None if the node does not exist.
+
+    See `list_nodes` for why the executor travels alongside the node.
+    """
+    node = await session.get(NodeModel, node_id)
+    if node is None:
+        return None
+    executor = (
+        (await session.execute(select(ExecutorModel).where(ExecutorModel.node_id == node_id)))
+        .scalars()
+        .first()
+    )
+    return node, executor
 
 
 async def next_dispatchable_task(session: AsyncSession, executor_id: str) -> TaskModel | None:

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -328,6 +328,101 @@ class DiscoveryRoot(BaseModel):
         return value
 
 
+class EngineAvailability(BaseModel):
+    """Whether one `AgentEngine` can actually run on this node, right now.
+
+    Issue #73 Stage 2 asks a node for its "available execution engines". Three
+    different facts get confused under that word, so all three are carried
+    separately:
+
+    * `implemented` — a `Runner` exists in this codebase for the engine. A
+      compile-time claim, the same on every node running the same version.
+    * `available` — the binary answered on this machine when probed. A runtime
+      fact, and the only one that predicts whether a dispatch will start.
+    * `version` — what the binary reported, when it reported anything.
+
+    Collapsing them loses the two cases the operator most needs to see: an
+    engine this build supports but this machine lacks (`implemented` and not
+    `available` — install it), and an engine present on the machine that no
+    runner can drive (`available` and not `implemented` — a code gap, not an
+    ops one). `detail` carries the reason a probe failed, never a stack trace
+    and never a path.
+    """
+
+    engine: str = Field(min_length=1, max_length=64)
+    implemented: bool = False
+    available: bool = False
+    version: str | None = Field(default=None, max_length=200)
+    detail: str | None = Field(default=None, max_length=400)
+
+
+class NodeAnnouncement(BaseModel):
+    """What a node reports about itself when it connects (`hello` payload).
+
+    Issue #73 Stage 2. Deliberately carries **no identity**: the node is the
+    one the authenticated `executor_id` already maps to. "Node identity must
+    survive reconnects and must not be inferred from mutable hostname/IP
+    alone" — accepting a self-declared id would also let a node claim another
+    node's row, which is the announcement-as-authorization failure #73 names.
+
+    Nothing here is a permission. `capabilities` is what the node's own
+    configuration would *permit* it to do; what it may actually do to a given
+    project still lives in `project_authorizations`, written by the operator.
+    The gateway stores this as an observation with a timestamp, so a stale
+    inventory is visibly stale rather than silently believed.
+
+    `discovery_root_count` is a count, not the paths. Absolute paths are
+    sensitive operational data (`docs/api/README.md`); the fleet surface needs
+    to answer "is this node configured to discover anything at all", which a
+    count answers without putting a filesystem layout in every client.
+    """
+
+    agent_version: str | None = Field(default=None, max_length=64)
+    os: str | None = Field(default=None, max_length=120)
+    arch: str | None = Field(default=None, max_length=60)
+    engines: list[EngineAvailability] = Field(default_factory=list)
+    capabilities: list[Capability] = Field(default_factory=list)
+    max_concurrent_tasks: int = Field(default=1, ge=0, le=1000)
+    discovery_root_count: int = Field(default=0, ge=0)
+
+    @field_validator("engines")
+    @classmethod
+    def _refuse_duplicate_engines(cls, value: list[EngineAvailability]) -> list[EngineAvailability]:
+        seen = [engine.engine for engine in value]
+        duplicated = sorted({name for name in seen if seen.count(name) > 1})
+        if duplicated:
+            raise ValueError(f"engine reported more than once: {duplicated}")
+        return value
+
+
+def node_health(
+    *,
+    live: bool,
+    enabled: bool,
+    ever_seen: bool,
+    health_reason: str | None = None,
+) -> "NodeHealth":
+    """Derive a node's health from facts, at read time, never from a column.
+
+    The order matters and is not arbitrary. A node nobody has ever heard from
+    is `UNKNOWN`, not `OFFLINE`: "never connected" and "was here and went
+    away" are different problems with different fixes, and #73 requires that
+    "offline/stale information must be visibly distinguished from current
+    observations". A disabled node reads `OFFLINE` while it is not live —
+    saying `DEGRADED` about a machine that is simply switched off invents an
+    incident. `DEGRADED` is reserved for a node that is answering but that
+    the operator or the node itself has flagged.
+    """
+
+    if not ever_seen:
+        return NodeHealth.UNKNOWN
+    if not live:
+        return NodeHealth.OFFLINE
+    if not enabled or health_reason:
+        return NodeHealth.DEGRADED
+    return NodeHealth.OK
+
+
 class ProjectRegistration(BaseModel):
     project_id: str
     name: str

--- a/tests/integration/test_agent_ws_identity.py
+++ b/tests/integration/test_agent_ws_identity.py
@@ -1,0 +1,219 @@
+"""An envelope's `executor_id` is a claim; the handshake's is the fact.
+
+`AgentEnvelope.executor_id` is a field the CLIENT writes into the message body.
+The `executor_id` on `/agent/ws` is the one that presented a machine token.
+Believing the first let any connected node write another node's row — forge the
+capabilities it reports, or refresh its liveness so a dead node reads healthy —
+which is exactly the fleet surface issue #73 Stage 2 exists to make
+trustworthy. Issue #16 had already fixed this for `task.ack` alone; every
+message type added afterwards inherited the same trust.
+
+These tests drive real envelopes through the real receive loop, because that is
+where the gap lived: `store.record_node_announcement` called directly is
+well-behaved, and the suite passed over the hole.
+
+`agent_ws` is awaited directly with a fake socket rather than through
+`TestClient.websocket_connect`. The `TestClient` runs the app in its own
+thread and event loop; sharing one in-memory aiosqlite engine across the two
+deadlocks, and polling for the effect from the test's loop makes a negative
+assertion that would also hold if nothing had been processed at all. Awaiting
+the handler means the loop has provably finished before anything is asserted.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from starlette.websockets import WebSocketDisconnect
+
+from gateway.app.db.base import Base
+from gateway.app.services import store
+from shared.protocol import AgentMessageType, ExecutorRegistration
+
+
+VICTIM = "victim-node"
+ATTACKER = "attacker-node"
+
+FORGED = {
+    "agent_version": "FORGED",
+    "os": "FORGED-OS",
+    "capabilities": ["modify", "deliver"],
+    "max_concurrent_tasks": 999,
+}
+
+
+class FakeSocket:
+    """Just enough `WebSocket` for `agent_ws`: it accepts, sends, and runs dry.
+
+    `receive_json` raising `WebSocketDisconnect` once the queue empties is what
+    ends the handler's `while True`, the same way a real client hanging up
+    does.
+    """
+
+    def __init__(self, incoming: list[dict]) -> None:
+        self._incoming = list(incoming)
+        self.sent: list[dict] = []
+        self.accepted = False
+        self.close_code: int | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000) -> None:
+        self.close_code = code
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    async def receive_json(self) -> dict:
+        if not self._incoming:
+            raise WebSocketDisconnect(1000)
+        return self._incoming.pop(0)
+
+
+@pytest.fixture
+async def wired(monkeypatch) -> AsyncIterator[async_sessionmaker]:
+    from gateway.app import main
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(main, "SessionLocal", factory)
+    # `AgentHub` was built at import time holding the PRODUCTION factory, so
+    # patching `main.SessionLocal` alone leaves `hub.register` talking to
+    # `./codex_bridge.db`: the handshake then dies with `unknown_executor`
+    # before the receive loop starts, and every assertion below would pass
+    # because nothing ran.
+    monkeypatch.setattr(main.hub, "session_factory", factory)
+
+    async with factory() as session:
+        await store.upsert_registry(
+            session,
+            [
+                ExecutorRegistration(
+                    executor_id=name,
+                    display_name=name,
+                    machine_token=f"token-{name}",
+                    allowed_projects=[],
+                )
+                for name in (VICTIM, ATTACKER)
+            ],
+            [],
+        )
+
+    yield factory
+    await engine.dispose()
+
+
+def _envelope(executor_id: str, message_type: AgentMessageType, payload: dict) -> dict:
+    return {
+        "message_id": str(uuid4()),
+        "executor_id": executor_id,
+        "sent_at": datetime.now(timezone.utc).isoformat(),
+        "type": message_type.value,
+        "payload": payload,
+    }
+
+
+async def _speak(as_executor: str, *envelopes: dict) -> FakeSocket:
+    """Authenticate as `as_executor` and let it say `envelopes`, in order."""
+    from gateway.app import main
+
+    socket = FakeSocket(list(envelopes))
+    await main.agent_ws(socket, executor_id=as_executor, x_executor_token=f"token-{as_executor}")
+    assert socket.accepted, "the handshake was refused; the test proves nothing"
+    return socket
+
+
+async def _node(factory: async_sessionmaker, node_id: str):
+    async with factory() as session:
+        row = await store.get_node(session, node_id)
+    assert row is not None
+    return row[0]
+
+
+async def _last_seen(factory: async_sessionmaker, executor_id: str):
+    async with factory() as session:
+        executor = await session.get(store.ExecutorModel, executor_id)
+        seen = executor.last_seen_at
+    if seen is not None and seen.tzinfo is None:
+        seen = seen.replace(tzinfo=timezone.utc)
+    return seen
+
+
+async def test_a_node_announcing_itself_is_recorded(wired) -> None:
+    """The honest path, so every refusal below is not passing for want of wiring."""
+    await _speak(ATTACKER, _envelope(ATTACKER, AgentMessageType.HELLO, {"agent_version": "1.2.3", "os": "Linux"}))
+
+    node = await _node(wired, ATTACKER)
+    assert node.agent_version == "1.2.3"
+    assert node.os == "Linux"
+    assert node.capabilities_observed_at is not None
+
+
+async def test_a_node_cannot_announce_on_another_nodes_behalf(wired) -> None:
+    """The exploit: authenticate as one node, claim to be another.
+
+    Before the guard this overwrote the victim's `os`, `agent_version` and
+    reported capabilities — a node the connection held no token for and that
+    had never sent anything.
+    """
+    await _speak(ATTACKER, _envelope(VICTIM, AgentMessageType.HELLO, FORGED))
+
+    victim = await _node(wired, VICTIM)
+    assert victim.agent_version is None
+    assert victim.os is None
+    assert victim.capabilities_observed_at is None
+    assert json.loads(victim.capabilities_json or "{}").get("capabilities") in (None, [])
+
+
+async def test_the_forged_envelope_is_dropped_not_redirected(wired) -> None:
+    """Rewriting the claimed id to the authenticated one would be worse.
+
+    It would silently accept, as the sender's own, a message the sender never
+    made about itself. The envelope is refused outright.
+    """
+    await _speak(ATTACKER, _envelope(VICTIM, AgentMessageType.HELLO, FORGED))
+
+    attacker = await _node(wired, ATTACKER)
+    assert attacker.agent_version is None
+    assert attacker.os is None
+
+
+async def test_a_forged_heartbeat_does_not_refresh_another_nodes_liveness(wired) -> None:
+    """Liveness feeds `node_health`, so forging it forges the fleet's health.
+
+    Same root cause one branch over — which is why the guard sits before the
+    dispatch instead of inside either branch.
+    """
+    stale = datetime.now(timezone.utc) - timedelta(hours=6)
+    async with wired() as session:
+        victim = await session.get(store.ExecutorModel, VICTIM)
+        victim.connected = True
+        victim.last_seen_at = stale
+        await session.commit()
+
+    await _speak(ATTACKER, _envelope(VICTIM, AgentMessageType.HEARTBEAT, {}))
+
+    assert await _last_seen(wired, VICTIM) < datetime.now(timezone.utc) - timedelta(hours=5)
+
+
+async def test_the_connection_survives_a_forged_envelope(wired) -> None:
+    """Dropping the message must not drop the socket.
+
+    Hanging up here would turn a buggy agent into an outage, and would hand an
+    attacker a way to disconnect a node by making it send one bad envelope.
+    """
+    await _speak(
+        ATTACKER,
+        _envelope(VICTIM, AgentMessageType.HELLO, FORGED),
+        _envelope(ATTACKER, AgentMessageType.HELLO, {"agent_version": "after-the-forgery"}),
+    )
+
+    assert (await _node(wired, ATTACKER)).agent_version == "after-the-forgery"

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -32,6 +32,7 @@ from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import decisions as decisions_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
+from gateway.app.api.routes import nodes as nodes_routes
 from gateway.app.api.routes import missions as missions_routes
 from gateway.app.api.routes import projects as projects_routes
 from gateway.app.api.routes import sessions as sessions_routes
@@ -164,6 +165,7 @@ async def api(users_file, monkeypatch):
     app.include_router(epics_routes.router)
     app.include_router(issues_routes.router)
     app.include_router(conversations_routes.router)
+    app.include_router(nodes_routes.router)
 
     async def override():
         async with factory() as s:
@@ -1008,6 +1010,7 @@ async def test_me_separates_read_operational_and_administrative(api) -> None:
 # One request per action, so the report can be checked against the thing it
 # describes.
 ENDPOINT_FOR_ACTION = {
+    "nodes.read": ("GET", "/api/v1/nodes"),
     "sessions.read": ("GET", "/api/v1/sessions"),
     "sessions.readLogs": ("GET", "/api/v1/sessions/{id}/logs"),
     "sessions.explainError": ("POST", "/api/v1/sessions/{id}/explain-error"),

--- a/tests/integration/test_nodes.py
+++ b/tests/integration/test_nodes.py
@@ -1,0 +1,323 @@
+"""Bridge Node fleet visibility — issue #73 Stage 2.
+
+Weighted like `test_projects.py`: authorization, the four reachable health
+values, inventory staleness and the "never a filesystem path" rule get the
+attention, not serialization. Fixture idiom copied from `test_projects.py` —
+real FastAPI app, in-memory sqlite, `store.upsert_registry` seeding, OAuth
+tokens minted through `store.create_oauth_access_token`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import nodes as nodes_routes
+from gateway.app.api.routes.nodes import INVENTORY_STALE_AFTER_SECONDS
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.models.entities import ExecutorModel, NodeModel
+from gateway.app.services import store
+from shared.protocol import Capability, EngineAvailability, ExecutorRegistration, NodeAnnouncement
+
+
+ADMIN_TOKEN = "token-admin"      # roles=["admin"] -- sees the fleet
+ALICE_TOKEN = "token-alice"      # authenticated, codexbridge.read only -- no fleet access
+NOSCOPE_TOKEN = "token-noscope"  # authenticated, no scopes at all
+EXPIRED_TOKEN = "token-expired"
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "admin", "email": "admin@example.com", "password_hash": "x",
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "enabled": True,
+                    },
+                    {
+                        "user_id": "alice", "email": "alice@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read"], "enabled": True,
+                    },
+                    {
+                        "user_id": "noscope", "email": "noscope@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": [],
+                        "scopes": [], "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def api(users_file, monkeypatch):
+    """A real app over a real database, seeded with one executor -> one node.
+
+    `E1` is registered but never marked connected — every test that needs a
+    "live" or "stale" node drives that through `store.mark_executor_connected`
+    and `set_last_seen` itself, the same discipline `test_projects.py` applies,
+    so the starting point (health `unknown`) is not an assumption a test
+    silently depends on.
+    """
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="E1", display_name="E1", machine_token="t",
+                    allowed_projects=["p1"], enabled=True,
+                )
+            ],
+            projects=[],
+        )
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        for token, user_id, scopes in (
+            (ADMIN_TOKEN, "admin", ["codexbridge.admin"]),
+            (ALICE_TOKEN, "alice", ["codexbridge.read"]),
+            (NOSCOPE_TOKEN, "noscope", []),
+        ):
+            await store.create_oauth_access_token(
+                seed, token=token, client_id="c", user_id=user_id,
+                scopes=scopes, expires_at=future,
+            )
+        await store.create_oauth_access_token(
+            seed, token=EXPIRED_TOKEN, client_id="c", user_id="admin",
+            scopes=["codexbridge.admin"],
+            expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(nodes_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.factory = factory  # type: ignore[attr-defined]
+    yield client
+    await engine.dispose()
+
+
+async def mark_live(factory, executor_id: str = "E1") -> None:
+    async with factory() as s:
+        await store.mark_executor_connected(s, executor_id, True)
+
+
+async def set_last_seen(factory, executor_id: str, when: datetime) -> None:
+    async with factory() as s:
+        executor = await s.get(ExecutorModel, executor_id)
+        executor.last_seen_at = when
+        await s.commit()
+
+
+async def set_node_enabled(factory, node_id: str, enabled: bool) -> None:
+    async with factory() as s:
+        node = await s.get(NodeModel, node_id)
+        node.enabled = enabled
+        await s.commit()
+
+
+async def set_capabilities_observed_at(factory, node_id: str, when: datetime) -> None:
+    async with factory() as s:
+        node = await s.get(NodeModel, node_id)
+        node.capabilities_observed_at = when
+        await s.commit()
+
+
+async def announce(factory, executor_id: str = "E1", **overrides) -> None:
+    defaults = dict(
+        agent_version="1.2.3",
+        os="Linux",
+        arch="x86_64",
+        engines=[EngineAvailability(engine="codex", implemented=True, available=True, version="0.9.0")],
+        capabilities=[Capability.READ, Capability.TEST],
+        max_concurrent_tasks=2,
+        discovery_root_count=3,
+    )
+    defaults.update(overrides)
+    async with factory() as s:
+        executor = await s.get(ExecutorModel, executor_id)
+        await store.record_node_announcement(s, executor, NodeAnnouncement(**defaults))
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _assert_no_absolute_paths(value) -> None:
+    if isinstance(value, str):
+        assert not value.startswith("/"), f"absolute path leaked: {value!r}"
+    elif isinstance(value, dict):
+        for item in value.values():
+            _assert_no_absolute_paths(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_absolute_paths(item)
+
+
+# --------------------------------------------------------------------------
+# Authentication and authorization
+# --------------------------------------------------------------------------
+
+
+async def test_nodes_require_a_token(api) -> None:
+    response = api.get("/api/v1/nodes")
+    assert response.status_code == 401
+    assert response.json()["code"] == "unauthenticated"
+
+
+async def test_an_expired_token_is_refused(api) -> None:
+    assert api.get("/api/v1/nodes", headers=auth(EXPIRED_TOKEN)).status_code == 401
+
+
+async def test_a_token_without_the_admin_scope_is_forbidden(api) -> None:
+    response = api.get("/api/v1/nodes", headers=auth(ALICE_TOKEN))
+    assert response.status_code == 403
+    assert response.json()["code"] == "permission_denied"
+
+
+async def test_a_token_with_no_scopes_at_all_is_forbidden(api) -> None:
+    response = api.get("/api/v1/nodes", headers=auth(NOSCOPE_TOKEN))
+    assert response.status_code == 403
+
+
+async def test_an_unknown_node_id_is_not_found(api) -> None:
+    response = api.get("/api/v1/nodes/does-not-exist", headers=auth(ADMIN_TOKEN))
+    assert response.status_code == 404
+    assert response.json()["code"] == "not_found"
+
+
+# --------------------------------------------------------------------------
+# List and detail return the seeded node
+# --------------------------------------------------------------------------
+
+
+async def test_list_returns_the_seeded_node(api) -> None:
+    body = api.get("/api/v1/nodes", headers=auth(ADMIN_TOKEN)).json()
+    assert [item["id"] for item in body["items"]] == ["E1"]
+    assert body["items"][0]["displayName"] == "E1"
+    assert body["items"][0]["enabled"] is True
+
+
+async def test_detail_returns_the_seeded_node(api) -> None:
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["id"] == "E1"
+    assert body["displayName"] == "E1"
+
+
+# --------------------------------------------------------------------------
+# Health: all four values are reachable
+# --------------------------------------------------------------------------
+
+
+async def test_health_is_unknown_when_the_node_has_never_been_seen(api) -> None:
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["health"] == "unknown"
+
+
+async def test_health_is_offline_when_last_seen_is_older_than_the_reconnect_grace(api) -> None:
+    from gateway.app.core.config import settings
+
+    # Mark it live once (so `last_seen_at` is set) and then rewind past the
+    # grace window without a real disconnect -- the same technique
+    # `test_projects.py` uses for its own stale-heartbeat case.
+    await mark_live(api.factory)
+    await set_last_seen(
+        api.factory, "E1", datetime.now(timezone.utc) - timedelta(seconds=settings.reconnect_grace_seconds + 1)
+    )
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["health"] == "offline"
+
+
+async def test_health_is_degraded_when_live_but_disabled(api) -> None:
+    await mark_live(api.factory)
+    await set_node_enabled(api.factory, "E1", False)
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["health"] == "degraded"
+
+
+async def test_health_is_ok_when_live_and_enabled(api) -> None:
+    await mark_live(api.factory)
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["health"] == "ok"
+
+
+# --------------------------------------------------------------------------
+# Inventory staleness
+# --------------------------------------------------------------------------
+
+
+async def test_inventory_is_stale_before_any_announcement(api) -> None:
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["inventoryStale"] is True
+    assert body["capabilitiesObservedAt"] is None
+
+
+async def test_inventory_is_not_stale_right_after_an_announcement(api) -> None:
+    await announce(api.factory)
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["inventoryStale"] is False
+    assert body["capabilitiesObservedAt"] is not None
+    assert body["agentVersion"] == "1.2.3"
+    assert body["os"] == "Linux"
+    assert body["arch"] == "x86_64"
+    assert body["maxConcurrentTasks"] == 2
+    assert body["discoveryRootCount"] == 3
+    assert set(body["capabilities"]) == {"read", "test"}
+    assert body["engines"][0]["engine"] == "codex"
+
+
+async def test_a_stale_capabilities_observed_at_is_reported_stale(api) -> None:
+    await announce(api.factory)
+    stale_at = datetime.now(timezone.utc) - timedelta(seconds=INVENTORY_STALE_AFTER_SECONDS + 1)
+    await set_capabilities_observed_at(api.factory, "E1", stale_at)
+    body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    assert body["inventoryStale"] is True
+
+
+# --------------------------------------------------------------------------
+# No absolute filesystem path ever leaks
+# --------------------------------------------------------------------------
+
+
+async def test_no_absolute_path_leaks_after_an_announcement(api) -> None:
+    """`docs/api/README.md` "fields that must never ship" excludes absolute
+    paths; `NodeAnnouncement.discovery_root_count` exists precisely so this
+    endpoint never needs one.
+    """
+    await announce(api.factory, discovery_root_count=5)
+
+    list_body = api.get("/api/v1/nodes", headers=auth(ADMIN_TOKEN)).json()
+    _assert_no_absolute_paths(list_body)
+
+    detail_body = api.get("/api/v1/nodes/E1", headers=auth(ADMIN_TOKEN)).json()
+    _assert_no_absolute_paths(detail_body)
+    assert "discoveryRootCount" in detail_body
+    assert "discoveryRoots" not in detail_body

--- a/tests/unit/test_agent_announcement.py
+++ b/tests/unit/test_agent_announcement.py
@@ -1,0 +1,172 @@
+"""The `hello` payload's real content -- issue #73 Stage 2.
+
+Before this work `_run_once` sent `{"version": "0.1.0"}` and nothing else.
+These tests drive the real `_run_once`/`_build_announcement` code (the same
+`_FakeAgentSocket`/`_FakeConnect` idiom `tests/unit/test_agent_service.py`
+already uses for its own `_run_once` tests), not a hand-built envelope, so a
+mutation that guts `_build_announcement` fails these tests directly instead
+of a copy of the expected payload staying green next to broken production
+code.
+"""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from agent.codex_bridge_agent import service as service_module
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.service import AGENT_VERSION, AgentService
+from shared.protocol import AgentEnvelope, AgentMessageType, Capability, NodeAnnouncement
+
+
+class _FakeAgentSocket:
+    """Async-iterable stand-in for the real websocket -- copied from
+
+    `tests/unit/test_agent_service.py`'s own harness of the same name, not
+    reinvented. An empty `incoming` list (every test here passes one) means
+    `_run_once` sends `hello`, then the socket's `__anext__` raises
+    `StopAsyncIteration` immediately, ending the loop cleanly with exactly
+    one sent message to inspect.
+    """
+
+    def __init__(self, incoming: list[str]) -> None:
+        self._incoming = list(incoming)
+        self.sent: list[str] = []
+
+    async def __aenter__(self) -> "_FakeAgentSocket":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+    def __aiter__(self) -> "_FakeAgentSocket":
+        return self
+
+    async def __anext__(self) -> str:
+        if not self._incoming:
+            raise StopAsyncIteration
+        return self._incoming.pop(0)
+
+
+class _FakeConnect:
+    def __init__(self, socket: _FakeAgentSocket) -> None:
+        self._socket = socket
+
+    def __call__(self, url: str, **kwargs: object) -> "_FakeConnect":
+        return self
+
+    async def __aenter__(self) -> _FakeAgentSocket:
+        return self._socket
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+
+async def _hello_payload(service: AgentService, monkeypatch) -> dict:
+    """Drives `_run_once` against a fake socket with nothing incoming and
+
+    returns the parsed `hello` envelope's payload -- the first (and only)
+    message the service sends before the loop ends.
+    """
+    incoming: list[str] = []
+    socket = _FakeAgentSocket(incoming)
+    monkeypatch.setattr(service_module.websockets, "connect", _FakeConnect(socket))
+    await service._run_once()
+    assert len(socket.sent) >= 1
+    hello_envelope = AgentEnvelope.model_validate_json(socket.sent[0])
+    assert hello_envelope.type == AgentMessageType.HELLO
+    return hello_envelope.payload, socket.sent[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "allow_workspace_write,allow_git_delivery,expected_present,expected_absent",
+    [
+        pytest.param(False, False, set(), {"modify", "deliver"}, id="neither"),
+        pytest.param(True, False, {"modify"}, {"deliver"}, id="modify-only"),
+        pytest.param(True, True, {"modify", "deliver"}, set(), id="both"),
+    ],
+)
+async def test_hello_envelope_validates_as_node_announcement_with_derived_capabilities(
+    monkeypatch, allow_workspace_write, allow_git_delivery, expected_present, expected_absent
+) -> None:
+    settings = AgentSettings(allow_workspace_write=allow_workspace_write, allow_git_delivery=allow_git_delivery)
+    service = AgentService(settings)
+
+    async def fake_probe_all() -> list:
+        return []
+
+    monkeypatch.setattr(service.runners, "probe_all", fake_probe_all)
+
+    payload, _raw = await _hello_payload(service, monkeypatch)
+
+    # Validates as the real, strict DTO -- not just "has some keys".
+    announcement = NodeAnnouncement.model_validate(payload)
+    caps = {c.value for c in announcement.capabilities}
+
+    # READ and TEST are unconditional -- see `AgentService._build_announcement`.
+    assert Capability.READ.value in caps
+    assert Capability.TEST.value in caps
+    for cap in expected_present:
+        assert cap in caps, f"expected {cap!r} present for allow_workspace_write={allow_workspace_write}, allow_git_delivery={allow_git_delivery}"
+    for cap in expected_absent:
+        assert cap not in caps, f"expected {cap!r} absent for allow_workspace_write={allow_workspace_write}, allow_git_delivery={allow_git_delivery}"
+
+
+@pytest.mark.asyncio
+async def test_hello_envelope_carries_os_and_arch_but_never_the_hostname(monkeypatch) -> None:
+    """Issue #73: node identity must not be inferred from mutable hostname --
+
+    and the fleet questions this announcement answers never needed it.
+    `platform.system()`/`platform.machine()` are fine (coarse platform facts,
+    the same on every node of the same kind); `platform.node()` (the
+    hostname) must never appear anywhere in the serialised payload.
+    """
+    service = AgentService(AgentSettings())
+
+    async def fake_probe_all() -> list:
+        return []
+
+    monkeypatch.setattr(service.runners, "probe_all", fake_probe_all)
+
+    payload, raw_json = await _hello_payload(service, monkeypatch)
+
+    announcement = NodeAnnouncement.model_validate(payload)
+    assert announcement.os == platform.system()
+    assert announcement.arch == platform.machine()
+
+    hostname = platform.node()
+    if hostname:
+        assert hostname not in raw_json
+
+
+@pytest.mark.asyncio
+async def test_build_announcement_falls_back_to_minimal_payload_when_probing_raises(monkeypatch) -> None:
+    """`_build_announcement` must never cost the connection. If anything
+
+    inside it raises (here, `RunnerPool.probe_all` itself), `_run_once` still
+    gets a valid, minimal `NodeAnnouncement` to send rather than an
+    exception that would abort the whole connection attempt.
+    """
+    service = AgentService(AgentSettings())
+
+    async def raising_probe_all() -> list:
+        raise RuntimeError("boom: engine probing exploded")
+
+    monkeypatch.setattr(service.runners, "probe_all", raising_probe_all)
+
+    # Direct call: must not raise.
+    announcement = await service._build_announcement()
+    assert announcement.agent_version == AGENT_VERSION
+    assert announcement.engines == []
+    assert announcement.capabilities == []
+
+    # End-to-end: `_run_once` still connects and sends a valid `hello`.
+    payload, _raw = await _hello_payload(service, monkeypatch)
+    fallback = NodeAnnouncement.model_validate(payload)
+    assert fallback.agent_version == AGENT_VERSION

--- a/tests/unit/test_node_store.py
+++ b/tests/unit/test_node_store.py
@@ -1,0 +1,211 @@
+"""`store.ensure_node_for_executor` / `upsert_registry` / `record_node_announcement`
+(issue #73 Stage 2).
+
+Same in-memory-sqlite idiom `tests/integration/test_store_and_mcp.py` uses for
+store-level tests: a real async engine, `Base.metadata.create_all`, no FastAPI
+app. Kept under `tests/unit` per the task spec even though it drives a real
+(in-memory) database, matching how `test_store_and_mcp.py` is itself
+categorized as integration for the same shape of test — the distinction here
+is "does this exercise the HTTP surface", and none of these do.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.db.base import Base
+from gateway.app.models.entities import ExecutorModel, NodeModel, ProjectAuthorizationModel
+from gateway.app.services import store
+from shared.protocol import Capability, EngineAvailability, ExecutorRegistration, NodeAnnouncement
+
+
+@pytest.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _add_bare_executor(session: AsyncSession, executor_id: str, *, enabled: bool = True) -> ExecutorModel:
+    """An executor row with `node_id` left NULL, bypassing `upsert_registry`.
+
+    Simulates a row written before issue #73's node concept existed —
+    `ensure_node_for_executor` exists precisely to repair a row like this one.
+    """
+    executor = ExecutorModel(
+        id=executor_id,
+        display_name=f"Display {executor_id}",
+        enabled=enabled,
+        connected=False,
+        metadata_json=json.dumps({"machine_token": "t", "allowed_projects": []}),
+    )
+    session.add(executor)
+    await session.commit()
+    await session.refresh(executor)
+    return executor
+
+
+# --------------------------------------------------------------------------
+# ensure_node_for_executor
+# --------------------------------------------------------------------------
+
+
+async def test_ensure_node_for_executor_creates_and_binds_when_node_id_is_null(db_session) -> None:
+    executor = await _add_bare_executor(db_session, "E1")
+    assert executor.node_id is None
+
+    node = await store.ensure_node_for_executor(db_session, executor)
+    await db_session.commit()
+
+    assert node.id == "E1"
+    assert node.display_name == "Display E1"
+    assert node.enabled is True
+    assert executor.node_id == "E1"
+    assert await db_session.get(NodeModel, "E1") is not None
+
+
+async def test_ensure_node_for_executor_is_idempotent(db_session) -> None:
+    executor = await _add_bare_executor(db_session, "E1")
+
+    first = await store.ensure_node_for_executor(db_session, executor)
+    await db_session.commit()
+    second = await store.ensure_node_for_executor(db_session, executor)
+    await db_session.commit()
+
+    assert first.id == second.id
+    rows = (await db_session.execute(select(NodeModel))).scalars().all()
+    assert len(rows) == 1
+
+
+# --------------------------------------------------------------------------
+# upsert_registry
+# --------------------------------------------------------------------------
+
+
+async def test_upsert_registry_produces_a_node_for_a_newly_added_executor(db_session) -> None:
+    await store.upsert_registry(
+        db_session,
+        executors=[
+            ExecutorRegistration(
+                executor_id="E1", display_name="E1", machine_token="t",
+                allowed_projects=["p1"], enabled=True,
+            )
+        ],
+        projects=[],
+    )
+    node = await db_session.get(NodeModel, "E1")
+    assert node is not None
+    assert node.display_name == "E1"
+
+    # The scenario `ensure_node_for_executor`'s docstring names: a second
+    # executor added on a later registry reload, after the migration that
+    # seeded nodes 1:1 from executors has already run. Nothing but
+    # `upsert_registry` calling `ensure_node_for_executor` itself can give it
+    # a node.
+    await store.upsert_registry(
+        db_session,
+        executors=[
+            ExecutorRegistration(
+                executor_id="E1", display_name="E1", machine_token="t",
+                allowed_projects=["p1"], enabled=True,
+            ),
+            ExecutorRegistration(
+                executor_id="E2", display_name="E2", machine_token="t2",
+                allowed_projects=["p1"], enabled=True,
+            ),
+        ],
+        projects=[],
+    )
+    node2 = await db_session.get(NodeModel, "E2")
+    assert node2 is not None
+    assert node2.display_name == "E2"
+    executor2 = await db_session.get(ExecutorModel, "E2")
+    assert executor2.node_id == "E2"
+
+
+# --------------------------------------------------------------------------
+# record_node_announcement
+# --------------------------------------------------------------------------
+
+
+async def test_record_node_announcement_writes_observation_fields(db_session) -> None:
+    executor = await _add_bare_executor(db_session, "E1")
+    await store.ensure_node_for_executor(db_session, executor)
+    await db_session.commit()
+
+    announcement = NodeAnnouncement(
+        agent_version="1.2.3",
+        os="Linux",
+        arch="x86_64",
+        engines=[EngineAvailability(engine="codex", implemented=True, available=True, version="0.9.0")],
+        capabilities=[Capability.READ, Capability.TEST],
+        max_concurrent_tasks=2,
+        discovery_root_count=3,
+    )
+    now = datetime.now(timezone.utc)
+    node = await store.record_node_announcement(db_session, executor, announcement, now=now)
+
+    assert node.os == "Linux"
+    assert node.arch == "x86_64"
+    assert node.agent_version == "1.2.3"
+    # SQLite hands the timestamp back naive even though it was written aware
+    # (the same naive/aware split `store._as_utc` exists to paper over
+    # elsewhere in this module) -- compare the instant, not the `tzinfo`.
+    observed = node.capabilities_observed_at
+    if observed.tzinfo is None:
+        observed = observed.replace(tzinfo=timezone.utc)
+    assert observed == now
+
+    inventory = json.loads(node.capabilities_json)
+    assert inventory["capabilities"] == ["read", "test"]
+    assert inventory["max_concurrent_tasks"] == 2
+    assert inventory["discovery_root_count"] == 3
+    assert inventory["engines"] == [
+        {"engine": "codex", "implemented": True, "available": True, "version": "0.9.0", "detail": None}
+    ]
+
+
+async def test_record_node_announcement_leaves_enabled_health_reason_and_authorizations_untouched(db_session) -> None:
+    """An announcement is an observation, never a grant (issue #73)."""
+    executor = await _add_bare_executor(db_session, "E1", enabled=True)
+    node = await store.ensure_node_for_executor(db_session, executor)
+    node.enabled = False
+    node.health_reason = "operator paused this node"
+    session_authorization = ProjectAuthorizationModel(
+        id="auth-1",
+        node_id="E1",
+        project_id="p1",
+        capabilities_json="[]",
+        granted_by="operator:esteban",
+        granted_at=datetime.now(timezone.utc),
+    )
+    db_session.add(session_authorization)
+    await db_session.commit()
+
+    announcement = NodeAnnouncement(
+        agent_version="9.9.9",
+        capabilities=[Capability.READ, Capability.MODIFY, Capability.DELIVER],
+    )
+    await store.record_node_announcement(db_session, executor, announcement)
+
+    reloaded = await db_session.get(NodeModel, "E1")
+    assert reloaded.enabled is False
+    assert reloaded.health_reason == "operator paused this node"
+
+    authorizations = (
+        await db_session.execute(
+            select(ProjectAuthorizationModel).where(ProjectAuthorizationModel.node_id == "E1")
+        )
+    ).scalars().all()
+    assert len(authorizations) == 1
+    assert authorizations[0].revoked_at is None
+    assert json.loads(authorizations[0].capabilities_json) == []

--- a/tests/unit/test_runner_probe.py
+++ b/tests/unit/test_runner_probe.py
@@ -1,0 +1,229 @@
+"""`Runner.probe()` and `RunnerPool.probe_all()` -- issue #73 Stage 2.
+
+`capabilities()` is a compile-time claim ("this code can drive engine X");
+`probe()` is a runtime measurement ("the binary is on THIS machine and
+answered"). These tests prove the runtime side: a probe never raises (a node
+whose probe raised would fail to connect at all -- see
+`agent/codex_bridge_agent/runners/base.py:EngineProbe`'s own docstring), never
+leaks a filesystem path into `detail`, and `RunnerPool.probe_all()` always
+reports one entry per `KNOWN_ENGINES` key, implemented or not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import agent.codex_bridge_agent.runners.claude as claude_module
+import agent.codex_bridge_agent.runners.codex as codex_module
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.runners.base import EngineProbe
+from agent.codex_bridge_agent.runners.claude import ClaudeRunner
+from agent.codex_bridge_agent.runners.codex import CodexRunner
+from agent.codex_bridge_agent.runners.pool import RunnerPool
+from agent.codex_bridge_agent.runners.registry import KNOWN_ENGINES
+from shared.protocol import EngineAvailability
+
+
+class _FakeProcess:
+    """Stands in for `asyncio.subprocess.Process` for `probe()`'s own
+
+    `--version` call -- only `communicate()`/`kill()`/`wait()` are exercised,
+    so nothing else needs faking.
+    """
+
+    def __init__(self, stdout: bytes = b"", hang: bool = False) -> None:
+        self._stdout = stdout
+        self._hang = hang
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hang:
+            await asyncio.sleep(3600)
+        return (self._stdout, b"")
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return 0
+
+
+# (runner class, the `AgentSettings` field that names its binary) -- every
+# test below is parametrized across both real runners so a regression in
+# either engine's `probe()` is caught, not just one.
+_RUNNER_PARAMS = [
+    pytest.param(CodexRunner, "codex_bin", id="codex"),
+    pytest.param(ClaudeRunner, "claude_bin", id="claude"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runner_cls,bin_field", _RUNNER_PARAMS)
+async def test_probe_reports_unavailable_when_binary_not_on_path(monkeypatch, runner_cls, bin_field) -> None:
+    settings = AgentSettings(**{bin_field: "some-binary-name"})
+    runner = runner_cls(settings)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    result = await runner.probe()
+
+    assert isinstance(result, EngineProbe)
+    assert result.available is False
+    assert result.detail is not None
+    assert "path" in result.detail.lower()
+    assert result.version is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runner_cls,bin_field", _RUNNER_PARAMS)
+async def test_probe_reports_available_and_the_parsed_version(monkeypatch, runner_cls, bin_field) -> None:
+    settings = AgentSettings(**{bin_field: "some-binary-name"})
+    runner = runner_cls(settings)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/some-binary-name")
+
+    async def fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _FakeProcess:
+        return _FakeProcess(stdout=b"tool-version 9.9.9\nextra ignored line\n")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+    result = await runner.probe()
+
+    assert result.available is True
+    assert result.version == "tool-version 9.9.9"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runner_cls,bin_field", _RUNNER_PARAMS)
+async def test_probe_survives_oserror_without_raising(monkeypatch, runner_cls, bin_field) -> None:
+    settings = AgentSettings(**{bin_field: "some-binary-name"})
+    runner = runner_cls(settings)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/some-binary-name")
+
+    async def raising(*_args: object, **_kwargs: object) -> _FakeProcess:
+        raise OSError("no such file or directory")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", raising)
+
+    result = await runner.probe()
+
+    assert result.available is False
+    assert result.detail is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runner_cls,bin_field,timeout_module", [
+    pytest.param(CodexRunner, "codex_bin", codex_module, id="codex"),
+    pytest.param(ClaudeRunner, "claude_bin", claude_module, id="claude"),
+])
+async def test_probe_survives_a_timeout_without_raising(monkeypatch, runner_cls, bin_field, timeout_module) -> None:
+    settings = AgentSettings(**{bin_field: "some-binary-name"})
+    runner = runner_cls(settings)
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/some-binary-name")
+    # The real timeout is 5s; shrink it so this test doesn't spend 5 real
+    # seconds waiting for a probe that is deliberately never going to answer.
+    monkeypatch.setattr(timeout_module, "_PROBE_TIMEOUT_SECONDS", 0.05)
+
+    async def hanging(*_args: object, **_kwargs: object) -> _FakeProcess:
+        return _FakeProcess(hang=True)
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", hanging)
+
+    result = await runner.probe()
+
+    assert result.available is False
+    assert result.detail is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runner_cls,bin_field", _RUNNER_PARAMS)
+async def test_probe_detail_never_carries_the_configured_binary_path(monkeypatch, runner_cls, bin_field) -> None:
+    """`detail` is meant to explain a probe failure to an operator, never to
+
+    leak where the binary lives on this machine -- `shared/protocol.py`'s own
+    `EngineAvailability.detail` docstring makes this the whole point of the
+    field. The resolved path from `shutil.which` (a plausible install
+    location, not the literal configured name) is what would leak if
+    `probe()` ever built its message from it.
+    """
+    settings = AgentSettings(**{bin_field: "some-binary-name"})
+    runner = runner_cls(settings)
+    secret_resolved_path = "/opt/very/secret/install/path/some-binary-name"
+    monkeypatch.setattr("shutil.which", lambda _name: secret_resolved_path)
+
+    async def raising(*_args: object, **_kwargs: object) -> _FakeProcess:
+        raise OSError("boom")
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", raising)
+
+    result = await runner.probe()
+
+    assert result.available is False
+    detail = result.detail or ""
+    assert secret_resolved_path not in detail
+    assert getattr(settings, bin_field) not in detail
+
+
+class _FakeProbeRunner:
+    """A `Runner` stand-in that only `probe_all()` ever calls -- `probe()`.
+
+    Follows `tests/unit/test_agent_service.py`'s idiom of injecting a fake
+    directly into `pool._runners[...]` rather than building a new harness.
+    """
+
+    def __init__(self, result: EngineProbe | None = None, raise_exc: Exception | None = None) -> None:
+        self._result = result
+        self._raise = raise_exc
+
+    async def probe(self) -> EngineProbe:
+        if self._raise is not None:
+            raise self._raise
+        assert self._result is not None
+        return self._result
+
+
+@pytest.mark.asyncio
+async def test_probe_all_returns_one_entry_per_known_engine() -> None:
+    pool = RunnerPool(AgentSettings())
+    pool._runners["codex"] = _FakeProbeRunner(EngineProbe(available=True, version="1.2.3"))
+    pool._runners["claude"] = _FakeProbeRunner(EngineProbe(available=False, detail="not found on PATH"))
+
+    result = await pool.probe_all()
+
+    assert {entry.engine for entry in result} == set(KNOWN_ENGINES.keys())
+    by_engine = {entry.engine: entry for entry in result}
+
+    assert by_engine["codex"] == EngineAvailability(
+        engine="codex", implemented=True, available=True, version="1.2.3", detail=None
+    )
+    assert by_engine["claude"] == EngineAvailability(
+        engine="claude", implemented=True, available=False, version=None, detail="not found on PATH"
+    )
+    for name, registration in KNOWN_ENGINES.items():
+        if registration.implemented:
+            continue
+        entry = by_engine[name]
+        assert entry.implemented is False
+        assert entry.available is False
+        assert entry.detail == "no runner implemented"
+
+
+@pytest.mark.asyncio
+async def test_probe_all_survives_one_runner_raising() -> None:
+    pool = RunnerPool(AgentSettings())
+    pool._runners["codex"] = _FakeProbeRunner(raise_exc=RuntimeError("codex probe exploded"))
+    pool._runners["claude"] = _FakeProbeRunner(EngineProbe(available=True, version="9.9.9"))
+
+    result = await pool.probe_all()
+
+    by_engine = {entry.engine: entry for entry in result}
+    assert by_engine["codex"].implemented is True
+    assert by_engine["codex"].available is False
+    assert by_engine["codex"].detail == "probe failed"
+    assert by_engine["claude"].available is True
+    assert by_engine["claude"].version == "9.9.9"
+    # Every other known engine is still present -- one bad runner did not
+    # shrink the announcement's engine list.
+    assert {entry.engine for entry in result} == set(KNOWN_ENGINES.keys())


### PR DESCRIPTION
Stage 2 (**Fleet visibility**) of epic #73, on top of Stage 1 (#74, merged). Answers the epic's first two operator questions: *what nodes do I have* and *which are online, offline or degraded*.

**No migration.** Stage 1's `nodes` columns already carry everything Stage 2 records; the engine/capability inventory goes into the existing `capabilities_json`.

## The `hello` message stops being inert

It carried `{"version": "0.1.0"}` and the gateway had **no branch for it** — persisted as a receipt, dropped. It now carries a `NodeAnnouncement`, and three properties of that payload are load-bearing:

| property | why |
|---|---|
| **no identity in the payload** | the node is the one the authenticated `executor_id` maps to. #73 requires identity to survive reconnects and not come from a mutable hostname — and a self-declared id would let a node claim another node's row |
| **grants nothing** | `capabilities` is what that machine's config *permits*, never what it may do to a project. This path never writes `project_authorizations`, `enabled` or `health_reason` |
| **dated** | `capabilities_observed_at` is stamped on arrival; the route derives `inventoryStale`. #73: stale information must be visibly distinguished from current observation |

## Three facts hide under the word "engine"

`EngineAvailability` keeps them apart — `implemented` (a runner exists in this build), `available` (the binary answered *on this machine*), `version`. Merging the first two erases the two cases an operator most needs to tell apart: an engine this build supports but the machine lacks (*install it*) versus one present on the machine that no runner can drive (*a code gap*). Different problems, different owners.

`Runner.probe()` measures instead of declaring, and **never raises** — a probe that escaped would cost the node its connection, and an invisible node is worse than one engine marked unavailable.

## Health is derived, never stored

One derivation, `shared.protocol.node_health`. Never seen reads `unknown`, not `offline` — "never connected" and "was here and left" have different fixes. A switched-off node reads `offline`, not `degraded`: calling a powered-down machine degraded invents an incident.

## Security fix found reviewing this branch

Adversarial review turned up a **confirmed** hole, with a working PoC: the websocket receive loop trusted `AgentEnvelope.executor_id` — a field the **client writes into the message body** — instead of the id authenticated at the handshake. A connected node could:

- announce itself **as another node**, forging that node's reported capabilities, version and OS;
- send a heartbeat on another node's behalf, so a dead node read healthy.

Issue #16 had fixed exactly this for `task.ack` alone; every message type added since inherited the trust. The guard now sits **once, before the dispatch**, so the next message type cannot reintroduce it. Forged envelopes are dropped rather than redirected (redirecting would silently accept, as the sender's own, a message it never made about itself) and never close the socket.

`tests/integration/test_agent_ws_identity.py` drives real envelopes through the real loop — the gap survived 794 passing tests precisely because nothing did. Two of its five tests fail against the pre-fix code; verified by restoring the vulnerable lines and re-running.

## No path, no hostname

`discovery_root_count` is a count so the fleet surface can answer "does this node discover anything at all" without publishing a machine's filesystem layout. Probe `detail` strings are static literals. The agent reads `platform.system()`/`platform.machine()` and never `platform.node()`.

## Checks

- `pytest -q` → **799 passed, 7 skipped** (branch baseline 757/7).
- Contract `1.6.0` → **`1.9.0`**; 1.7.0 and 1.8.0 are taken by PRs #61 and #62, so the operator re-bumps on merge order.

## Not validated

No deploy; no real agent has connected to a real gateway with this build; `inventoryObservedAt` is exposed but reserved for the Stage 3 discovery surface and stays `null`. `GET /api/v1/nodes` returns the whole fleet unpaginated — fine at current fleet size, and called out here rather than silently.

Refs #73. work_id: `WK-20260901-gh73-fleet-visibility`.

https://claude.ai/code/session_013ZzDZZA8uAnKjackPX49VA
