### PR TITLE
feat(gh-78): plan epics and issues from the chat (MCP, forge-less project)

### DIFF
--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -140,6 +140,7 @@ tests/
     test_decisions.py  — "Operational decisions — issue #6."
     test_dispatch_payload_engine_and_delivery.py  — "`AgentHub.dispatch_next` forwards engine/issue_ref/delivery to the executor."
     test_epics_issues.py  — "Epics and issues — issue #8."
+    test_mcp_epics_issues.py  — "The `create_epic`/`list_epics`/`create_issue`/`list_issues` MCP tools -- issue #78."
     test_mcp_reminders.py  — "The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
     test_oauth_authorize.py  — "The browser OAuth form — the *other* caller of the password check."
@@ -1193,6 +1194,27 @@ tests/
 - `test_a_failed_link_does_not_keep_the_key_claimed(api)` *(async function)*
 - `test_the_epic_list_cursor_walks_every_epic_once(api)` *(async function)*
 - `test_list_epics_filters_by_status(api)` *(async function)*
+
+### `tests/integration/test_mcp_epics_issues.py`
+
+> The `create_epic`/`list_epics`/`create_issue`/`list_issues` MCP tools -- issue #78.
+
+- **`DummyHub`** *(class)*
+  - `is_connected(self, executor_id)` *(method)*
+  - `dispatch_next(self, executor_id)` *(async method)*
+  - `send(self, executor_id, envelope)` *(async method)*
+- `users_file(tmp_path)`
+- `env(users_file, monkeypatch)` *(async function)* — "One database, two doors onto it: `handle_mcp_call` directly, and a REST"
+- `_call(env, principal, tool_name, arguments)` *(async function)*
+- `test_create_epic_two_issues_and_list_them(env)` *(async function)*
+- `test_retried_create_epic_with_same_key_returns_the_same_epic(env)` *(async function)*
+- `test_same_idempotency_key_with_a_different_body_is_a_conflict(env)` *(async function)*
+- `test_principal_without_project_access_gets_a_typed_error_not_an_empty_list(env)` *(async function)*
+- `test_principal_without_write_scope_gets_missing_scope(env)` *(async function)*
+- `test_create_issue_returns_an_issue_ref_matching_the_shared_pattern(env)` *(async function)*
+- `test_unknown_status_or_priority_is_a_typed_validation_error(env)` *(async function)*
+- `test_an_epic_id_from_another_project_is_unknown_epic(env)` *(async function)*
+- `test_rows_created_via_mcp_appear_unchanged_via_rest(env)` *(async function)*
 
 ### `tests/integration/test_mcp_reminders.py`
 

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1291,3 +1291,26 @@ operador, a experiencia dele e o dado; a minha leitura e a hipotese.
 Efeito colateral util: a leitura correta (composicao — o conector planeja no
 forge, o CodexBridge executa na maquina) e um argumento melhor do que o que eu
 tinha antes, e virou a folha 3 da landing.
+
+## 2026-09-01 — "confirmado contra a versao X" e evidencia com prazo de validade
+
+Os comentarios de `agent/codex_bridge_agent/runners/codex.py` registram, com
+cuidado, que os modos de sandbox foram confirmados contra `codex-cli 0.147.0`.
+Isso e boa pratica e foi util. Mas ao testar a rede dentro do sandbox na devel3,
+a CLI instalada ja era a **0.151.0** — quatro versoes adiante do que o comentario
+afirma ter verificado.
+
+Desta vez o comportamento nao mudou (o `workspace-write` continua sem rede, e
+`danger-full-access` continua existindo). Mas ninguem sabia disso antes do teste:
+a decisao de arquitetura inteira estava apoiada numa observacao feita contra uma
+versao que nao e mais a que roda.
+
+Licao: anotar a versao nao congela o comportamento, so datar a evidencia. Quando
+uma propriedade de seguranca depende do comportamento de uma ferramenta externa,
+o teste tem de ser re-executavel — de preferencia um teste no repositorio, nao
+uma frase num comentario — para que a proxima sessao descubra a mudanca por
+falha, e nao por sorte.
+
+Adendo do mesmo teste: `sandbox_workspace_write.network_access=true` liga a rede
+dentro do sandbox com uma unica flag por invocacao. A facilidade e o argumento
+*contra* usar esse caminho, nao a favor (issue #80).

--- a/gateway/app/mcp/server.py
+++ b/gateway/app/mcp/server.py
@@ -7,10 +7,13 @@ from uuid import uuid4
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from gateway.app.api import idempotency, permissions
+from gateway.app.api.errors import ApiError
 from gateway.app.models.entities import ExecutorModel, IssueModel
 from gateway.app.services import store
 from gateway.app.services.agent_hub import AgentHub, hub_envelope
 from gateway.app.services.audit import record_event
+from gateway.app.services.issue_types import IssuePlanningError
 from gateway.app.mcp.tools import tool_definitions
 from gateway.app.core.users import AuthenticatedPrincipal
 from gateway.app.version import APP_VERSION
@@ -74,6 +77,31 @@ async def handle_mcp_call(
             raise HTTPException(status_code=401, detail="oauth_required")
         if not principal.has_scope(scope):
             raise HTTPException(status_code=403, detail=f"missing_scope:{scope}")
+
+    def require_action(action: permissions.Action) -> None:
+        # Epics/issues reuse the REST catalogue in gateway/app/api/permissions.py
+        # instead of a hand-copied scope string: that catalogue is the one
+        # `GET /api/v1/auth/me` and the REST routes both read, so a scope
+        # rename or a re-classification (issue #8's ISSUES_WRITE_SCOPE) shows
+        # up here for free instead of silently diverging on the next change.
+        if principal is None:
+            raise HTTPException(status_code=401, detail="oauth_required")
+        if not permissions.is_allowed(principal, action):
+            raise HTTPException(status_code=403, detail=f"missing_scope:{action.scope}")
+
+    async def resolve_project_or_404(text: str) -> "store.ProjectModel":
+        try:
+            project = await store.resolve_project_reference(session, str(text))
+        except store.AmbiguousProjectReference as exc:
+            candidates = ", ".join(f"{c.id} ({c.name})" for c in exc.candidates)
+            raise HTTPException(status_code=409, detail=f"ambiguous_project: {candidates}")
+        except ValueError:
+            raise HTTPException(status_code=404, detail="unknown_project")
+        # require_action already ensured `principal` is not None for every
+        # caller of this helper.
+        if not principal.can_access_project(project.id):
+            raise HTTPException(status_code=403, detail="project_access_denied")
+        return project
 
     def require_task_access(task) -> None:
         if principal is None:
@@ -550,6 +578,234 @@ async def handle_mcp_call(
             ]
         }
         result = _text_result(f"Returned {len(payload['tasks'])} tasks.", payload)
+    elif tool_name == "create_epic":
+        # Issue #78: exposes the same store.create_epic REST already tests
+        # (gateway/app/api/routes/epics.py) over the MCP/ChatGPT transport, for
+        # a project that may have no forge at all -- planning entities live in
+        # this gateway's own tables, not in GitHub.
+        require_action(permissions.EPICS_CREATE)
+        project = await resolve_project_or_404(arguments["project"])
+
+        idempotency_key = arguments.get("idempotency_key")
+        endpoint = "mcp:create_epic"
+        request_fingerprint = idempotency.fingerprint(
+            json.dumps(
+                {k: v for k, v in arguments.items() if k != "idempotency_key"},
+                sort_keys=True, default=str,
+            ).encode()
+        )
+        claim = None
+        if idempotency_key:
+            # ApiError is idempotency.py's native failure (a reused key with a
+            # different body, or one still in flight) -- gateway/app/api/scope.py
+            # exempts `/mcp` from the app-wide ApiError handler, so left
+            # uncaught this becomes a raw 500 that breaks the JSON-RPC envelope.
+            try:
+                outcome = await idempotency.reserve(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
+                    request_fingerprint=request_fingerprint,
+                )
+            except ApiError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+            if isinstance(outcome, idempotency.ReplayedResponse):
+                result = _text_result(f"Epic {outcome.body['epic_id']} already existed.", outcome.body)
+                return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
+            claim = outcome
+
+        try:
+            epic = await store.create_epic(
+                session,
+                project_id=project.id,
+                title=str(arguments["title"]),
+                description=arguments.get("description"),
+                status=arguments.get("status"),
+                actor_user_id=principal.user_id,
+                actor_email=principal.email,
+            )
+        except IssuePlanningError as exc:
+            if claim is not None:
+                await idempotency.release(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+                )
+            raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
+        except Exception:
+            if claim is not None:
+                await idempotency.release(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+                )
+            raise
+
+        payload = {
+            "epic_id": epic.id,
+            "project_id": epic.project_id,
+            "title": epic.title,
+            "description": epic.description,
+            "status": epic.status,
+        }
+        if claim is not None:
+            try:
+                await idempotency.complete(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
+                    status_code=201, body=payload, claim=claim, request_fingerprint=request_fingerprint,
+                )
+            except ApiError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+        result = _text_result(f"Epic {epic.id} created.", payload)
+    elif tool_name == "list_epics":
+        require_action(permissions.EPICS_READ)
+        project = await resolve_project_or_404(arguments["project"])
+        limit = int(arguments.get("limit", 20))
+        rows = await store.list_epics_page(
+            session, project_id=project.id, status=arguments.get("status"), limit=limit + 1
+        )
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        payload = {
+            "epics": [
+                {
+                    "epic_id": epic.id,
+                    "project_id": epic.project_id,
+                    "title": epic.title,
+                    "description": epic.description,
+                    "status": epic.status,
+                }
+                for epic in rows
+            ],
+            "has_more": has_more,
+        }
+        result = _text_result(f"Found {len(payload['epics'])} epics.", payload)
+    elif tool_name == "create_issue":
+        require_action(permissions.ISSUES_CREATE)
+        project = await resolve_project_or_404(arguments["project"])
+
+        epic_id = arguments.get("epic_id")
+        if epic_id is not None:
+            # Pre-checked here, distinct from the IssuePlanningError store.create_issue
+            # would otherwise raise for the same condition: this is a reference the
+            # caller should have gotten right by listing epics first (like an
+            # unknown project or issue), not a malformed field on this request's own
+            # body -- so it gets its own typed detail instead of validation_failed's
+            # generic shape.
+            epic_row = await store.get_epic_for_projects(session, str(epic_id), [project.id])
+            if epic_row is None:
+                raise HTTPException(status_code=404, detail="unknown_epic")
+
+        idempotency_key = arguments.get("idempotency_key")
+        endpoint = "mcp:create_issue"
+        request_fingerprint = idempotency.fingerprint(
+            json.dumps(
+                {k: v for k, v in arguments.items() if k != "idempotency_key"},
+                sort_keys=True, default=str,
+            ).encode()
+        )
+        claim = None
+        if idempotency_key:
+            try:
+                outcome = await idempotency.reserve(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
+                    request_fingerprint=request_fingerprint,
+                )
+            except ApiError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+            if isinstance(outcome, idempotency.ReplayedResponse):
+                result = _text_result(f"Issue {outcome.body['issue_id']} already existed.", outcome.body)
+                return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
+            claim = outcome
+
+        try:
+            issue = await store.create_issue(
+                session,
+                project_id=project.id,
+                epic_id=str(epic_id) if epic_id is not None else None,
+                title=str(arguments["title"]),
+                description=arguments.get("description"),
+                status=arguments.get("status"),
+                priority=arguments.get("priority"),
+                labels=arguments.get("labels"),
+                assignee_user_id=arguments.get("assignee_user_id"),
+                assignee_email=arguments.get("assignee_email"),
+                dependencies=arguments.get("dependencies"),
+                blocked_reason=arguments.get("blocked_reason"),
+                actor_user_id=principal.user_id,
+                actor_email=principal.email,
+            )
+        except IssuePlanningError as exc:
+            if claim is not None:
+                await idempotency.release(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+                )
+            raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
+        except Exception:
+            if claim is not None:
+                await idempotency.release(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+                )
+            raise
+
+        payload = {
+            "issue_id": issue.id,
+            # Same shape ISSUE_REF_PATTERN (shared/protocol.py) already accepts
+            # and start_development_task already resolves -- an issue created
+            # in chat goes straight to execution without a second id space.
+            "issue_ref": f"local:{issue.id}",
+            "project_id": issue.project_id,
+            "epic_id": issue.epic_id,
+            "title": issue.title,
+            "description": issue.description,
+            "status": issue.status,
+            "priority": issue.priority,
+            "labels": json.loads(issue.labels_json or "[]"),
+            "assignee_user_id": issue.assignee_user_id,
+            "assignee_email": issue.assignee_email,
+            "dependencies": json.loads(issue.dependencies_json or "[]"),
+            "blocked_reason": issue.blocked_reason,
+        }
+        if claim is not None:
+            try:
+                await idempotency.complete(
+                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
+                    status_code=201, body=payload, claim=claim, request_fingerprint=request_fingerprint,
+                )
+            except ApiError as exc:
+                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+        result = _text_result(f"Issue {issue.id} created.", payload)
+    elif tool_name == "list_issues":
+        require_action(permissions.ISSUES_READ)
+        project = await resolve_project_or_404(arguments["project"])
+        limit = int(arguments.get("limit", 20))
+        rows = await store.list_issues_page(
+            session,
+            project_id=project.id,
+            status=arguments.get("status"),
+            priority=arguments.get("priority"),
+            epic_id=arguments.get("epic_id"),
+            assignee_user_id=arguments.get("assignee_user_id"),
+            limit=limit + 1,
+        )
+        has_more = len(rows) > limit
+        rows = rows[:limit]
+        payload = {
+            "issues": [
+                {
+                    "issue_id": issue.id,
+                    "issue_ref": f"local:{issue.id}",
+                    "project_id": issue.project_id,
+                    "epic_id": issue.epic_id,
+                    "title": issue.title,
+                    "description": issue.description,
+                    "status": issue.status,
+                    "priority": issue.priority,
+                    "labels": json.loads(issue.labels_json or "[]"),
+                    "assignee_user_id": issue.assignee_user_id,
+                    "assignee_email": issue.assignee_email,
+                    "dependencies": json.loads(issue.dependencies_json or "[]"),
+                    "blocked_reason": issue.blocked_reason,
+                }
+                for issue in rows
+            ],
+            "has_more": has_more,
+        }
+        result = _text_result(f"Found {len(payload['issues'])} issues.", payload)
     elif tool_name == "create_reminder":
         # WK-20260830-chatgpt-entry-provider-and-delivery, issue #71. Runs on
         # the gateway, not the executor -- see google_calendar.py's module

--- a/gateway/app/mcp/tools.py
+++ b/gateway/app/mcp/tools.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from gateway.app.services.issue_types import EPIC_STATUSES, ISSUE_PRIORITIES, ISSUE_STATUSES
+
 
 def tool_definitions() -> list[dict[str, Any]]:
     return [
@@ -215,6 +217,107 @@ def tool_definitions() -> list[dict[str, Any]]:
                         "description": "Filtra por estado. Util para 'o que terminou desde a ultima vez que perguntei' (ex: [\"completed\", \"failed\"]).",
                     },
                 },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "create_epic",
+            "title": "Create epic",
+            "description": "Criar uma epica para agrupar issues dentro de um projeto que pode nao ter forge nenhum.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "project_id, nome, ou prefixo unico de um dos dois (retornado por list_projects).",
+                    },
+                    "title": {"type": "string", "minLength": 1, "maxLength": 255},
+                    "description": {"type": "string", "maxLength": 20000},
+                    "status": {"type": "string", "enum": sorted(EPIC_STATUSES)},
+                    "idempotency_key": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "description": "Repetir a mesma chave devolve a mesma epica em vez de criar outra.",
+                    },
+                },
+                "required": ["project", "title"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "list_epics",
+            "title": "List epics",
+            "description": "Listar epicas de um projeto, mais recentes primeiro.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "project_id, nome, ou prefixo unico de um dos dois (retornado por list_projects).",
+                    },
+                    "status": {"type": "array", "items": {"type": "string", "enum": sorted(EPIC_STATUSES)}},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+                },
+                "required": ["project"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "create_issue",
+            "title": "Create issue",
+            "description": "Criar uma issue em um projeto, opcionalmente dentro de uma epica ja existente.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "project_id, nome, ou prefixo unico de um dos dois (retornado por list_projects).",
+                    },
+                    "epic_id": {"type": "string", "description": "id de uma epica existente no mesmo projeto (retornado por list_epics)."},
+                    "title": {"type": "string", "minLength": 1, "maxLength": 255},
+                    "description": {"type": "string", "maxLength": 20000},
+                    "status": {"type": "string", "enum": sorted(ISSUE_STATUSES)},
+                    "priority": {"type": "string", "enum": sorted(ISSUE_PRIORITIES)},
+                    "labels": {"type": "array", "items": {"type": "string"}, "maxItems": 64},
+                    "assignee_user_id": {"type": "string", "maxLength": 255},
+                    "assignee_email": {"type": "string", "maxLength": 255},
+                    "dependencies": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "maxItems": 64,
+                        "description": "ids de outras issues no mesmo projeto.",
+                    },
+                    "blocked_reason": {"type": "string", "maxLength": 20000},
+                    "idempotency_key": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "description": "Repetir a mesma chave devolve a mesma issue em vez de criar outra.",
+                    },
+                },
+                "required": ["project", "title"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "list_issues",
+            "title": "List issues",
+            "description": "Listar issues de um projeto, mais recentes primeiro, com filtros opcionais.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project": {
+                        "type": "string",
+                        "description": "project_id, nome, ou prefixo unico de um dos dois (retornado por list_projects).",
+                    },
+                    "status": {"type": "array", "items": {"type": "string", "enum": sorted(ISSUE_STATUSES)}},
+                    "priority": {"type": "array", "items": {"type": "string", "enum": sorted(ISSUE_PRIORITIES)}},
+                    "epic_id": {"type": "string"},
+                    "assignee_user_id": {"type": "string"},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+                },
+                "required": ["project"],
                 "additionalProperties": False,
             },
         },

--- a/tests/integration/test_mcp_epics_issues.py
+++ b/tests/integration/test_mcp_epics_issues.py
@@ -1,0 +1,343 @@
+"""The `create_epic`/`list_epics`/`create_issue`/`list_issues` MCP tools -- issue #78.
+
+Exposes the epics/issues store already tested via REST
+(`tests/integration/test_epics_issues.py`) over the MCP/ChatGPT transport, for
+a project that may have no forge at all -- "plan conversing in ChatGPT". This
+file does not re-prove store validation (that belongs to
+`tests/unit`/`tests/integration/test_epics_issues.py`); it proves the four
+tools reach the SAME store, apply the same authorization catalogue
+(`gateway/app/api/permissions.py`) the REST routes use, add idempotency on the
+two creators only (mirroring the REST pair, since `PATCH /issues/{id}` has
+none), and return the `issue_ref` shape `start_development_task` already
+resolves.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import epics as epics_routes
+from gateway.app.api.routes import issues as issues_routes
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.mcp.server import handle_mcp_call
+from gateway.app.services import store
+from shared.protocol import ISSUE_REF_PATTERN, ExecutorRegistration, ProjectRegistration
+
+
+class DummyHub:
+    def is_connected(self, executor_id: str) -> bool:
+        return False
+
+    async def dispatch_next(self, executor_id: str):
+        return None
+
+    async def send(self, executor_id: str, envelope):
+        pass
+
+
+# p1 only, holds codexbridge.issues.write -- the ISSUES_WRITE_SCOPE both
+# EPICS_CREATE and ISSUES_CREATE require (gateway/app/api/permissions.py).
+ALICE = AuthenticatedPrincipal(
+    user_id="alice",
+    email="alice@example.com",
+    allowed_projects=["p1"],
+    scopes=["codexbridge.read", "codexbridge.issues.write"],
+)
+
+# p1 only, read-only -- no ISSUES_WRITE_SCOPE.
+READER = AuthenticatedPrincipal(
+    user_id="reader",
+    email="reader@example.com",
+    allowed_projects=["p1"],
+    scopes=["codexbridge.read"],
+)
+
+# Holds the write scope but p1 is not in its allowed_projects: p2 only.
+OUTSIDER = AuthenticatedPrincipal(
+    user_id="outsider",
+    email="outsider@example.com",
+    allowed_projects=["p2"],
+    scopes=["codexbridge.read", "codexbridge.issues.write"],
+)
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "admin", "email": "admin@example.com", "password_hash": "x",
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def env(users_file, monkeypatch):
+    """One database, two doors onto it: `handle_mcp_call` directly, and a REST
+
+    `TestClient` mounting the real `epics`/`issues` routers -- so test #8 below
+    can prove they are the same storage, not a parallel one.
+    """
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="T1", display_name="T1", machine_token="t",
+                    allowed_projects=["p1", "p2"], max_concurrent_tasks=5,
+                )
+            ],
+            projects=[
+                ProjectRegistration(project_id="p1", name="Projeto Um", path="/srv/p1", max_timeout_seconds=3600),
+                ProjectRegistration(project_id="p2", name="Projeto Dois", path="/srv/p2", max_timeout_seconds=3600),
+            ],
+        )
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        await store.create_oauth_access_token(
+            seed, token="admin-tok", client_id="c", user_id="admin",
+            scopes=["codexbridge.admin"], expires_at=future,
+        )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(epics_routes.router)
+    app.include_router(issues_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    class Env:
+        def __init__(self):
+            self.factory = factory
+            self.client = TestClient(app, raise_server_exceptions=False)
+            self.admin_headers = {"Authorization": "Bearer admin-tok"}
+
+    yield Env()
+    await engine.dispose()
+
+
+async def _call(env, principal, tool_name: str, arguments: dict) -> dict:
+    async with env.factory() as session:
+        response = await handle_mcp_call(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},
+            session, DummyHub(), principal,
+        )
+    return response["result"]["structuredContent"]
+
+
+# --------------------------------------------------------------------------
+# 1. Epic, two issues on it, list both -- all through MCP.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_epic_two_issues_and_list_them(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Q3 planning"})
+    assert epic["project_id"] == "p1"
+    assert epic["status"] == "open"
+
+    issue_a = await _call(env, ALICE, "create_issue", {
+        "project": "p1", "epic_id": epic["epic_id"], "title": "First slice",
+    })
+    issue_b = await _call(env, ALICE, "create_issue", {
+        "project": "p1", "epic_id": epic["epic_id"], "title": "Second slice",
+    })
+
+    listed = await _call(env, ALICE, "list_issues", {"project": "p1", "epic_id": epic["epic_id"]})
+    assert listed["has_more"] is False
+    ids = {item["issue_id"] for item in listed["issues"]}
+    assert ids == {issue_a["issue_id"], issue_b["issue_id"]}
+
+    epics_listed = await _call(env, ALICE, "list_epics", {"project": "p1"})
+    assert [e["epic_id"] for e in epics_listed["epics"]] == [epic["epic_id"]]
+
+
+# --------------------------------------------------------------------------
+# 2/3. Idempotency on create_epic.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retried_create_epic_with_same_key_returns_the_same_epic(env):
+    first = await _call(env, ALICE, "create_epic", {
+        "project": "p1", "title": "Once only", "idempotency_key": "epic-key-1",
+    })
+    second = await _call(env, ALICE, "create_epic", {
+        "project": "p1", "title": "Once only", "idempotency_key": "epic-key-1",
+    })
+    assert second["epic_id"] == first["epic_id"]
+
+    listed = await _call(env, ALICE, "list_epics", {"project": "p1"})
+    assert len(listed["epics"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_idempotency_key_with_a_different_body_is_a_conflict(env):
+    await _call(env, ALICE, "create_epic", {
+        "project": "p1", "title": "Body A", "idempotency_key": "epic-key-2",
+    })
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "create_epic", {
+            "project": "p1", "title": "Body B (different)", "idempotency_key": "epic-key-2",
+        })
+    assert raised.value.status_code == 409
+
+
+# --------------------------------------------------------------------------
+# 4. A principal without the project in allowed_projects gets a typed error,
+#    never a silently empty list that looks like success.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_principal_without_project_access_gets_a_typed_error_not_an_empty_list(env):
+    await _call(env, ALICE, "create_issue", {"project": "p1", "title": "Visible to Alice only"})
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, OUTSIDER, "list_issues", {"project": "p1"})
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "project_access_denied"
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, OUTSIDER, "create_issue", {"project": "p1", "title": "Should not land"})
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "project_access_denied"
+
+
+# --------------------------------------------------------------------------
+# 5. A principal without the write scope is refused with missing_scope, not a
+#    generic 403.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_principal_without_write_scope_gets_missing_scope(env):
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, READER, "create_issue", {"project": "p1", "title": "Reader cannot write"})
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "missing_scope:codexbridge.issues.write"
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, READER, "create_epic", {"project": "p1", "title": "Reader cannot write"})
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "missing_scope:codexbridge.issues.write"
+
+    # READER still holds codexbridge.read, so listing is unaffected.
+    listed = await _call(env, READER, "list_issues", {"project": "p1"})
+    assert listed["issues"] == []
+
+
+# --------------------------------------------------------------------------
+# 6. create_issue returns issue_ref in the exact shape start_development_task
+#    already resolves.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_issue_returns_an_issue_ref_matching_the_shared_pattern(env):
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "Resolvable from chat"})
+    assert issue["issue_ref"] == f"local:{issue['issue_id']}"
+    assert ISSUE_REF_PATTERN.match(issue["issue_ref"])
+
+    listed = await _call(env, ALICE, "list_issues", {"project": "p1"})
+    assert listed["issues"][0]["issue_ref"] == issue["issue_ref"]
+
+
+# --------------------------------------------------------------------------
+# 7. Unknown status/priority are translated store validation, not a raw 500.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_status_or_priority_is_a_typed_validation_error(env):
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x", "status": "not-a-status"})
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "validation_failed:/status:invalid_status"
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x", "priority": "not-a-priority"})
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "validation_failed:/priority:invalid_priority"
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x", "status": "not-a-status"})
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "validation_failed:/status:invalid_status"
+
+
+@pytest.mark.asyncio
+async def test_an_epic_id_from_another_project_is_unknown_epic(env):
+    other = await _call(env, AuthenticatedPrincipal(
+        user_id="admin", email="admin@example.com", roles=["admin"],
+        allowed_projects=[], scopes=["codexbridge.admin"],
+    ), "create_epic", {"project": "p2", "title": "Lives in p2"})
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "create_issue", {
+            "project": "p1", "epic_id": other["epic_id"], "title": "Cross-project link",
+        })
+    assert raised.value.status_code == 404
+    assert raised.value.detail == "unknown_epic"
+
+
+# --------------------------------------------------------------------------
+# 8. The same rows, unchanged, through the REST surface #8 already ships --
+#    proving one store, not a parallel one.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rows_created_via_mcp_appear_unchanged_via_rest(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Seen from both sides"})
+    issue = await _call(env, ALICE, "create_issue", {
+        "project": "p1", "epic_id": epic["epic_id"], "title": "Same row, two doors",
+        "priority": "high", "labels": ["backend"],
+    })
+
+    rest_epics = env.client.get("/api/v1/projects/p1/epics", headers=env.admin_headers).json()
+    assert len(rest_epics["items"]) == 1
+    rest_epic = rest_epics["items"][0]
+    assert rest_epic["id"] == epic["epic_id"]
+    assert rest_epic["title"] == epic["title"]
+    assert rest_epic["status"] == epic["status"]
+
+    rest_issue_resp = env.client.get(f"/api/v1/issues/{issue['issue_id']}", headers=env.admin_headers)
+    assert rest_issue_resp.status_code == 200
+    rest_issue = rest_issue_resp.json()
+    assert rest_issue["id"] == issue["issue_id"]
+    assert rest_issue["epicId"] == epic["epic_id"]
+    assert rest_issue["title"] == issue["title"]
+    assert rest_issue["priority"] == "high"
+    assert rest_issue["labels"] == ["backend"]


### PR DESCRIPTION
Issue #78, stage 1 of 2. Lets an operator create and list epics and issues from ChatGPT, on a project bound to no forge at all — the storage already existed (`EpicModel`/`IssueModel`, migration `0006`, REST from #8), nothing exposed it to the conversation.

## What changes
Four MCP tools — `create_epic`, `list_epics`, `create_issue`, `list_issues` — over the store REST already tests. No new table, no new id space, no schema change.

## Three decisions worth reviewing
- **Authorization imports the REST catalogue** (`permissions.is_allowed`) instead of copying `"codexbridge.issues.write"` as a string. The catalogue is what `GET /api/v1/auth/me` and the REST routes both read; a hand-copied string passes today and diverges on the next change. This repository has recorded that exact failure twice (`STOPPABLE_TASK_STATES`; `task.decision_resolved_by_actor`).
- **`ApiError` is translated to `HTTPException` at every reuse of REST plumbing.** `gateway/app/api/scope.py` exempts `/mcp` from the app-wide `ApiError` handler, so an uncaught one becomes a raw 500 that breaks the JSON-RPC envelope.
- **`create_issue` returns `issue_ref = "local:<id>"`** — the shape `ISSUE_REF_PATTERN` already accepts and `start_development_task` already resolves, so an issue created in chat goes straight to execution without a second id space.

Idempotency only on the two creates (the REST `PATCH` has none, and inventing one here would be the asymmetry this PR is avoiding). Pagination is `limit`-only, matching `list_recent_tasks`.

## Not here, on purpose
No delete tool. `cancelled` exists in both vocabularies, nothing in this system has `DELETE`, and removing an issue would retroactively break `dependencies_json` for anything that depended on it — `store._validate_dependencies` treats an unknown id as a hard error on the next write. This closes the open question in #78.

## Validation
`pytest -q`: 766 passed, 7 skipped, 0 failed. `tests/contract/`: 26 passed. Nine integration tests at the `handle_mcp_call` layer, including: idempotent retry yields one row, reused key with a different body → 409, a principal outside `allowed_projects` gets a typed error rather than an empty list that looks like success, and rows written via MCP read back unchanged through the REST surface.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw