### PR TITLE
feat(gh-78): epic update, issue update and issue-to-epic move over MCP

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -779,6 +779,7 @@ validate the current mission state").
 `GET /api/v1/projects/{projectId}/epics`, `GET .../issues`,
 `GET /api/v1/issues/{issueId}`, `POST /api/v1/issues`,
 `PATCH /api/v1/issues/{issueId}`, `POST /api/v1/epics`,
+`GET /api/v1/epics/{epicId}`, `PATCH /api/v1/epics/{epicId}`,
 `POST /api/v1/epics/{epicId}/issues/{issueId}`.
 
 An **epic** groups issues within one project. An **issue** carries status,
@@ -815,6 +816,20 @@ choice a future issue should make deliberately rather than this one making it
 implicitly. A future issue that defines what a "decision" or "mission"
 reference from an issue actually means can add it the same way `epicId` was
 added here.
+
+### An epic could not itself be changed, and that was a dead end
+
+Before `WK-20260902-epic-update-and-move`, an epic could be created, listed,
+read as part of a list page, and linked to — but there was no transport, REST
+or MCP, that could change an epic's own `title`, `description` or `status`.
+That is not a gap symmetric with issues: this project's answer to "there is no
+delete, use `cancelled`" (see `docs/limits.md`) is only an answer if
+`cancelled` is reachable, and for an epic it was not. `GET /api/v1/epics/{epicId}`
+and `PATCH /api/v1/epics/{epicId}` close it, mirroring `GET`/`PATCH
+/api/v1/issues/{issueId}` field for field — `ETag`/`If-Match`, 404 for a
+hidden epic never 403, `validation_failed` for an unknown `status` — with the
+one difference that follows from the model itself: an epic has no `labels` or
+`dependencies` to carry into `UpdateEpicRequest`.
 
 ### Two ways to change an issue, on purpose kept to one relationship
 
@@ -864,10 +879,19 @@ precedent already argues against.
 `POST /api/v1/epics`, `POST /api/v1/issues` and the link endpoint all accept
 `Idempotency-Key`, the same reserve-then-complete flow `POST
 /api/v1/sessions/{sessionId}/stop` uses: a client that lost the network after
-creating an issue can retry without risking a second issue. `PATCH` does not
-carry it — a repeated identical `PATCH` is naturally idempotent at the field
-level, and `If-Match` already refuses a retry that arrived after a concurrent
-change.
+creating an issue can retry without risking a second issue. Neither `PATCH`
+(issues or epics) carries it — a repeated identical `PATCH` is naturally
+idempotent at the field level, and `If-Match` already refuses a retry that
+arrived after a concurrent change. The MCP tools this same work_id adds
+(`update_issue`, `update_epic`, `move_issue_to_epic`) follow the same split:
+the first two carry no idempotency key, `move_issue_to_epic` does, mirroring
+the link endpoint it wraps. All three require `expected_revision` — the
+JSON-RPC shape of `If-Match` — since an MCP caller must not get a laxer
+concurrency contract on the same domain just because JSON-RPC has no header
+to forget: absent is `expected_revision_required` (400), stale is
+`stale_write` (409), same codes `gateway/app/api/concurrency.py` uses for the
+REST `428`/`412` pair, translated to the status codes the `/mcp` JSON-RPC
+transport already uses elsewhere (`gateway/app/mcp/server.py`).
 
 ### The write scope is separate from cancel
 

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.6.0
+  version: 1.11.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -1727,6 +1727,86 @@ paths:
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
 
+  /api/v1/epics/{epicId}:
+    get:
+      operationId: getEpic
+      tags: [epics]
+      summary: One epic
+      description: |
+        Returns an `ETag` derived from the epic's revision. Send it back as
+        `If-Match` on `PATCH`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: epicId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+      responses:
+        '200':
+          description: The epic.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Epic'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+    patch:
+      operationId: updateEpic
+      tags: [epics]
+      summary: Change title, description or status
+      description: |
+        A field the caller does not mention is left untouched; a field sent
+        explicitly as `null` is cleared. This is the one transport that can
+        move an epic to `cancelled` -- this build's answer to "there is no
+        delete" applied to epics, not only to issues.
+
+        Requires `If-Match`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: epicId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IfMatch'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateEpicRequest'
+      responses:
+        '200':
+          description: The epic after the update.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+            ETag:
+              $ref: '#/components/headers/ETag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Epic'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '412': {$ref: '#/components/responses/StaleWrite'}
+        '428': {$ref: '#/components/responses/PreconditionRequired'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
   /api/v1/issues:
     post:
       operationId: createIssue
@@ -3366,6 +3446,23 @@ components:
         status:
           $ref: '#/components/schemas/EpicStatus'
           description: Defaults to `open` when omitted.
+
+    UpdateEpicRequest:
+      type: object
+      description: |
+        Every field is optional. A field the caller does not mention is left
+        unchanged; a field sent explicitly as `null` is cleared. An epic has
+        no `labels` or `dependencies`, unlike `UpdateIssueRequest`.
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 255
+        description:
+          type: [string, 'null']
+          maxLength: 20000
+        status:
+          $ref: '#/components/schemas/EpicStatus'
 
     CreateIssueRequest:
       type: object

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-01 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-epic-update-and-move`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-epic-update-and-move map`
 
 ## Summary
 
-- 126 file(s) · 1181 symbol(s) indexed
-- Languages: config (2), python (122), shell (2)
+- 127 file(s) · 1222 symbol(s) indexed
+- Languages: config (2), python (123), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -140,7 +140,7 @@ tests/
     test_decisions.py  — "Operational decisions — issue #6."
     test_dispatch_payload_engine_and_delivery.py  — "`AgentHub.dispatch_next` forwards engine/issue_ref/delivery to the executor."
     test_epics_issues.py  — "Epics and issues — issue #8."
-    test_mcp_epics_issues.py  — "The `create_epic`/`list_epics`/`create_issue`/`list_issues` MCP tools -- issue #78."
+    test_mcp_epics_issues.py  — "The epics/issues MCP tools -- issue #78."
     test_mcp_reminders.py  — "The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
     test_oauth_authorize.py  — "The browser OAuth form — the *other* caller of the password check."
@@ -419,8 +419,11 @@ tests/
 > Epics — issue #8.
 
 - **`CreateEpicRequest`** *(class)*
+- **`UpdateEpicRequest`** *(class)*
 - `list_epics(project_id, response, status, cursor, limit, principal, session)` *(async function)* — "Epics in one project, newest first."
+- `get_epic_detail(epic_id, response, principal, session)` *(async function)*
 - `create_epic(payload, response, idempotency_key, principal, session)` *(async function)*
+- `update_epic(epic_id, payload, response, if_match, principal, session)` *(async function)* — "Change title, description or status."
 - `link_issue(epic_id, issue_id, response, if_match, idempotency_key, principal, session)` *(async function)* — "Attach an issue to an epic. Both must be in a project the caller may see."
 
 ### `gateway/app/api/routes/issues.py`
@@ -745,6 +748,7 @@ tests/
 - `get_epic(session, epic_id)` *(async function)*
 - `get_epic_for_projects(session, epic_id, project_ids)` *(async function)* — "An epic the caller may see, or None. Mirrors `get_task_for_projects`."
 - `list_epics_page(session)` *(async function)* — "Epics in one project, newest first, over-fetched by one."
+- `update_epic(session, epic_id)` *(async function)* — "Change title, description or status. Mirrors `update_issue` below --"
 - `create_issue(session)` *(async function)*
 - `get_issue(session, issue_id)` *(async function)*
 - `get_issue_for_projects(session, issue_id, project_ids)` *(async function)*
@@ -1194,10 +1198,17 @@ tests/
 - `test_a_failed_link_does_not_keep_the_key_claimed(api)` *(async function)*
 - `test_the_epic_list_cursor_walks_every_epic_once(api)` *(async function)*
 - `test_list_epics_filters_by_status(api)` *(async function)*
+- `test_get_epic_returns_an_etag(api)` *(async function)*
+- `test_update_epic_requires_if_match(api)` *(async function)*
+- `test_update_epic_with_a_stale_etag_is_refused(api)` *(async function)*
+- `test_update_epic_changes_only_the_mentioned_fields(api)` *(async function)* — "Positive control for the two If-Match negatives above."
+- `test_update_epic_can_explicitly_clear_a_nullable_field(api)` *(async function)*
+- `test_update_epic_rejects_an_unknown_status(api)` *(async function)*
+- `test_a_reader_cannot_update_an_epic(api)` *(async function)*
 
 ### `tests/integration/test_mcp_epics_issues.py`
 
-> The `create_epic`/`list_epics`/`create_issue`/`list_issues` MCP tools -- issue #78.
+> The epics/issues MCP tools -- issue #78.
 
 - **`DummyHub`** *(class)*
   - `is_connected(self, executor_id)` *(method)*
@@ -1205,7 +1216,6 @@ tests/
   - `send(self, executor_id, envelope)` *(async method)*
 - `users_file(tmp_path)`
 - `env(users_file, monkeypatch)` *(async function)* — "One database, two doors onto it: `handle_mcp_call` directly, and a REST"
-- `_call(env, principal, tool_name, arguments)` *(async function)*
 - `test_create_epic_two_issues_and_list_them(env)` *(async function)*
 - `test_retried_create_epic_with_same_key_returns_the_same_epic(env)` *(async function)*
 - `test_same_idempotency_key_with_a_different_body_is_a_conflict(env)` *(async function)*
@@ -1215,6 +1225,21 @@ tests/
 - `test_unknown_status_or_priority_is_a_typed_validation_error(env)` *(async function)*
 - `test_an_epic_id_from_another_project_is_unknown_epic(env)` *(async function)*
 - `test_rows_created_via_mcp_appear_unchanged_via_rest(env)` *(async function)*
+- `test_update_issue_changes_only_the_mentioned_fields(env)` *(async function)* — "Positive control for the two expected_revision negatives below."
+- `test_update_issue_accepts_the_bare_id_or_the_local_prefixed_ref(env)` *(async function)*
+- `test_update_issue_without_expected_revision_is_refused(env)` *(async function)*
+- `test_update_issue_with_a_stale_expected_revision_is_refused(env)` *(async function)*
+- `test_update_issue_with_an_unknown_status_is_a_typed_validation_error(env)` *(async function)*
+- `test_update_issue_on_another_projects_issue_is_unknown_issue(env)` *(async function)*
+- `test_update_epic_changes_only_the_mentioned_fields(env)` *(async function)* — "Positive control for the two expected_revision negatives below."
+- `test_update_epic_without_expected_revision_is_refused(env)` *(async function)*
+- `test_update_epic_with_a_stale_expected_revision_is_refused(env)` *(async function)*
+- `test_update_epic_with_an_unknown_status_is_a_typed_validation_error(env)` *(async function)*
+- `test_move_issue_to_epic_changes_the_issues_epic(env)` *(async function)* — "Positive control for the two expected_revision negatives below."
+- `test_move_issue_to_epic_without_expected_revision_is_refused(env)` *(async function)*
+- `test_move_issue_to_epic_with_a_stale_expected_revision_is_refused(env)` *(async function)*
+- `test_move_issue_to_epic_from_a_foreign_project_is_unknown_epic(env)` *(async function)*
+- `test_a_retried_move_does_not_move_the_issue_twice(env)` *(async function)*
 
 ### `tests/integration/test_mcp_reminders.py`
 

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -211,6 +211,13 @@ EPICS_CREATE = Action(
     summary="Create an epic in one of the actor's projects.",
 )
 
+EPICS_UPDATE = Action(
+    name="epics.update",
+    category=OPERATIONAL,
+    scope=ISSUES_WRITE_SCOPE,
+    summary="Change title, description or status of an epic.",
+)
+
 ISSUES_CREATE = Action(
     name="issues.create",
     category=OPERATIONAL,
@@ -272,6 +279,7 @@ CATALOGUE: tuple[Action, ...] = (
     SESSIONS_RESTART,
     MISSIONS_CANCEL,
     EPICS_CREATE,
+    EPICS_UPDATE,
     ISSUES_CREATE,
     ISSUES_UPDATE,
     EPICS_LINK_ISSUE,

--- a/gateway/app/api/routes/epics.py
+++ b/gateway/app/api/routes/epics.py
@@ -75,6 +75,19 @@ class CreateEpicRequest(BaseModel):
     status: str | None = Field(default=None, max_length=32)
 
 
+class UpdateEpicRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    title: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = Field(default=None, max_length=20000)
+    status: str | None = Field(default=None, max_length=32)
+
+
+# Sent as an explicit sentinel for a PATCH field the caller did not mention,
+# the same way `routes/issues.py:_UPDATE_FIELDS` does for `UpdateIssueRequest`.
+_UPDATE_FIELDS = ("title", "description", "status")
+
+
 @router.get("/projects/{project_id}/epics", tags=["epics"])
 async def list_epics(
     project_id: str,
@@ -115,6 +128,21 @@ async def list_epics(
     )
     response.headers["Cache-Control"] = "no-store"
     return {"items": [_epic_dto(epic) for epic in page], "page": info}
+
+
+@router.get("/epics/{epic_id}", tags=["epics"])
+async def get_epic_detail(
+    epic_id: str,
+    response: Response,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.EPICS_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    epic = await store.get_epic_for_projects(session, epic_id, visible_projects(principal))
+    if epic is None:
+        raise _epic_not_found()
+    response.headers[concurrency.ETAG_HEADER] = concurrency.etag_for(epic.revision)
+    response.headers["Cache-Control"] = "no-store"
+    return _epic_dto(epic)
 
 
 @router.post("/epics", tags=["epics"], status_code=201)
@@ -184,6 +212,50 @@ async def create_epic(
         )
     response.headers[concurrency.ETAG_HEADER] = concurrency.etag_for(epic.revision)
     return body
+
+
+@router.patch("/epics/{epic_id}", tags=["epics"])
+async def update_epic(
+    epic_id: str,
+    payload: UpdateEpicRequest,
+    response: Response,
+    if_match: str | None = Header(default=None, alias="If-Match"),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.EPICS_UPDATE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Change title, description or status.
+
+    This closes an asymmetry the create/read/link surface otherwise left open:
+    an epic could be created and linked to, but never itself changed, so
+    `cancelled` -- the project's own answer to "there is no delete, use
+    cancelled" -- was reachable for an issue and not for the epic grouping it.
+
+    Fields the caller does not mention are left untouched; a field explicitly
+    sent as `null` clears it. Requires `If-Match`, same rule as
+    `PATCH /api/v1/issues/{issueId}`.
+    """
+    projects = visible_projects(principal)
+    epic = await store.get_epic_for_projects(session, epic_id, projects)
+    if epic is None:
+        raise _epic_not_found()
+    concurrency.require_if_match(if_match, epic.revision)
+
+    changes = payload.model_dump(exclude_unset=True)
+    kwargs = {field: changes[field] for field in _UPDATE_FIELDS if field in changes}
+
+    try:
+        updated = await store.update_epic(
+            session,
+            epic_id,
+            actor_user_id=principal.user_id,
+            actor_email=principal.email,
+            **kwargs,
+        )
+    except IssuePlanningError as exc:
+        raise _planning_error(exc) from exc
+
+    response.headers[concurrency.ETAG_HEADER] = concurrency.etag_for(updated.revision)
+    return _epic_dto(updated)
 
 
 @router.post("/epics/{epic_id}/issues/{issue_id}", tags=["epics"])

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -67,7 +67,17 @@ version_router = APIRouter()
 # an optional `reason` field on its request body, recorded on the mission's
 # timeline. Additive only (new optional field; an existing client sending no
 # body is unaffected), so another minor bump.
-API_CONTRACT_VERSION = "1.6.0"
+#
+# 1.6.0 -> 1.11.0: `GET`/`PATCH /api/v1/epics/{epicId}` (issue #8, work_id
+# WK-20260902-epic-update-and-move) -- an epic could be created, read in a
+# list, and linked to, but never itself changed, so `cancelled` (this
+# project's answer to "there is no delete") was unreachable for an epic.
+# Additive only (new endpoints, new `UpdateEpicRequest` schema), so a minor
+# bump. The jump from 1.6.0 rather than 1.7.0 is deliberate: 1.7.0/1.8.0/
+# 1.9.0/1.10.0 are already claimed by concurrently open PRs (#61, #62, #75)
+# and another track of this same orchestration, none of which had merged
+# into this branch's ancestry when this line was written.
+API_CONTRACT_VERSION = "1.11.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a

--- a/gateway/app/mcp/server.py
+++ b/gateway/app/mcp/server.py
@@ -41,6 +41,19 @@ def _text_result(message: str, data: dict) -> dict:
     }
 
 
+def _strip_issue_ref(raw: object) -> str:
+    """Accept either the bare `IssueModel.id` or the `local:<id>` shape
+
+    `create_issue`/`list_issues` already return as `issue_ref` -- so a caller
+    that just listed issues can pass either field straight back in without
+    reaching for string surgery of its own.
+    """
+    text = str(raw)
+    if text.startswith("local:"):
+        return text.split(":", 1)[1]
+    return text
+
+
 async def handle_mcp_call(
     body: dict,
     session: AsyncSession,
@@ -102,6 +115,74 @@ async def handle_mcp_call(
         if not principal.can_access_project(project.id):
             raise HTTPException(status_code=403, detail="project_access_denied")
         return project
+
+    # Idempotency, extracted from A1's create_epic/create_issue (issue #78
+    # review): the reserve -> detect-replay -> release-on-error -> complete
+    # sequence was ~45 identical lines in each of those two branches, and
+    # move_issue_to_epic below would have been a third copy. These four
+    # helpers close over `session` and `principal` the same way
+    # `require_action`/`resolve_project_or_404` do, so every call site keeps
+    # the same shape it already had -- only the duplication is gone.
+    def write_fingerprint(args: dict) -> bytes:
+        """The bytes `idempotency.fingerprint` hashes, `idempotency_key` excluded.
+
+        The key itself must not be part of what makes two requests "the same
+        body" -- a caller retrying with a fresh key would otherwise fingerprint
+        differently and never see a replay.
+        """
+        return json.dumps(
+            {k: v for k, v in args.items() if k != "idempotency_key"},
+            sort_keys=True, default=str,
+        ).encode()
+
+    async def reserve_idempotent(
+        endpoint: str, key: str, fingerprint: str
+    ) -> idempotency.ReplayedResponse | idempotency.Claim:
+        # ApiError is idempotency.py's native failure (a reused key with a
+        # different body, or one still in flight) -- gateway/app/api/scope.py
+        # exempts `/mcp` from the app-wide ApiError handler, so left uncaught
+        # this becomes a raw 500 that breaks the JSON-RPC envelope.
+        try:
+            return await idempotency.reserve(
+                session, key=key, endpoint=endpoint, actor_id=principal.user_id,
+                request_fingerprint=fingerprint,
+            )
+        except ApiError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+
+    async def release_idempotent(endpoint: str, key: str, claim: idempotency.Claim) -> None:
+        await idempotency.release(
+            session, key=key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
+        )
+
+    async def complete_idempotent(
+        endpoint: str, key: str, claim: idempotency.Claim, status_code: int, body: dict, fingerprint: str
+    ) -> None:
+        try:
+            await idempotency.complete(
+                session, key=key, endpoint=endpoint, actor_id=principal.user_id,
+                status_code=status_code, body=body, claim=claim, request_fingerprint=fingerprint,
+            )
+        except ApiError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+
+    def require_expected_revision(current: int, expected: object) -> None:
+        """`expected_revision` is mandatory on every planning-entity mutator
+        this file adds after A1 (`update_issue`, `update_epic`,
+        `move_issue_to_epic`): the REST side of the same domain already refuses
+        a `PATCH`/link with no `If-Match` instead of treating it as "no
+        opinion" (`gateway/app/api/concurrency.py:require_if_match`), and the
+        MCP transport must not be laxer about the same optimistic-concurrency
+        contract just because JSON-RPC has no header to forget.
+        """
+        if expected is None:
+            raise HTTPException(status_code=400, detail="expected_revision_required")
+        try:
+            expected_int = int(expected)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail="expected_revision_required")
+        if expected_int != current:
+            raise HTTPException(status_code=409, detail="stale_write")
 
     def require_task_access(task) -> None:
         if principal is None:
@@ -588,25 +669,10 @@ async def handle_mcp_call(
 
         idempotency_key = arguments.get("idempotency_key")
         endpoint = "mcp:create_epic"
-        request_fingerprint = idempotency.fingerprint(
-            json.dumps(
-                {k: v for k, v in arguments.items() if k != "idempotency_key"},
-                sort_keys=True, default=str,
-            ).encode()
-        )
+        request_fingerprint = idempotency.fingerprint(write_fingerprint(arguments))
         claim = None
         if idempotency_key:
-            # ApiError is idempotency.py's native failure (a reused key with a
-            # different body, or one still in flight) -- gateway/app/api/scope.py
-            # exempts `/mcp` from the app-wide ApiError handler, so left
-            # uncaught this becomes a raw 500 that breaks the JSON-RPC envelope.
-            try:
-                outcome = await idempotency.reserve(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
-                    request_fingerprint=request_fingerprint,
-                )
-            except ApiError as exc:
-                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+            outcome = await reserve_idempotent(endpoint, idempotency_key, request_fingerprint)
             if isinstance(outcome, idempotency.ReplayedResponse):
                 result = _text_result(f"Epic {outcome.body['epic_id']} already existed.", outcome.body)
                 return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
@@ -624,15 +690,11 @@ async def handle_mcp_call(
             )
         except IssuePlanningError as exc:
             if claim is not None:
-                await idempotency.release(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
-                )
+                await release_idempotent(endpoint, idempotency_key, claim)
             raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
         except Exception:
             if claim is not None:
-                await idempotency.release(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
-                )
+                await release_idempotent(endpoint, idempotency_key, claim)
             raise
 
         payload = {
@@ -641,15 +703,13 @@ async def handle_mcp_call(
             "title": epic.title,
             "description": epic.description,
             "status": epic.status,
+            # Additive since A1: `update_epic` needs the caller to know the
+            # current revision to fill `expected_revision` with, the same way
+            # `ETag` lets a REST caller fill `If-Match`.
+            "revision": epic.revision,
         }
         if claim is not None:
-            try:
-                await idempotency.complete(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
-                    status_code=201, body=payload, claim=claim, request_fingerprint=request_fingerprint,
-                )
-            except ApiError as exc:
-                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+            await complete_idempotent(endpoint, idempotency_key, claim, 201, payload, request_fingerprint)
         result = _text_result(f"Epic {epic.id} created.", payload)
     elif tool_name == "list_epics":
         require_action(permissions.EPICS_READ)
@@ -668,12 +728,55 @@ async def handle_mcp_call(
                     "title": epic.title,
                     "description": epic.description,
                     "status": epic.status,
+                    "revision": epic.revision,
                 }
                 for epic in rows
             ],
             "has_more": has_more,
         }
         result = _text_result(f"Found {len(payload['epics'])} epics.", payload)
+    elif tool_name == "update_epic":
+        # Issue #78 / WK-20260902-epic-update-and-move: mirrors
+        # `PATCH /api/v1/epics/{epicId}` (gateway/app/api/routes/epics.py)
+        # over MCP. `expected_revision` plays the role `If-Match` plays there
+        # -- required, not optional, so this transport is not laxer than REST
+        # about the same optimistic-concurrency contract.
+        require_action(permissions.EPICS_UPDATE)
+        epic_id = str(arguments["epic_id"])
+        epic = await store.get_epic(session, epic_id)
+        # A hidden epic (unknown, or in a project this principal cannot see)
+        # answers the same `unknown_epic` a nonexistent one would -- the same
+        # probing-prevention rule `get_epic_for_projects` applies on the REST
+        # side, which is why this is 404 and not 403.
+        if epic is None or not principal.can_access_project(epic.project_id):
+            raise HTTPException(status_code=404, detail="unknown_epic")
+        require_expected_revision(epic.revision, arguments.get("expected_revision"))
+
+        # Only keys the caller actually sent reach the store -- the MCP
+        # equivalent of `UpdateEpicRequest.model_dump(exclude_unset=True)`:
+        # JSON-RPC already distinguishes an omitted key from one sent `null`,
+        # so no pydantic model is needed to preserve that distinction.
+        kwargs = {
+            field: arguments[field]
+            for field in ("title", "description", "status")
+            if field in arguments
+        }
+        try:
+            updated = await store.update_epic(
+                session, epic_id, actor_user_id=principal.user_id, actor_email=principal.email, **kwargs,
+            )
+        except IssuePlanningError as exc:
+            raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
+
+        payload = {
+            "epic_id": updated.id,
+            "project_id": updated.project_id,
+            "title": updated.title,
+            "description": updated.description,
+            "status": updated.status,
+            "revision": updated.revision,
+        }
+        result = _text_result(f"Epic {updated.id} updated.", payload)
     elif tool_name == "create_issue":
         require_action(permissions.ISSUES_CREATE)
         project = await resolve_project_or_404(arguments["project"])
@@ -692,21 +795,10 @@ async def handle_mcp_call(
 
         idempotency_key = arguments.get("idempotency_key")
         endpoint = "mcp:create_issue"
-        request_fingerprint = idempotency.fingerprint(
-            json.dumps(
-                {k: v for k, v in arguments.items() if k != "idempotency_key"},
-                sort_keys=True, default=str,
-            ).encode()
-        )
+        request_fingerprint = idempotency.fingerprint(write_fingerprint(arguments))
         claim = None
         if idempotency_key:
-            try:
-                outcome = await idempotency.reserve(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
-                    request_fingerprint=request_fingerprint,
-                )
-            except ApiError as exc:
-                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+            outcome = await reserve_idempotent(endpoint, idempotency_key, request_fingerprint)
             if isinstance(outcome, idempotency.ReplayedResponse):
                 result = _text_result(f"Issue {outcome.body['issue_id']} already existed.", outcome.body)
                 return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
@@ -731,15 +823,11 @@ async def handle_mcp_call(
             )
         except IssuePlanningError as exc:
             if claim is not None:
-                await idempotency.release(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
-                )
+                await release_idempotent(endpoint, idempotency_key, claim)
             raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
         except Exception:
             if claim is not None:
-                await idempotency.release(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim
-                )
+                await release_idempotent(endpoint, idempotency_key, claim)
             raise
 
         payload = {
@@ -759,15 +847,12 @@ async def handle_mcp_call(
             "assignee_email": issue.assignee_email,
             "dependencies": json.loads(issue.dependencies_json or "[]"),
             "blocked_reason": issue.blocked_reason,
+            # Additive since A1, same reason as create_epic's: `update_issue`
+            # and `move_issue_to_epic` need it for `expected_revision`.
+            "revision": issue.revision,
         }
         if claim is not None:
-            try:
-                await idempotency.complete(
-                    session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id,
-                    status_code=201, body=payload, claim=claim, request_fingerprint=request_fingerprint,
-                )
-            except ApiError as exc:
-                raise HTTPException(status_code=exc.status_code, detail=exc.code) from exc
+            await complete_idempotent(endpoint, idempotency_key, claim, 201, payload, request_fingerprint)
         result = _text_result(f"Issue {issue.id} created.", payload)
     elif tool_name == "list_issues":
         require_action(permissions.ISSUES_READ)
@@ -800,12 +885,117 @@ async def handle_mcp_call(
                     "assignee_email": issue.assignee_email,
                     "dependencies": json.loads(issue.dependencies_json or "[]"),
                     "blocked_reason": issue.blocked_reason,
+                    "revision": issue.revision,
                 }
                 for issue in rows
             ],
             "has_more": has_more,
         }
         result = _text_result(f"Found {len(payload['issues'])} issues.", payload)
+    elif tool_name == "update_issue":
+        # Mirrors `PATCH /api/v1/issues/{issueId}` (gateway/app/api/routes/issues.py)
+        # over MCP. `epicId` is absent here for the same reason it is absent
+        # from the REST body: `move_issue_to_epic` (this file) /
+        # `POST /api/v1/epics/{epicId}/issues/{issueId}` (REST) is the one
+        # mechanism that moves an issue between epics.
+        require_action(permissions.ISSUES_UPDATE)
+        issue_id = _strip_issue_ref(arguments["issue_id"])
+        issue = await store.get_issue(session, issue_id)
+        if issue is None or not principal.can_access_project(issue.project_id):
+            raise HTTPException(status_code=404, detail="unknown_issue")
+        require_expected_revision(issue.revision, arguments.get("expected_revision"))
+
+        kwargs = {
+            field: arguments[field]
+            for field in (
+                "title", "description", "status", "priority", "labels",
+                "assignee_user_id", "assignee_email", "dependencies", "blocked_reason",
+            )
+            if field in arguments
+        }
+        try:
+            updated = await store.update_issue(
+                session, issue_id, actor_user_id=principal.user_id, actor_email=principal.email, **kwargs,
+            )
+        except IssuePlanningError as exc:
+            raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
+
+        payload = {
+            "issue_id": updated.id,
+            "issue_ref": f"local:{updated.id}",
+            "project_id": updated.project_id,
+            "epic_id": updated.epic_id,
+            "title": updated.title,
+            "description": updated.description,
+            "status": updated.status,
+            "priority": updated.priority,
+            "labels": json.loads(updated.labels_json or "[]"),
+            "assignee_user_id": updated.assignee_user_id,
+            "assignee_email": updated.assignee_email,
+            "dependencies": json.loads(updated.dependencies_json or "[]"),
+            "blocked_reason": updated.blocked_reason,
+            "revision": updated.revision,
+        }
+        result = _text_result(f"Issue {updated.id} updated.", payload)
+    elif tool_name == "move_issue_to_epic":
+        # Mirrors `POST /api/v1/epics/{epicId}/issues/{issueId}`
+        # (gateway/app/api/routes/epics.py:link_issue) over MCP -- the only
+        # mechanism, on either transport, that changes which epic an issue
+        # belongs to. Idempotency mirrors that REST pair's own
+        # `Idempotency-Key`; `expected_revision` mirrors its required
+        # `If-Match` on the issue's revision.
+        require_action(permissions.EPICS_LINK_ISSUE)
+        issue_id = _strip_issue_ref(arguments["issue_id"])
+        epic_id = str(arguments["epic_id"])
+        issue = await store.get_issue(session, issue_id)
+        if issue is None or not principal.can_access_project(issue.project_id):
+            raise HTTPException(status_code=404, detail="unknown_issue")
+        epic = await store.get_epic_for_projects(session, epic_id, [issue.project_id])
+        if epic is None:
+            raise HTTPException(status_code=404, detail="unknown_epic")
+
+        # Idempotency replay is checked BEFORE `expected_revision`, mirroring
+        # `link_issue`'s own order (reserve/replay, then `require_if_match`):
+        # a retried call arrives after the first one already bumped the
+        # revision, so validating `expected_revision` against the NEW current
+        # value first would turn a legitimate replay into a false
+        # `stale_write` -- the exact bug this ordering avoids.
+        idempotency_key = arguments.get("idempotency_key")
+        endpoint = "mcp:move_issue_to_epic"
+        request_fingerprint = idempotency.fingerprint(write_fingerprint(arguments))
+        claim = None
+        if idempotency_key:
+            outcome = await reserve_idempotent(endpoint, idempotency_key, request_fingerprint)
+            if isinstance(outcome, idempotency.ReplayedResponse):
+                result = _text_result(f"Issue {outcome.body['issue_id']} moved to epic {outcome.body['epic_id']}.", outcome.body)
+                return {"jsonrpc": "2.0", "id": rpc_id, "result": result}
+            claim = outcome
+
+        try:
+            require_expected_revision(issue.revision, arguments.get("expected_revision"))
+            updated = await store.link_issue_to_epic(
+                session, issue_id=issue_id, epic_id=epic_id,
+                actor_user_id=principal.user_id, actor_email=principal.email,
+            )
+        except IssuePlanningError as exc:
+            if claim is not None:
+                await release_idempotent(endpoint, idempotency_key, claim)
+            raise HTTPException(status_code=400, detail=f"validation_failed:{exc.field}:{exc.code}") from exc
+        except Exception:
+            if claim is not None:
+                await release_idempotent(endpoint, idempotency_key, claim)
+            raise
+
+        payload = {
+            "issue_id": updated.id,
+            "issue_ref": f"local:{updated.id}",
+            "project_id": updated.project_id,
+            "epic_id": updated.epic_id,
+            "revision": updated.revision,
+        }
+        if claim is not None:
+            await complete_idempotent(endpoint, idempotency_key, claim, 200, payload, request_fingerprint)
+        result = _text_result(f"Issue {updated.id} moved to epic {updated.epic_id}.", payload)
     elif tool_name == "create_reminder":
         # WK-20260830-chatgpt-entry-provider-and-delivery, issue #71. Runs on
         # the gateway, not the executor -- see google_calendar.py's module

--- a/gateway/app/mcp/tools.py
+++ b/gateway/app/mcp/tools.py
@@ -264,6 +264,30 @@ def tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "update_epic",
+            "title": "Update epic",
+            "description": "Mudar titulo, descricao ou status de uma epica existente.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "epic_id": {"type": "string", "description": "id da epica (retornado por create_epic ou list_epics)."},
+                    "title": {"type": "string", "minLength": 1, "maxLength": 255},
+                    "description": {"type": "string", "maxLength": 20000},
+                    "status": {"type": "string", "enum": sorted(EPIC_STATUSES)},
+                    "expected_revision": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": (
+                            "Revisao atual da epica (campo 'revision' de create_epic/list_epics). "
+                            "Obrigatorio: protege contra sobrescrever uma mudanca concorrente."
+                        ),
+                    },
+                },
+                "required": ["epic_id", "expected_revision"],
+                "additionalProperties": False,
+            },
+        },
+        {
             "name": "create_issue",
             "title": "Create issue",
             "description": "Criar uma issue em um projeto, opcionalmente dentro de uma epica ja existente.",
@@ -318,6 +342,81 @@ def tool_definitions() -> list[dict[str, Any]]:
                     "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
                 },
                 "required": ["project"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "update_issue",
+            "title": "Update issue",
+            "description": (
+                "Mudar status, prioridade, labels, assignee, dependencias ou motivo de bloqueio de "
+                "uma issue existente. Para trocar a epica da issue, use move_issue_to_epic."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "issue_id": {
+                        "type": "string",
+                        "description": "id da issue, ou 'local:<id>' (os dois formatos sao aceitos).",
+                    },
+                    "title": {"type": "string", "minLength": 1, "maxLength": 255},
+                    "description": {"type": "string", "maxLength": 20000},
+                    "status": {"type": "string", "enum": sorted(ISSUE_STATUSES)},
+                    "priority": {"type": "string", "enum": sorted(ISSUE_PRIORITIES)},
+                    "labels": {"type": "array", "items": {"type": "string"}, "maxItems": 64},
+                    "assignee_user_id": {"type": "string", "maxLength": 255},
+                    "assignee_email": {"type": "string", "maxLength": 255},
+                    "dependencies": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "maxItems": 64,
+                        "description": "Substitui o conjunto inteiro. ids de outras issues no mesmo projeto.",
+                    },
+                    "blocked_reason": {"type": "string", "maxLength": 20000},
+                    "expected_revision": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": (
+                            "Revisao atual da issue (campo 'revision' de create_issue/list_issues). "
+                            "Obrigatorio: protege contra sobrescrever uma mudanca concorrente."
+                        ),
+                    },
+                },
+                "required": ["issue_id", "expected_revision"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "move_issue_to_epic",
+            "title": "Move issue to epic",
+            "description": (
+                "Anexar (ou mover) uma issue para uma epica do mesmo projeto -- o unico mecanismo "
+                "para trocar a epica de uma issue."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "issue_id": {
+                        "type": "string",
+                        "description": "id da issue, ou 'local:<id>' (os dois formatos sao aceitos).",
+                    },
+                    "epic_id": {"type": "string", "description": "id da epica de destino, no mesmo projeto da issue."},
+                    "expected_revision": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": (
+                            "Revisao atual da issue (campo 'revision' de create_issue/list_issues). "
+                            "Obrigatorio: protege contra sobrescrever uma mudanca concorrente."
+                        ),
+                    },
+                    "idempotency_key": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "description": "Repetir a mesma chave devolve o mesmo resultado em vez de mover de novo.",
+                    },
+                },
+                "required": ["issue_id", "epic_id", "expected_revision"],
                 "additionalProperties": False,
             },
         },

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -1609,6 +1609,60 @@ async def list_epics_page(
     return list(result.scalars())
 
 
+# Sentinel distinguishing "field omitted" from "field explicitly set to null"
+# for the partial-update functions below (`update_epic`, `update_issue`).
+# `None` cannot serve: `description`, `assignee_user_id` and the like are
+# nullable columns a caller may legitimately want to clear.
+UNSET = object()
+
+
+async def update_epic(
+    session: AsyncSession,
+    epic_id: str,
+    *,
+    title: object = UNSET,
+    description: object = UNSET,
+    status: object = UNSET,
+    actor_user_id: str,
+    actor_email: str | None,
+) -> EpicModel:
+    """Change title, description or status. Mirrors `update_issue` below --
+
+    same `UNSET` sentinel, same revision bump, same audit event shape. An epic
+    has no `labels` or `dependencies`, so it does not need the parts of
+    `update_issue` that exist only for those.
+    """
+    epic = await session.get(EpicModel, epic_id)
+    if epic is None:
+        raise ValueError("unknown_epic")
+
+    if title is not UNSET:
+        cleaned = (title or "").strip()
+        if not cleaned:
+            raise IssuePlanningError("/title", "required", "title must not be empty.")
+        epic.title = cleaned
+    if description is not UNSET:
+        epic.description = description
+    if status is not UNSET:
+        if status not in EPIC_STATUSES:
+            raise IssuePlanningError(
+                "/status", "invalid_status", f"status must be one of {sorted(EPIC_STATUSES)}."
+            )
+        epic.status = status
+
+    epic.updated_by_user_id = actor_user_id
+    epic.updated_by_email = actor_email
+    epic.updated_at = datetime.now(timezone.utc)
+    epic.revision += 1
+    await record_event(
+        session, "epic", epic.id, "epic.updated",
+        {"actor_id": actor_user_id, "status": epic.status},
+    )
+    await session.commit()
+    await session.refresh(epic)
+    return epic
+
+
 async def create_issue(
     session: AsyncSession,
     *,
@@ -1724,9 +1778,6 @@ async def list_issues_page(
     statement = statement.order_by(IssueModel.created_at.desc(), IssueModel.id.desc()).limit(limit + 1)
     result = await session.execute(statement)
     return list(result.scalars())
-
-
-UNSET = object()
 
 
 async def update_issue(

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1034,6 +1034,7 @@ ENDPOINT_FOR_ACTION = {
     "issues.create": ("POST", "/api/v1/issues"),
     "issues.update": ("PATCH", "/api/v1/issues/{id}"),
     "epics.create": ("POST", "/api/v1/epics"),
+    "epics.update": ("PATCH", "/api/v1/epics/{id}"),
     "epics.linkIssue": ("POST", "/api/v1/epics/e1/issues/{id}"),
     "conversations.read": ("GET", "/api/v1/conversations"),
     "conversations.create": ("POST", "/api/v1/conversations"),

--- a/tests/integration/test_epics_issues.py
+++ b/tests/integration/test_epics_issues.py
@@ -193,6 +193,13 @@ async def test_an_epic_or_issue_in_an_invisible_project_is_not_found(api) -> Non
     theirs_epic = await make_epic(api.factory, "p2")
     theirs_issue = await make_issue(api.factory, "p2")
     assert api.get(f"/api/v1/issues/{theirs_issue.id}", headers=auth(ALICE_TOKEN)).status_code == 404
+    assert api.get(f"/api/v1/epics/{theirs_epic.id}", headers=auth(ALICE_TOKEN)).status_code == 404
+    response = api.patch(
+        f"/api/v1/epics/{theirs_epic.id}",
+        json={"status": "cancelled"},
+        headers={**auth(ALICE_TOKEN), "If-Match": f'"{theirs_epic.revision}"'},
+    )
+    assert response.status_code == 404
     # Linking reaches for both records, and both checks must hold.
     response = api.post(
         f"/api/v1/epics/{theirs_epic.id}/issues/{theirs_issue.id}",
@@ -605,3 +612,92 @@ async def test_list_epics_filters_by_status(api) -> None:
         "/api/v1/projects/p1/epics", params={"status": "open"}, headers=auth(ALICE_TOKEN)
     ).json()
     assert [item["id"] for item in body["items"]] == [open_epic.id]
+
+
+# --------------------------------------------------------------------------
+# Reading and updating epics -- WK-20260902-epic-update-and-move (issue #8).
+#
+# Before this, an epic could be created, listed and linked to, but never
+# itself changed: `cancelled` -- the project's "there is no delete, use
+# cancelled" answer -- was unreachable for an epic through any transport.
+# --------------------------------------------------------------------------
+
+
+async def test_get_epic_returns_an_etag(api) -> None:
+    epic = await make_epic(api.factory)
+    response = api.get(f"/api/v1/epics/{epic.id}", headers=auth(ALICE_TOKEN))
+    assert response.status_code == 200
+    assert response.headers["ETag"] == f'"{epic.revision}"'
+    assert response.json()["id"] == epic.id
+
+
+async def test_update_epic_requires_if_match(api) -> None:
+    epic = await make_epic(api.factory)
+    response = api.patch(
+        f"/api/v1/epics/{epic.id}", json={"status": "in_progress"}, headers=auth(ALICE_TOKEN)
+    )
+    assert response.status_code == 428
+
+
+async def test_update_epic_with_a_stale_etag_is_refused(api) -> None:
+    epic = await make_epic(api.factory)
+    response = api.patch(
+        f"/api/v1/epics/{epic.id}",
+        json={"status": "in_progress"},
+        headers={**auth(ALICE_TOKEN), "If-Match": '"999"'},
+    )
+    assert response.status_code == 412
+    assert response.json()["code"] == "stale_write"
+
+
+async def test_update_epic_changes_only_the_mentioned_fields(api) -> None:
+    """Positive control for the two If-Match negatives above."""
+    epic = await make_epic(api.factory, title="Original")
+    response = api.patch(
+        f"/api/v1/epics/{epic.id}",
+        json={"status": "cancelled"},
+        headers={**auth(ALICE_TOKEN), "If-Match": f'"{epic.revision}"'},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "cancelled"
+    assert body["title"] == "Original"
+    assert body["revision"] == epic.revision + 1
+    assert body["updatedBy"] == "alice@example.com"
+    assert response.headers["ETag"] == f'"{epic.revision + 1}"'
+
+
+async def test_update_epic_can_explicitly_clear_a_nullable_field(api) -> None:
+    async with api.factory() as s:
+        epic = await store.create_epic(
+            s, project_id="p1", title="x", description="Track it", status=None,
+            actor_user_id="alice", actor_email="alice@example.com",
+        )
+    response = api.patch(
+        f"/api/v1/epics/{epic.id}",
+        json={"description": None},
+        headers={**auth(ALICE_TOKEN), "If-Match": f'"{epic.revision}"'},
+    )
+    assert response.status_code == 200
+    assert response.json()["description"] is None
+
+
+async def test_update_epic_rejects_an_unknown_status(api) -> None:
+    epic = await make_epic(api.factory)
+    response = api.patch(
+        f"/api/v1/epics/{epic.id}",
+        json={"status": "orbiting"},
+        headers={**auth(ALICE_TOKEN), "If-Match": f'"{epic.revision}"'},
+    )
+    assert response.status_code == 400
+    assert response.json()["details"][0]["field"] == "/status"
+
+
+async def test_a_reader_cannot_update_an_epic(api) -> None:
+    epic = await make_epic(api.factory)
+    response = api.patch(
+        f"/api/v1/epics/{epic.id}",
+        json={"status": "cancelled"},
+        headers={**auth(READER_TOKEN), "If-Match": f'"{epic.revision}"'},
+    )
+    assert response.status_code == 403

--- a/tests/integration/test_mcp_epics_issues.py
+++ b/tests/integration/test_mcp_epics_issues.py
@@ -1,15 +1,21 @@
-"""The `create_epic`/`list_epics`/`create_issue`/`list_issues` MCP tools -- issue #78.
+"""The epics/issues MCP tools -- issue #78.
 
 Exposes the epics/issues store already tested via REST
 (`tests/integration/test_epics_issues.py`) over the MCP/ChatGPT transport, for
 a project that may have no forge at all -- "plan conversing in ChatGPT". This
 file does not re-prove store validation (that belongs to
-`tests/unit`/`tests/integration/test_epics_issues.py`); it proves the four
-tools reach the SAME store, apply the same authorization catalogue
+`tests/unit`/`tests/integration/test_epics_issues.py`); it proves the tools
+reach the SAME store, apply the same authorization catalogue
 (`gateway/app/api/permissions.py`) the REST routes use, add idempotency on the
-two creators only (mirroring the REST pair, since `PATCH /issues/{id}` has
-none), and return the `issue_ref` shape `start_development_task` already
-resolves.
+two creators and on `move_issue_to_epic` (mirroring the REST pair and the
+link endpoint, since `PATCH /issues|epics/{id}` has none), and return the
+`issue_ref` shape `start_development_task` already resolves.
+
+`update_issue`, `update_epic` and `move_issue_to_epic`
+(WK-20260902-epic-update-and-move) additionally require `expected_revision`:
+the MCP equivalent of `If-Match`, and just as mandatory -- absent is
+`expected_revision_required` (400), stale is `stale_write` (409). Each has a
+happy-path test as its positive control, in this same file.
 """
 
 from __future__ import annotations
@@ -341,3 +347,219 @@ async def test_rows_created_via_mcp_appear_unchanged_via_rest(env):
     assert rest_issue["title"] == issue["title"]
     assert rest_issue["priority"] == "high"
     assert rest_issue["labels"] == ["backend"]
+
+
+# --------------------------------------------------------------------------
+# 9. update_issue -- WK-20260902-epic-update-and-move.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_issue_changes_only_the_mentioned_fields(env):
+    """Positive control for the two expected_revision negatives below."""
+    issue = await _call(env, ALICE, "create_issue", {
+        "project": "p1", "title": "Original", "priority": "low", "labels": ["a"],
+    })
+    updated = await _call(env, ALICE, "update_issue", {
+        "issue_id": issue["issue_id"], "status": "in_progress", "expected_revision": issue["revision"],
+    })
+    assert updated["status"] == "in_progress"
+    assert updated["title"] == "Original"
+    assert updated["priority"] == "low"
+    assert updated["labels"] == ["a"]
+    assert updated["revision"] == issue["revision"] + 1
+
+
+@pytest.mark.asyncio
+async def test_update_issue_accepts_the_bare_id_or_the_local_prefixed_ref(env):
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+
+    via_bare = await _call(env, ALICE, "update_issue", {
+        "issue_id": issue["issue_id"], "status": "in_progress", "expected_revision": issue["revision"],
+    })
+    via_ref = await _call(env, ALICE, "update_issue", {
+        "issue_id": issue["issue_ref"], "status": "blocked", "expected_revision": via_bare["revision"],
+    })
+    assert via_ref["status"] == "blocked"
+    assert via_ref["issue_id"] == issue["issue_id"]
+
+
+@pytest.mark.asyncio
+async def test_update_issue_without_expected_revision_is_refused(env):
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_issue", {"issue_id": issue["issue_id"], "status": "in_progress"})
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "expected_revision_required"
+
+
+@pytest.mark.asyncio
+async def test_update_issue_with_a_stale_expected_revision_is_refused(env):
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_issue", {
+            "issue_id": issue["issue_id"], "status": "in_progress", "expected_revision": issue["revision"] + 1,
+        })
+    assert raised.value.status_code == 409
+    assert raised.value.detail == "stale_write"
+
+
+@pytest.mark.asyncio
+async def test_update_issue_with_an_unknown_status_is_a_typed_validation_error(env):
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_issue", {
+            "issue_id": issue["issue_id"], "status": "not-a-status", "expected_revision": issue["revision"],
+        })
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "validation_failed:/status:invalid_status"
+
+
+@pytest.mark.asyncio
+async def test_update_issue_on_another_projects_issue_is_unknown_issue(env):
+    theirs = await _call(env, AuthenticatedPrincipal(
+        user_id="admin", email="admin@example.com", roles=["admin"],
+        allowed_projects=[], scopes=["codexbridge.admin"],
+    ), "create_issue", {"project": "p2", "title": "Lives in p2"})
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_issue", {
+            "issue_id": theirs["issue_id"], "status": "in_progress", "expected_revision": theirs["revision"],
+        })
+    assert raised.value.status_code == 404
+    assert raised.value.detail == "unknown_issue"
+
+
+# --------------------------------------------------------------------------
+# 10. update_epic -- WK-20260902-epic-update-and-move.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_epic_changes_only_the_mentioned_fields(env):
+    """Positive control for the two expected_revision negatives below."""
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Original"})
+    updated = await _call(env, ALICE, "update_epic", {
+        "epic_id": epic["epic_id"], "status": "cancelled", "expected_revision": epic["revision"],
+    })
+    assert updated["status"] == "cancelled"
+    assert updated["title"] == "Original"
+    assert updated["revision"] == epic["revision"] + 1
+
+
+@pytest.mark.asyncio
+async def test_update_epic_without_expected_revision_is_refused(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_epic", {"epic_id": epic["epic_id"], "status": "cancelled"})
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "expected_revision_required"
+
+
+@pytest.mark.asyncio
+async def test_update_epic_with_a_stale_expected_revision_is_refused(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_epic", {
+            "epic_id": epic["epic_id"], "status": "cancelled", "expected_revision": epic["revision"] + 1,
+        })
+    assert raised.value.status_code == 409
+    assert raised.value.detail == "stale_write"
+
+
+@pytest.mark.asyncio
+async def test_update_epic_with_an_unknown_status_is_a_typed_validation_error(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "update_epic", {
+            "epic_id": epic["epic_id"], "status": "orbiting", "expected_revision": epic["revision"],
+        })
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "validation_failed:/status:invalid_status"
+
+
+# --------------------------------------------------------------------------
+# 11. move_issue_to_epic -- WK-20260902-epic-update-and-move.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_move_issue_to_epic_changes_the_issues_epic(env):
+    """Positive control for the two expected_revision negatives below."""
+    origin = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Origin"})
+    target = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Target"})
+    issue = await _call(env, ALICE, "create_issue", {
+        "project": "p1", "epic_id": origin["epic_id"], "title": "Movable",
+    })
+
+    moved = await _call(env, ALICE, "move_issue_to_epic", {
+        "issue_id": issue["issue_id"], "epic_id": target["epic_id"], "expected_revision": issue["revision"],
+    })
+    assert moved["epic_id"] == target["epic_id"]
+    assert moved["revision"] == issue["revision"] + 1
+
+    listed = await _call(env, ALICE, "list_issues", {"project": "p1", "epic_id": target["epic_id"]})
+    assert [i["issue_id"] for i in listed["issues"]] == [issue["issue_id"]]
+
+
+@pytest.mark.asyncio
+async def test_move_issue_to_epic_without_expected_revision_is_refused(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x"})
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "move_issue_to_epic", {"issue_id": issue["issue_id"], "epic_id": epic["epic_id"]})
+    assert raised.value.status_code == 400
+    assert raised.value.detail == "expected_revision_required"
+
+
+@pytest.mark.asyncio
+async def test_move_issue_to_epic_with_a_stale_expected_revision_is_refused(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x"})
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "move_issue_to_epic", {
+            "issue_id": issue["issue_id"], "epic_id": epic["epic_id"], "expected_revision": issue["revision"] + 1,
+        })
+    assert raised.value.status_code == 409
+    assert raised.value.detail == "stale_write"
+
+
+@pytest.mark.asyncio
+async def test_move_issue_to_epic_from_a_foreign_project_is_unknown_epic(env):
+    foreign_epic = await _call(env, AuthenticatedPrincipal(
+        user_id="admin", email="admin@example.com", roles=["admin"],
+        allowed_projects=[], scopes=["codexbridge.admin"],
+    ), "create_epic", {"project": "p2", "title": "Lives in p2"})
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "move_issue_to_epic", {
+            "issue_id": issue["issue_id"], "epic_id": foreign_epic["epic_id"], "expected_revision": issue["revision"],
+        })
+    assert raised.value.status_code == 404
+    assert raised.value.detail == "unknown_epic"
+
+
+@pytest.mark.asyncio
+async def test_a_retried_move_does_not_move_the_issue_twice(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "x"})
+    issue = await _call(env, ALICE, "create_issue", {"project": "p1", "title": "x"})
+    arguments = {
+        "issue_id": issue["issue_id"], "epic_id": epic["epic_id"],
+        "expected_revision": issue["revision"], "idempotency_key": "move-1",
+    }
+
+    first = await _call(env, ALICE, "move_issue_to_epic", arguments)
+    second = await _call(env, ALICE, "move_issue_to_epic", arguments)
+    assert second == first
+
+    listed = await _call(env, ALICE, "list_issues", {"project": "p1", "epic_id": epic["epic_id"]})
+    assert len(listed["issues"]) == 1, "the move must not have applied twice"
+    assert listed["issues"][0]["revision"] == issue["revision"] + 1
+
+
+# --------------------------------------------------------------------------
+# 12. Extracting the idempotency helpers (review debt on A1, Tarefa 0) must
+#     not change what create_epic/create_issue's own idempotency tests prove
+#     -- see this module's tests #2/#3 above, left unmodified by this PR.
+# --------------------------------------------------------------------------


### PR DESCRIPTION
Issue #78, stage 2 of 2 — stacked on #83, review that first. Also closes a REST hole from #8.

## What changes
- `store.update_epic` — the function that was missing. Mirrors `update_issue` (UNSET sentinel, status validation, revision bump, audit event).
- `GET` and `PATCH /api/v1/epics/{epicId}`, mirroring the issue pair. **Until now an epic could not reach `cancelled` on any transport**, which made "no delete, use `cancelled`" a dead end for epics specifically.
- Three MCP tools: `update_issue`, `update_epic`, `move_issue_to_epic`.
- Contract 1.6.0 → **1.11.0** (1.7.0–1.10.0 are claimed by open PRs #61/#62/#75 and a sibling branch).

## Two things a reviewer should look at
- **`expected_revision` is mandatory** on all three tools — absent is `400 expected_revision_required`, stale is `409 stale_write`. REST already refuses a missing `If-Match` rather than treating it as "no opinion"; MCP must not be laxer about the same domain.
- **Idempotency replay is checked before `expected_revision`** in `move_issue_to_epic`, mirroring `link_issue`'s own order. This was a real bug found in implementation: a retry arrives after the first call already bumped the revision, so validating the revision first turns a legitimate replay into a false `stale_write`.

Review debt from #83 paid first: the ~45-line idempotency block duplicated between `create_epic` and `create_issue` is now four closures (`write_fingerprint`, `reserve_idempotent`, `release_idempotent`, `complete_idempotent`). #83's own idempotency tests pass unmodified — that is the proof the extraction was faithful.

`revision` was added to the four existing tools' payloads (additive) because callers need it to fill `expected_revision`.

## Validation
`pytest -q`: 788 passed, 7 skipped, 0 failed (766 + exactly the 22 new tests). `tests/contract/`: 26 passed. Every negative test has a positive control in the same file.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw