### PR TITLE
feat(gh-80,gh-79): forge operation vocabulary and structurally-sensitive policy

### DIFF
--- a/agent/codex_bridge_agent/config.py
+++ b/agent/codex_bridge_agent/config.py
@@ -70,6 +70,27 @@ class AgentSettings(BaseSettings):
     git_author_name: str = "CodexBridge"
     git_author_email: str = "codexbridge@invalid"
     git_push_timeout_seconds: float = 120
+    # WK-20260902-forge-protocol-and-policy, issue #80/#79. Same "last
+    # barrier on this machine" shape as `allow_git_delivery` above, and the
+    # same reasoning: a new capability with no existing behavior to
+    # preserve, so the safe default is off until an operator turns it on.
+    # This flag alone is table stakes, not a bypass -- even with it True,
+    # every forge WRITE still stops at the human approval gate
+    # (`shared.policy.forge_operation_policy_level`: there is no
+    # pre-authorization for a forge write, structurally, on purpose). Turning
+    # this on lets an executor run forge operations at all; it cannot let one
+    # skip approval.
+    allow_forge_operations: bool = False
+    # The `gh` CLI binary this executor invokes for forge operations -- the
+    # same "operator can point at a shim or a pinned path" role `codex_bin`
+    # and `claude_bin` already play above. Not called anywhere yet: this PR
+    # is protocol and policy only.
+    forge_gh_bin: str = "gh"
+    # Upper bound on a single forge operation (issue open/comment/close/list).
+    # Short on purpose: a forge operation is one bounded API call through
+    # `gh`, not a coding-agent session -- `git_push_timeout_seconds` above
+    # sets the analogous bound for git delivery.
+    forge_operation_timeout_seconds: float = 60
 
     model_config = SettingsConfigDict(env_prefix="CODEX_BRIDGE_AGENT_", env_file=".env")
 

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- 127 file(s) · 1195 symbol(s) indexed
+- 127 file(s) · 1196 symbol(s) indexed
 - Languages: config (2), python (123), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -1684,6 +1684,7 @@ tests/
 - `test_repo_identity_pattern_rejects_dangerous_or_malformed_identities(value)` — "Mirrors the role `_REMOTE_NAME_PATTERN` plays for git remotes."
 - `test_forge_operation_request_refuses_a_bad_repo_identity_at_parse()`
 - `test_issue_comment_without_issue_number_is_refused_at_parse()`
+- `test_issue_comment_without_a_body_is_refused_at_parse(body)` — "An empty comment is a human decision spent on a no-op."
 - `test_issue_close_without_issue_number_is_refused_at_parse()`
 - `test_issue_open_without_title_is_refused_at_parse()`
 - `test_issue_list_requires_neither_title_nor_issue_number()`

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-01 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-protocol-and-policy`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-protocol-and-policy map`
 
 ## Summary
 
-- 126 file(s) · 1181 symbol(s) indexed
-- Languages: config (2), python (122), shell (2)
+- 127 file(s) · 1195 symbol(s) indexed
+- Languages: config (2), python (123), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -162,6 +162,7 @@ tests/
     test_config_settings.py  — "issue #17 council round 1, "the second caller": `cancel_replay_max_age_seconds`"
     test_discover_projects.py  — "`scripts/discover_projects.py` -- read-only repo discovery."
     test_email_templates.py  — "`gateway.app.services.email_templates` -- pure rendering, no I/O."
+    test_forge_policy.py  — "The forge vocabulary and policy issue #80/#79 build the write gate on."
     test_git_delivery.py  — "`git_delivery.deliver_changes` against real throwaway git repos."
     test_google_calendar.py  — "`gateway.app.services.google_calendar`, without ever touching Google."
     test_instructions.py  — "`resolve_issue_text` and `build_task_instruction`."
@@ -795,6 +796,7 @@ tests/
 - `policy_level_for_mode(mode)`
 - `push_branch_is_allowed(delivery)` — "Whether `delivery.branch` is a branch a pre-authorized push may target."
 - `push_is_preauthorized(request)` — "Whether this request's own `delivery` block authorizes a push."
+- `forge_operation_policy_level(kind)` — "The policy tier a forge operation is classified at -- issue #80/#79."
 - `evaluate_task_policy(request)`
 
 ### `shared/project_discovery.py`
@@ -824,6 +826,8 @@ tests/
 - **`ProjectRegistration`** *(class)*
 - **`ExecutorRegistration`** *(class)*
 - **`DeliveryRequest`** *(class)* — "What the requester authorized the executor to do with git, once a task"
+- **`ForgeOperationKind`** *(class)* — "The only things a forge operation may do, per issue #80/#79."
+- **`ForgeOperationRequest`** *(class)* — "One forge operation a `FORGE_OPERATION` envelope may carry."
 - **`SubmitTaskRequest`** *(class)*
 - **`ContinueSessionRequest`** *(class)*
 - **`AgentEnvelope`** *(class)*
@@ -1669,6 +1673,22 @@ tests/
 - `test_no_style_block_and_no_class_attribute()` — "Email clients strip <style> blocks and class selectors unpredictably"
 - `test_no_inline_svg_shipped_in_a_real_email()` — "Outlook's desktop renderer does not support <svg> -- a broken icon in"
 - `test_no_rows_and_no_cta_omits_the_highlight_card()`
+
+### `tests/unit/test_forge_policy.py`
+
+> The forge vocabulary and policy issue #80/#79 build the write gate on.
+
+- `test_issue_list_is_read_and_every_other_kind_is_sensitive()` — "Iterates `ForgeOperationKind` itself, not a literal list of names."
+- `test_every_write_kind_is_sensitive_across_every_plausible_field_combination()` — "The property that must survive any future field added to the request."
+- `test_repo_identity_pattern_accepts_plausible_identities(value)`
+- `test_repo_identity_pattern_rejects_dangerous_or_malformed_identities(value)` — "Mirrors the role `_REMOTE_NAME_PATTERN` plays for git remotes."
+- `test_forge_operation_request_refuses_a_bad_repo_identity_at_parse()`
+- `test_issue_comment_without_issue_number_is_refused_at_parse()`
+- `test_issue_close_without_issue_number_is_refused_at_parse()`
+- `test_issue_open_without_title_is_refused_at_parse()`
+- `test_issue_list_requires_neither_title_nor_issue_number()`
+- `test_state_outside_the_closed_set_is_refused_at_parse()`
+- `test_forge_message_types_exist_and_are_distinct_from_task_dispatch()` — "Sanity check on the two new `AgentMessageType` members this PR adds."
 
 ### `tests/unit/test_git_delivery.py`
 

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1291,3 +1291,26 @@ operador, a experiencia dele e o dado; a minha leitura e a hipotese.
 Efeito colateral util: a leitura correta (composicao — o conector planeja no
 forge, o CodexBridge executa na maquina) e um argumento melhor do que o que eu
 tinha antes, e virou a folha 3 da landing.
+
+## 2026-09-01 — "confirmado contra a versao X" e evidencia com prazo de validade
+
+Os comentarios de `agent/codex_bridge_agent/runners/codex.py` registram, com
+cuidado, que os modos de sandbox foram confirmados contra `codex-cli 0.147.0`.
+Isso e boa pratica e foi util. Mas ao testar a rede dentro do sandbox na devel3,
+a CLI instalada ja era a **0.151.0** — quatro versoes adiante do que o comentario
+afirma ter verificado.
+
+Desta vez o comportamento nao mudou (o `workspace-write` continua sem rede, e
+`danger-full-access` continua existindo). Mas ninguem sabia disso antes do teste:
+a decisao de arquitetura inteira estava apoiada numa observacao feita contra uma
+versao que nao e mais a que roda.
+
+Licao: anotar a versao nao congela o comportamento, so datar a evidencia. Quando
+uma propriedade de seguranca depende do comportamento de uma ferramenta externa,
+o teste tem de ser re-executavel — de preferencia um teste no repositorio, nao
+uma frase num comentario — para que a proxima sessao descubra a mudanca por
+falha, e nao por sorte.
+
+Adendo do mesmo teste: `sandbox_workspace_write.network_access=true` liga a rede
+dentro do sandbox com uma unica flag por invocacao. A facilidade e o argumento
+*contra* usar esse caminho, nao a favor (issue #80).

--- a/shared/policy.py
+++ b/shared/policy.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from shared.protocol import DeliveryRequest, PolicyLevel, PUSHABLE_BRANCH_PATTERN, SubmitTaskRequest, TaskMode
+from shared.protocol import (
+    DeliveryRequest,
+    ForgeOperationKind,
+    PolicyLevel,
+    PUSHABLE_BRANCH_PATTERN,
+    SubmitTaskRequest,
+    TaskMode,
+)
 
 
 SENSITIVE_KEYWORDS = (
@@ -60,6 +67,56 @@ def push_is_preauthorized(request: SubmitTaskRequest) -> bool:
     """
     delivery = request.delivery
     return bool(delivery is not None and delivery.allow_push and push_branch_is_allowed(delivery))
+
+
+def forge_operation_policy_level(kind: ForgeOperationKind) -> PolicyLevel:
+    """The policy tier a forge operation is classified at -- issue #80/#79.
+
+    `ISSUE_LIST` is `READ`: it costs the forge nothing and changes nothing.
+    Every write kind -- `ISSUE_OPEN`, `ISSUE_COMMENT`, `ISSUE_CLOSE` -- is
+    `SENSITIVE`, unconditionally, for every value of every field on
+    `ForgeOperationRequest`.
+
+    This is the single most important thing in this module, so read it
+    before adding anything near this function. There is deliberately no
+    `forge_operation_is_preauthorized` sibling to `push_is_preauthorized`
+    above, and there must never be one added by analogy. `push_is_preauthorized`
+    exists because push already had a typed, narrow shape --
+    `DeliveryRequest.allow_push` plus `PUSHABLE_BRANCH_PATTERN` -- before
+    pre-authorization was layered onto it; the field predates the bypass, and
+    the bypass is scoped to exactly what that field already meant. Reaching
+    for the same shape here -- "a forge write needs its own
+    `allow_forge_write` flag the way push needed `allow_push`" -- is exactly
+    the mistake this function exists to head off. No field on
+    `ForgeOperationRequest`, present or future, may let a write skip the
+    human approval gate.
+
+    `delivery.allow_push` already establishes the pattern this follows:
+    `evaluate_task_policy` forces `SENSITIVE` for it "whether or not the word
+    push ever appears in instruction" -- a structural classification, not a
+    textual one. A forge write is `SENSITIVE` the same way, structurally, and
+    for a stronger reason than push has: the credential that performs it
+    never enters the agent's sandbox at all
+    (WK-20260902-forge-protocol-and-policy -- the sandbox has no network,
+    tested empirically on devel3 on 2026-09-01, so forge writes run on the
+    EXECUTOR process, outside the sandbox, and the credential stays there).
+    A forge write is also a published, third-party-visible act -- an issue
+    opened, a comment posted, an issue closed -- made in the operator's name
+    on infrastructure this codebase does not control. There is no request
+    shape trusted enough to skip a human seeing it first.
+
+    If a future change wants to narrow which forge writes need approval, it
+    must not live here as a bypass function: `forge_operation_policy_level`
+    returning `SENSITIVE` for every kind but `ISSUE_LIST` is the whole
+    guarantee. `tests/unit/test_forge_policy.py` iterates
+    `ForgeOperationKind` by the enum itself, not a literal list, and asserts
+    this property exhaustively over field combinations for every write kind,
+    so it fails the moment a new kind or a new field quietly earns an
+    exception.
+    """
+    if kind is ForgeOperationKind.ISSUE_LIST:
+        return PolicyLevel.READ
+    return PolicyLevel.SENSITIVE
 
 
 def evaluate_task_policy(request: SubmitTaskRequest) -> PolicyDecision:

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Iterable
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 EXECUTOR_TOKEN_HEADER = "X-Executor-Token"
@@ -214,6 +214,17 @@ class AgentMessageType(str, Enum):
     TASK_RESUME = "task.resume"
     TASK_RESTART = "task.restart"
     TASK_CANCELLED = "task.cancelled"
+    # WK-20260902-forge-protocol-and-policy, issue #80/#79. A forge operation
+    # travels as its own envelope pair, deliberately not folded into
+    # `TASK_DISPATCH`/`TASK_RESULT`: a task dispatch is a coding-agent session
+    # that runs inside the provider's sandbox, and a forge operation is the
+    # opposite of that on every axis that matters here -- it runs outside the
+    # sandbox, on the executor process itself, and it is `SENSITIVE` by
+    # construction rather than by what an instruction happens to say (see
+    # `shared.policy.forge_operation_policy_level`). Nothing dispatches or
+    # wires these yet -- this PR is only the vocabulary the wiring will use.
+    FORGE_OPERATION = "forge.operation"
+    FORGE_OPERATION_RESULT = "forge.operation_result"
     ERROR = "error"
 
 
@@ -405,6 +416,104 @@ class DeliveryRequest(BaseModel):
     base_branch: str = "development"
     remote: str = "origin"
     commit_subject: str | None = Field(default=None, max_length=200)
+
+
+class ForgeOperationKind(str, Enum):
+    """The only things a forge operation may do, per issue #80/#79.
+
+    Deliberately closed and enumerable -- there is no "run `gh` with
+    arbitrary argv" kind, and no member of this enum, present or future,
+    deletes an issue in any form. That is not an oversight to fill in later;
+    a forge write already happens outside the agent's sandbox, on
+    infrastructure this codebase does not control, in the operator's name --
+    so the surface it can reach is enumerated by hand, once, here, rather
+    than passed through from whatever a caller asks for. A new kind is a
+    deliberate, reviewed addition to this class, never something a caller can
+    request by naming a string this enum does not already have.
+
+    `shared.policy.forge_operation_policy_level` is the other half of this
+    decision: every member here except `ISSUE_LIST` is `SENSITIVE`, and there
+    is no field anywhere that lets a caller change that.
+    """
+
+    ISSUE_OPEN = "issue_open"
+    ISSUE_COMMENT = "issue_comment"
+    ISSUE_LIST = "issue_list"
+    ISSUE_CLOSE = "issue_close"
+
+
+# `owner/repo`, and nothing else -- no leading `-` or `.` on either side (a
+# leading `-` is how a value smuggles itself into flag position in an argv
+# list; see `_REMOTE_NAME_PATTERN`'s own docstring,
+# `agent/codex_bridge_agent/git_delivery.py:47`, for the same reasoning
+# applied to a git remote name), no doubled slash, no `..` anywhere. This
+# plays exactly that role for `ForgeOperationRequest.repo_identity`: the
+# executor's forge module (not written in this PR) will eventually place this
+# string as a positional argument to `gh`, and a value this pattern rejects
+# can never reach that call, because it is validated here, at parse time, on
+# both the gateway and the executor -- the same "one definition, two
+# importers" shape `PUSHABLE_BRANCH_PATTERN` already uses.
+REPO_IDENTITY_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,99}/[A-Za-z0-9][A-Za-z0-9._-]{0,99}$")
+
+
+class ForgeOperationRequest(BaseModel):
+    """One forge operation a `FORGE_OPERATION` envelope may carry.
+
+    WK-20260902-forge-protocol-and-policy, issue #80/#79. This model is shape
+    and coherence validation ONLY -- it decides nothing about whether an
+    operation may run without a human decision. That question belongs to
+    `shared.policy.forge_operation_policy_level`, and its answer for every
+    kind but `ISSUE_LIST` is unconditionally `SENSITIVE`: no combination of
+    the fields below can change that answer. Refusing an incoherent request
+    here, at parse time (a comment/close with no `issue_number`, an open with
+    no `title`), is better than letting it reach the executor and fail there
+    -- the same reasoning `DeliveryRequest` and `PUSHABLE_BRANCH_PATTERN`
+    already apply to push.
+    """
+
+    kind: ForgeOperationKind
+    repo_identity: str = Field(min_length=3, max_length=200)
+    title: str | None = Field(default=None, max_length=256)
+    body: str | None = Field(default=None, max_length=65536)
+    issue_number: int | None = Field(default=None, gt=0)
+    # Only meaningful for `ISSUE_LIST`; validated against a closed set below
+    # regardless of `kind`, since a value outside it is never a real forge
+    # issue state no matter which operation carries it.
+    state: str | None = None
+
+    @field_validator("repo_identity")
+    @classmethod
+    def _validate_repo_identity(cls, value: str) -> str:
+        if not REPO_IDENTITY_PATTERN.match(value):
+            raise ValueError(
+                f"repo_identity {value!r} must look like 'owner/repo' "
+                "(no leading '-'/'.', no doubled slash, no '..')"
+            )
+        return value
+
+    @field_validator("state")
+    @classmethod
+    def _validate_state(cls, value: str | None) -> str | None:
+        allowed = {"open", "closed", "all"}
+        if value is not None and value not in allowed:
+            raise ValueError(f"state must be one of {sorted(allowed)}, got {value!r}")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_kind_requires_its_fields(self) -> "ForgeOperationRequest":
+        """Recusa no parse é melhor que erro no executor.
+
+        `issue_comment`/`issue_close` name an existing issue; without
+        `issue_number` there is nothing to comment on or close.
+        `issue_open` creates one; without `title` there is nothing to open.
+        """
+        if self.kind in (ForgeOperationKind.ISSUE_COMMENT, ForgeOperationKind.ISSUE_CLOSE):
+            if self.issue_number is None:
+                raise ValueError(f"{self.kind.value} requires issue_number")
+        if self.kind is ForgeOperationKind.ISSUE_OPEN:
+            if not self.title:
+                raise ValueError("issue_open requires title")
+        return self
 
 
 class SubmitTaskRequest(BaseModel):

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -501,15 +501,20 @@ class ForgeOperationRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_kind_requires_its_fields(self) -> "ForgeOperationRequest":
-        """Recusa no parse é melhor que erro no executor.
+        """Refusing at parse time beats failing on the executor.
 
         `issue_comment`/`issue_close` name an existing issue; without
         `issue_number` there is nothing to comment on or close.
         `issue_open` creates one; without `title` there is nothing to open.
+        `issue_comment` additionally needs a non-empty `body`: `gh issue
+        comment` requires one, and an empty comment is an approved SENSITIVE
+        write that publishes nothing -- a human decision spent on a no-op.
         """
         if self.kind in (ForgeOperationKind.ISSUE_COMMENT, ForgeOperationKind.ISSUE_CLOSE):
             if self.issue_number is None:
                 raise ValueError(f"{self.kind.value} requires issue_number")
+        if self.kind is ForgeOperationKind.ISSUE_COMMENT and not self.body:
+            raise ValueError("issue_comment requires a non-empty body")
         if self.kind is ForgeOperationKind.ISSUE_OPEN:
             if not self.title:
                 raise ValueError("issue_open requires title")

--- a/tests/unit/test_forge_policy.py
+++ b/tests/unit/test_forge_policy.py
@@ -1,0 +1,191 @@
+"""The forge vocabulary and policy issue #80/#79 build the write gate on.
+
+WK-20260902-forge-protocol-and-policy. This PR is protocol and policy only --
+no module calls `gh`, nothing is wired into the executor yet (that is
+B2/B3). What has to be right *here*, before any of that exists, is that a
+forge write can never be classified as anything but `SENSITIVE`, for any
+`ForgeOperationKind` and any combination of `ForgeOperationRequest` fields --
+because the whole point of this stage is that later work inherits a
+vocabulary and a policy that cannot be quietly loosened by adding a field.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from pydantic import ValidationError
+
+from shared.policy import forge_operation_policy_level
+from shared.protocol import (
+    REPO_IDENTITY_PATTERN,
+    AgentMessageType,
+    ForgeOperationKind,
+    ForgeOperationRequest,
+    PolicyLevel,
+)
+
+
+def test_issue_list_is_read_and_every_other_kind_is_sensitive() -> None:
+    """Iterates `ForgeOperationKind` itself, not a literal list of names.
+
+    A future kind added to the enum and forgotten here would silently fall
+    through this loop as `SENSITIVE` -- which is the safe failure direction
+    -- but a future kind added to the enum and wrongly classified `READ`
+    would still be caught, because the loop checks every member, not just
+    the four that exist today.
+    """
+    for kind in ForgeOperationKind:
+        expected = PolicyLevel.READ if kind is ForgeOperationKind.ISSUE_LIST else PolicyLevel.SENSITIVE
+        assert forge_operation_policy_level(kind) == expected, kind
+
+
+# Field values used to build the exhaustive combinations below. Each tuple
+# includes at least one "edge" value: an empty body, the longest allowed
+# title, a large issue number.
+_TITLE_VALUES = (None, "x", "T" * 256)
+_BODY_VALUES = (None, "", "b" * 100)
+_ISSUE_NUMBER_VALUES = (None, 1, 999_999_999)
+_STATE_VALUES = (None, "open", "closed", "all")
+
+# `issue_open` has no issue to name (it creates one) but must have a title;
+# `issue_comment`/`issue_close` name an existing issue and must have one.
+# These overrides narrow the combination grid for the one field each kind
+# requires non-`None`, so every generated request is a request that would
+# actually pass the model's own coherence validator -- the classification
+# claim being tested is "SENSITIVE for every real request", not "SENSITIVE
+# for every request pydantic happens to accept including malformed ones".
+_REQUIRED_FIELD_OVERRIDES: dict[ForgeOperationKind, dict[str, tuple]] = {
+    ForgeOperationKind.ISSUE_OPEN: {"title": ("x", "T" * 256)},
+    ForgeOperationKind.ISSUE_COMMENT: {"issue_number": (1, 999_999_999)},
+    ForgeOperationKind.ISSUE_CLOSE: {"issue_number": (1, 999_999_999)},
+}
+
+
+def test_every_write_kind_is_sensitive_across_every_plausible_field_combination() -> None:
+    """The property that must survive any future field added to the request.
+
+    Written to break, not just to pass: it walks `ForgeOperationKind` by the
+    enum (so a new kind is automatically included) and asserts the property
+    for every member that is not `ISSUE_LIST`, over the full cross product of
+    plausible field values for that kind. If someone later adds a field like
+    `allow_write: bool = False` to `ForgeOperationRequest` and wires it into
+    `forge_operation_policy_level` as an escape hatch, this loop covers
+    `allow_write=True` in exactly the same sweep as everything else and
+    fails the moment the level stops being `SENSITIVE` -- there is no
+    branch of this test that only looks at the default value of a new
+    field.
+    """
+    write_kinds = [kind for kind in ForgeOperationKind if kind is not ForgeOperationKind.ISSUE_LIST]
+    assert write_kinds, "the write-kind fixture must not silently become empty"
+
+    checked = 0
+    expected = 0
+    for kind in write_kinds:
+        overrides = _REQUIRED_FIELD_OVERRIDES.get(kind, {})
+        title_values = overrides.get("title", _TITLE_VALUES)
+        issue_number_values = overrides.get("issue_number", _ISSUE_NUMBER_VALUES)
+        combos = list(itertools.product(title_values, _BODY_VALUES, issue_number_values, _STATE_VALUES))
+        expected += len(combos)
+        for title, body, issue_number, state in combos:
+            request = ForgeOperationRequest(
+                kind=kind,
+                repo_identity="owner/repo",
+                title=title,
+                body=body,
+                issue_number=issue_number,
+                state=state,
+            )
+            assert forge_operation_policy_level(request.kind) == PolicyLevel.SENSITIVE, (
+                kind,
+                title,
+                body,
+                issue_number,
+                state,
+            )
+            checked += 1
+
+    # Guards the loop itself: a change that made every combination raise
+    # `ValidationError` (and get silently skipped by an earlier, sloppier
+    # version of this test) would leave `checked == 0` and the assertions
+    # above vacuously true. `expected` is computed from the same
+    # `_REQUIRED_FIELD_OVERRIDES`-driven grid the loop actually walks, so
+    # this fails if a future edit to the overrides silently narrows the grid
+    # for one kind to nothing.
+    assert expected > 0
+    assert checked == expected
+
+
+@pytest.mark.parametrize("value", ["owner/repo", "Org-1/repo.js", "a/b"])
+def test_repo_identity_pattern_accepts_plausible_identities(value: str) -> None:
+    assert REPO_IDENTITY_PATTERN.match(value) is not None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "--flag/x",
+        "owner//repo",
+        "../etc",
+        "owner/",
+        "/repo",
+        "",
+        "owner repo",
+    ],
+)
+def test_repo_identity_pattern_rejects_dangerous_or_malformed_identities(value: str) -> None:
+    """Mirrors the role `_REMOTE_NAME_PATTERN` plays for git remotes.
+
+    `--flag/x` is the load-bearing case: a `repo_identity` that a naive
+    executor placed straight into `gh`'s argv could otherwise be read as an
+    option rather than a positional repository name.
+    """
+    assert REPO_IDENTITY_PATTERN.match(value) is None
+
+
+def test_forge_operation_request_refuses_a_bad_repo_identity_at_parse() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="--flag/x")
+    assert "repo_identity" in str(excinfo.value)
+
+
+def test_issue_comment_without_issue_number_is_refused_at_parse() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_COMMENT, repo_identity="owner/repo", body="hi")
+    assert "issue_number" in str(excinfo.value)
+
+
+def test_issue_close_without_issue_number_is_refused_at_parse() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_CLOSE, repo_identity="owner/repo")
+    assert "issue_number" in str(excinfo.value)
+
+
+def test_issue_open_without_title_is_refused_at_parse() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_OPEN, repo_identity="owner/repo")
+    assert "title" in str(excinfo.value)
+
+
+def test_issue_list_requires_neither_title_nor_issue_number() -> None:
+    request = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo", state="open")
+    assert request.title is None
+    assert request.issue_number is None
+
+
+def test_state_outside_the_closed_set_is_refused_at_parse() -> None:
+    with pytest.raises(ValidationError):
+        ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo", state="stale")
+
+
+def test_forge_message_types_exist_and_are_distinct_from_task_dispatch() -> None:
+    """Sanity check on the two new `AgentMessageType` members this PR adds.
+
+    Not a dispatch/wiring test -- nothing sends these yet -- only that the
+    vocabulary exists and does not collide with the task-dispatch pair it
+    sits beside.
+    """
+    assert AgentMessageType.FORGE_OPERATION.value == "forge.operation"
+    assert AgentMessageType.FORGE_OPERATION_RESULT.value == "forge.operation_result"
+    assert AgentMessageType.FORGE_OPERATION != AgentMessageType.TASK_DISPATCH
+    assert AgentMessageType.FORGE_OPERATION_RESULT != AgentMessageType.TASK_RESULT

--- a/tests/unit/test_forge_policy.py
+++ b/tests/unit/test_forge_policy.py
@@ -57,7 +57,7 @@ _STATE_VALUES = (None, "open", "closed", "all")
 # for every request pydantic happens to accept including malformed ones".
 _REQUIRED_FIELD_OVERRIDES: dict[ForgeOperationKind, dict[str, tuple]] = {
     ForgeOperationKind.ISSUE_OPEN: {"title": ("x", "T" * 256)},
-    ForgeOperationKind.ISSUE_COMMENT: {"issue_number": (1, 999_999_999)},
+    ForgeOperationKind.ISSUE_COMMENT: {"issue_number": (1, 999_999_999), "body": ("b", "b" * 100)},
     ForgeOperationKind.ISSUE_CLOSE: {"issue_number": (1, 999_999_999)},
 }
 
@@ -85,7 +85,8 @@ def test_every_write_kind_is_sensitive_across_every_plausible_field_combination(
         overrides = _REQUIRED_FIELD_OVERRIDES.get(kind, {})
         title_values = overrides.get("title", _TITLE_VALUES)
         issue_number_values = overrides.get("issue_number", _ISSUE_NUMBER_VALUES)
-        combos = list(itertools.product(title_values, _BODY_VALUES, issue_number_values, _STATE_VALUES))
+        body_values = overrides.get("body", _BODY_VALUES)
+        combos = list(itertools.product(title_values, body_values, issue_number_values, _STATE_VALUES))
         expected += len(combos)
         for title, body, issue_number, state in combos:
             request = ForgeOperationRequest(
@@ -153,6 +154,24 @@ def test_issue_comment_without_issue_number_is_refused_at_parse() -> None:
     with pytest.raises(ValidationError) as excinfo:
         ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_COMMENT, repo_identity="owner/repo", body="hi")
     assert "issue_number" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("body", [None, ""])
+def test_issue_comment_without_a_body_is_refused_at_parse(body: str | None) -> None:
+    """An empty comment is a human decision spent on a no-op.
+
+    `gh issue comment` requires a body, and a forge write is SENSITIVE: it
+    costs an operator an approval. Approving one that publishes nothing is
+    the one outcome worth refusing before it reaches the gate.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        ForgeOperationRequest(
+            kind=ForgeOperationKind.ISSUE_COMMENT,
+            repo_identity="owner/repo",
+            issue_number=7,
+            body=body,
+        )
+    assert "body" in str(excinfo.value)
 
 
 def test_issue_close_without_issue_number_is_refused_at_parse() -> None:


### PR DESCRIPTION
Issues #80 and #79, stage 1 of the forge work. **Types, policy and machine lock only** — nothing calls `gh`, nothing is wired into the executor (that is the next PR). The point of doing it first is that everything downstream inherits a vocabulary and a policy that cannot be quietly loosened later.

## The decision this encodes
#80's empirical test ran on `devel3` on 2026-09-01 and is recorded on the issue: `codex exec -s workspace-write` has **no network** (DNS failure, exit 6 in 0ms; the same curl outside the sandbox returns 200). A coding agent cannot reach a forge API today. Of the three ways out, the operator chose: **the forge operation belongs to the executor process, runs outside the agent's sandbox, the credential never enters the agent's environment, and a forge write is `SENSITIVE` and stops at the human gate.**

Rejected, to be recorded in `docs/security.md` in the final PR of this track: opening the network inside `workspace-write` (one flag, `sandbox_workspace_write.network_access=true` — the ease is the argument against it), and enabling the network only for an already-approved task (narrower, but still hands the agent the whole internet for the duration).

## What changes
- `ForgeOperationKind` — a closed enum of four: `issue_open`, `issue_comment`, `issue_list`, `issue_close`. There is no "run `gh` with arbitrary argv" kind, and no member deletes an issue in any form.
- `ForgeOperationRequest` with parse-time validation: `REPO_IDENTITY_PATTERN` (the role `_REMOTE_NAME_PATTERN` plays for git remotes — a value that could reach flag position in an argv never parses), a closed `state` set, and per-kind coherence (comment/close need `issue_number`; open needs `title`; comment needs a non-empty `body`).
- `AgentMessageType.FORGE_OPERATION` / `FORGE_OPERATION_RESULT` — its own envelope pair, deliberately not folded into `TASK_DISPATCH`.
- `forge_operation_policy_level`: `READ` for `issue_list`, `SENSITIVE` for every write, unconditionally.
- `allow_forge_operations = False` (machine lock, off by default, same shape as `allow_git_delivery`).

## The one thing to read carefully
There is deliberately **no `forge_operation_is_preauthorized`**, and none must be added by analogy to `push_is_preauthorized`. That function exists because push already had a typed, narrow shape (`allow_push` + `PUSHABLE_BRANCH_PATTERN`) before pre-authorization was layered onto it. A forge write is a published, third-party-visible act made in the operator's name on infrastructure this codebase does not control: no request shape is trusted enough to skip a human seeing it first. `tests/unit/test_forge_policy.py` iterates the enum itself, not a literal list, and sweeps the field cross-product, so it fails the moment a new kind or a new field earns a quiet exception.

## Validation
`pytest -q`: 778 passed, 7 skipped, 0 failed. `tests/contract/`: 26 passed.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw