### PR TITLE
fix(gh-15): remove the deprecated ?token= handshake form

### DIFF
--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -915,9 +915,8 @@ tests/
 - `test_a_handshake_with_no_credential_is_refused(client)`
 - `test_refusing_an_anonymous_handshake_touches_no_executor_record(client, monkeypatch)` — "4401 must be decided before the database, not after a lookup."
 - `test_the_header_is_bound_and_reaches_the_registry_check(client)` — "An unknown executor authenticating by header gets 4404, not 4401."
-- `test_the_query_parameter_still_works_and_warns(client, caplog)`
-- `test_the_deprecation_warning_does_not_print_the_token(client, caplog)` — "A warning about a leaked credential must not leak it again."
-- `test_the_header_path_logs_no_deprecation_warning(client, caplog)`
+- `test_the_query_parameter_no_longer_authenticates(client)` — "The removal #15 deferred by one release."
+- `test_a_query_token_cannot_stand_in_for_a_blank_header(client)` — "No fall-through: an empty header is absent, and the URL is not a backup."
 
 ### `tests/integration/test_api_conventions.py`
 
@@ -1505,12 +1504,10 @@ tests/
 
 > Credential resolution for the `/agent/ws` handshake — issue #15.
 
-- `test_header_is_the_new_path()`
-- `test_query_still_authenticates_during_the_transition()` — "Gateway and agent deploy independently, so the old form must keep working."
-- `test_header_wins_when_both_are_present()` — "An agent already on the header must not be downgraded by a stale query."
-- `test_nothing_presented_is_absent_not_empty_string()`
-- `test_blank_values_do_not_count_as_a_credential(blank)` — "`?token=` is not a presented credential."
-- `test_a_blank_header_falls_through_to_the_query()` — "Proxies that inject empty headers must not break the transition path."
+- `test_the_header_is_the_credential()`
+- `test_surrounding_whitespace_is_not_part_of_the_credential()`
+- `test_nothing_presented_is_absent()`
+- `test_blank_values_do_not_count_as_a_credential(blank)` — "A blank `X-Executor-Token:` is not a presented credential."
 
 ### `tests/unit/test_agent_auto_project.py`
 

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1291,3 +1291,26 @@ operador, a experiencia dele e o dado; a minha leitura e a hipotese.
 Efeito colateral util: a leitura correta (composicao — o conector planeja no
 forge, o CodexBridge executa na maquina) e um argumento melhor do que o que eu
 tinha antes, e virou a folha 3 da landing.
+
+## 2026-09-01 — "confirmado contra a versao X" e evidencia com prazo de validade
+
+Os comentarios de `agent/codex_bridge_agent/runners/codex.py` registram, com
+cuidado, que os modos de sandbox foram confirmados contra `codex-cli 0.147.0`.
+Isso e boa pratica e foi util. Mas ao testar a rede dentro do sandbox na devel3,
+a CLI instalada ja era a **0.151.0** — quatro versoes adiante do que o comentario
+afirma ter verificado.
+
+Desta vez o comportamento nao mudou (o `workspace-write` continua sem rede, e
+`danger-full-access` continua existindo). Mas ninguem sabia disso antes do teste:
+a decisao de arquitetura inteira estava apoiada numa observacao feita contra uma
+versao que nao e mais a que roda.
+
+Licao: anotar a versao nao congela o comportamento, so datar a evidencia. Quando
+uma propriedade de seguranca depende do comportamento de uma ferramenta externa,
+o teste tem de ser re-executavel — de preferencia um teste no repositorio, nao
+uma frase num comentario — para que a proxima sessao descubra a mudanca por
+falha, e nao por sorte.
+
+Adendo do mesmo teste: `sandbox_workspace_write.network_access=true` liga a rede
+dentro do sandbox com uma unica flag por invocacao. A facilidade e o argumento
+*contra* usar esse caminho, nao a favor (issue #80).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -66,11 +66,11 @@ Upgrade: websocket
 X-Executor-Token: <token de máquina>
 ```
 
-Compatibilidade: a forma antiga `?token=...` **continua aceita por uma release**,
-para que gateway e agente possam ser publicados em momentos diferentes. Quando ela
-é usada, o gateway emite um `WARNING` de depreciação — sem o valor do token. O
-header vence quando os dois estão presentes, para que um agente já corrigido não
-seja rebaixado por um parâmetro remanescente em proxy ou unit file.
+A forma antiga `?token=...` **foi removida** (a release de compatibilidade que
+#15 concedeu já passou). Token só na URL agora é o mesmo que token nenhum: o
+handshake fecha com `4401`, antes de qualquer consulta ao registro. Um executor
+que ainda mande o parâmetro precisa ser atualizado — o agente envia o header
+desde a mesma release (`agent/codex_bridge_agent/service.py`).
 
 Códigos de fechamento no handshake:
 

--- a/gateway/app/core/agent_auth.py
+++ b/gateway/app/core/agent_auth.py
@@ -1,49 +1,28 @@
 """Credential resolution for the `/agent/ws` handshake — issue #15.
 
-The executor machine token used to arrive only as a query parameter, so every
-component that logs a request line recorded it verbatim. The fix is to accept it
-from a header instead, keeping the query form working for one release so the
-gateway and the agent can be deployed independently.
+The executor machine token used to arrive as a query parameter, so every
+component that logs a request line recorded it verbatim. The fix was to accept
+it from the `X-Executor-Token` header instead, keeping the query form working
+for one release so the gateway and the agent could be deployed independently.
+That release has shipped: the query form is gone, and a handshake that presents
+a credential only in the URL is now refused like any other anonymous one.
 
 Resolution lives here, apart from the endpoint, because the interesting part is
-a decision — which credential was presented, and by which route — and a decision
-is worth testing without standing up a WebSocket, a database and a registry.
+a decision — whether a credential was presented at all — and a decision is worth
+testing without standing up a WebSocket, a database and a registry.
 """
 
 from __future__ import annotations
 
-from enum import Enum
 
+def resolve_executor_token(*, header_token: str | None) -> str | None:
+    """Return the credential to verify, or `None` when none was presented.
 
-class TokenSource(str, Enum):
-    """How the executor presented its machine token."""
-
-    HEADER = "header"
-    QUERY = "query"
-    ABSENT = "absent"
-
-
-def resolve_executor_token(
-    *,
-    header_token: str | None,
-    query_token: str | None,
-) -> tuple[str | None, TokenSource]:
-    """Pick the credential to verify and report where it came from.
-
-    The header wins when both are present: an agent that already sends the
-    header is on the new path, and a stale query parameter left behind by a
-    proxy or an old config must not silently downgrade it.
-
-    Empty strings count as absent. A blank `?token=` is not a presented
-    credential, and treating it as one would hand `secure_compare` an empty
-    string to check against the registry.
+    Empty and whitespace-only headers count as absent. A blank
+    `X-Executor-Token:` is not a presented credential, and treating it as one
+    would hand `secure_compare` an empty string to check against the registry —
+    a comparison that exists only to be rejected, and that a registry entry with
+    an empty `machine_token` would accept.
     """
     header = (header_token or "").strip()
-    if header:
-        return header, TokenSource.HEADER
-
-    query = (query_token or "").strip()
-    if query:
-        return query, TokenSource.QUERY
-
-    return None, TokenSource.ABSENT
+    return header or None

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -17,7 +17,7 @@ from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
 from gateway.app.api.setup import install_api_conventions
-from gateway.app.core.agent_auth import TokenSource, resolve_executor_token
+from gateway.app.core.agent_auth import resolve_executor_token
 from gateway.app.core.config import settings
 from gateway.app.version import APP_VERSION
 from gateway.app.core.logging import configure_logging
@@ -724,22 +724,16 @@ async def handle_task_cancelled(session: AsyncSession, envelope: AgentEnvelope) 
 async def agent_ws(
     websocket: WebSocket,
     executor_id: str,
-    token: str | None = None,
-    x_executor_token: str | None = Header(default=None),
+    x_executor_token: str | None = Header(default=None, alias=EXECUTOR_TOKEN_HEADER),
 ) -> None:
-    presented, source = resolve_executor_token(header_token=x_executor_token, query_token=token)
+    # The token is read from the header only. The deprecated `?token=...` form
+    # #15 kept accepting for one release is gone: a credential in the URL is a
+    # credential in every access log on the path, and the transition window it
+    # existed for has closed.
+    presented = resolve_executor_token(header_token=x_executor_token)
     if presented is None:
         await websocket.close(code=4401)
         return
-    if source == TokenSource.QUERY:
-        # No token value here, and none in any branch below: the point of the
-        # change is that this handshake stops writing the credential to logs.
-        logging.getLogger(__name__).warning(
-            "executor %s authenticated with the deprecated token query parameter, which is "
-            "recorded verbatim by every access log on the path; send the %s header instead (#15)",
-            executor_id,
-            EXECUTOR_TOKEN_HEADER,
-        )
 
     async with SessionLocal() as session:
         executor = await session.get(store.ExecutorModel, executor_id)

--- a/tests/integration/test_agent_ws_handshake.py
+++ b/tests/integration/test_agent_ws_handshake.py
@@ -3,13 +3,12 @@
 Resolution rules are unit-tested in `tests/unit/test_agent_auth.py`. What is
 worth an integration test is the wiring: that FastAPI actually binds the header,
 that a handshake with no credential is refused before anything touches the
-database, and that the surviving query path announces itself without printing
-the credential it was called with.
+database, and that the deprecated query form, kept accepted for one release, no
+longer authenticates anything.
 """
 
 from __future__ import annotations
 
-import logging
 from typing import AsyncIterator
 
 import pytest
@@ -96,39 +95,32 @@ def test_the_header_is_bound_and_reaches_the_registry_check(client: TestClient) 
     assert refused.value.code == 4404
 
 
-def test_the_query_parameter_still_works_and_warns(client: TestClient, caplog) -> None:
-    with caplog.at_level(logging.WARNING, logger="gateway.app.main"):
-        with pytest.raises(WebSocketDisconnect):
-            with client.websocket_connect("/agent/ws?executor_id=nobody&token=legacy"):
-                pass
+def test_the_query_parameter_no_longer_authenticates(client: TestClient) -> None:
+    """The removal #15 deferred by one release.
 
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("deprecated token query parameter" in r.getMessage() for r in warnings)
-
-
-def test_the_deprecation_warning_does_not_print_the_token(client: TestClient, caplog) -> None:
-    """A warning about a leaked credential must not leak it again.
-
-    This is the whole point of #15: the value stops appearing in anything the
-    gateway writes.
+    A credential presented only in the URL is now no credential at all: 4401,
+    decided before the registry is consulted, exactly like an anonymous
+    handshake. Any executor still on the old form must be upgraded to send the
+    header — the agent has sent it since the same release
+    (`agent/codex_bridge_agent/service.py`).
     """
-    with caplog.at_level(logging.WARNING, logger="gateway.app.main"):
-        with pytest.raises(WebSocketDisconnect):
-            with client.websocket_connect("/agent/ws?executor_id=nobody&token=s3cr3t-value"):
-                pass
-
-    for record in caplog.records:
-        assert "s3cr3t-value" not in record.getMessage()
-        assert "s3cr3t-value" not in str(record.args)
+    with pytest.raises(WebSocketDisconnect) as refused:
+        with client.websocket_connect("/agent/ws?executor_id=nobody&token=legacy"):
+            pass
+    assert refused.value.code == 4401
 
 
-def test_the_header_path_logs_no_deprecation_warning(client: TestClient, caplog) -> None:
-    with caplog.at_level(logging.WARNING, logger="gateway.app.main"):
-        with pytest.raises(WebSocketDisconnect):
-            with client.websocket_connect(
-                "/agent/ws?executor_id=nobody",
-                headers={EXECUTOR_TOKEN_HEADER: "whatever"},
-            ):
-                pass
+def test_a_query_token_cannot_stand_in_for_a_blank_header(client: TestClient) -> None:
+    """No fall-through: an empty header is absent, and the URL is not a backup.
 
-    assert not any("deprecated" in r.getMessage() for r in caplog.records)
+    The old resolver fell back to the query parameter when the header was blank,
+    so a proxy injecting an empty header kept the deprecated path alive. It does
+    not any more.
+    """
+    with pytest.raises(WebSocketDisconnect) as refused:
+        with client.websocket_connect(
+            "/agent/ws?executor_id=nobody&token=legacy",
+            headers={EXECUTOR_TOKEN_HEADER: ""},
+        ):
+            pass
+    assert refused.value.code == 4401

--- a/tests/unit/test_agent_auth.py
+++ b/tests/unit/test_agent_auth.py
@@ -1,63 +1,36 @@
 """Credential resolution for the `/agent/ws` handshake — issue #15.
 
 The token used to be a required query parameter, so it landed verbatim in every
-access log on the path. These tests pin the resolution rules that let the header
-replace it without breaking a fleet that is mid-upgrade.
+access log on the path. The header replaced it, and the compatibility window
+that kept `?token=...` alive for one release has closed: these tests pin what
+resolution accepts now that the header is the only route in.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from gateway.app.core.agent_auth import TokenSource, resolve_executor_token
+from gateway.app.core.agent_auth import resolve_executor_token
 
 
-def test_header_is_the_new_path() -> None:
-    presented, source = resolve_executor_token(header_token="t0ken", query_token=None)
-    assert presented == "t0ken"
-    assert source is TokenSource.HEADER
+def test_the_header_is_the_credential() -> None:
+    assert resolve_executor_token(header_token="t0ken") == "t0ken"
 
 
-def test_query_still_authenticates_during_the_transition() -> None:
-    """Gateway and agent deploy independently, so the old form must keep working."""
-    presented, source = resolve_executor_token(header_token=None, query_token="t0ken")
-    assert presented == "t0ken"
-    assert source is TokenSource.QUERY
+def test_surrounding_whitespace_is_not_part_of_the_credential() -> None:
+    assert resolve_executor_token(header_token="  t0ken  ") == "t0ken"
 
 
-def test_header_wins_when_both_are_present() -> None:
-    """An agent already on the header must not be downgraded by a stale query.
-
-    A proxy that rewrites the URL, or a leftover parameter in an old unit file,
-    would otherwise decide which credential authenticates — and would keep the
-    deprecation warning firing for an agent that was already fixed.
-    """
-    presented, source = resolve_executor_token(header_token="new", query_token="old")
-    assert presented == "new"
-    assert source is TokenSource.HEADER
-
-
-def test_nothing_presented_is_absent_not_empty_string() -> None:
-    presented, source = resolve_executor_token(header_token=None, query_token=None)
-    assert presented is None
-    assert source is TokenSource.ABSENT
+def test_nothing_presented_is_absent() -> None:
+    assert resolve_executor_token(header_token=None) is None
 
 
 @pytest.mark.parametrize("blank", ["", "   "])
 def test_blank_values_do_not_count_as_a_credential(blank: str) -> None:
-    """`?token=` is not a presented credential.
+    """A blank `X-Executor-Token:` is not a presented credential.
 
     Treating it as one hands `secure_compare` an empty string to check against
     the registry — a comparison that exists only to be rejected, and that a
     registry entry with an empty `machine_token` would accept.
     """
-    presented, source = resolve_executor_token(header_token=blank, query_token=blank)
-    assert presented is None
-    assert source is TokenSource.ABSENT
-
-
-def test_a_blank_header_falls_through_to_the_query() -> None:
-    """Proxies that inject empty headers must not break the transition path."""
-    presented, source = resolve_executor_token(header_token="", query_token="t0ken")
-    assert presented == "t0ken"
-    assert source is TokenSource.QUERY
+    assert resolve_executor_token(header_token=blank) is None


### PR DESCRIPTION
Closes the step #15 deferred: it moved the executor machine token to the `X-Executor-Token` header and kept `?token=...` accepted "for one release" so gateway and agent could ship independently. That release shipped — the agent has sent only the header since (`agent/codex_bridge_agent/service.py:85`). What stayed behind was the reason #15 existed: a credential in the URL is a credential in every access log on the path (37 occurrences in the gateway journal, 70 in nginx, per `docs/napkin-lessons.md`).

## What changes
- `/agent/ws` reads the header only, via the shared `EXECUTOR_TOKEN_HEADER` alias.
- A token presented only in the query string closes `4401`, **before** the registry is consulted — same path as an anonymous handshake, so it is not a probe for which executor ids exist.
- `resolve_executor_token` loses `TokenSource` and the blank-header fall-through with it: an empty header is absent, and the URL is no longer a backup for it.
- `docs/protocol.md` records the removal; `docs/codemap.md` follows the test rename.

## Validation
Full suite: 750 passed. The 4 failures in `test_probes.py`/`test_api_conventions.py` are pre-existing on `development` (verified with `git stash`): this checkout's `codex_bridge.db` predates migration 0009 and has no `users.json`.

## Operational note
Nothing deployed. A live executor still sending the query form would be refused until its agent is updated — the agent on `devel3` already sends the header.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw