### PR TITLE
feat(gh-80,gh-79): forge GitHub executor module, isolated

### DIFF
--- a/agent/codex_bridge_agent/config.py
+++ b/agent/codex_bridge_agent/config.py
@@ -91,6 +91,17 @@ class AgentSettings(BaseSettings):
     # `gh`, not a coding-agent session -- `git_push_timeout_seconds` above
     # sets the analogous bound for git delivery.
     forge_operation_timeout_seconds: float = 60
+    # WK-20260902-forge-github-module, issue #80/#79. Where `gh_tool.run_gh`
+    # looks, under `project_root`, for the GitHub token to inject as
+    # `GH_TOKEN`. The house convention this repo already practices
+    # (`.credentials/store` in this very tree; `.gitignore:46` ignores
+    # `.credentials/*`) is that this path is a SYMLINK to the real secret
+    # kept outside the project tree -- `run_gh` refuses outright if it
+    # resolves to a regular file inside the repo, because the coding agent
+    # that runs in this same tree can read whatever the working copy holds.
+    # An operator who keeps the token under a different name points this at
+    # it without touching code.
+    forge_credential_relative_path: str = ".credentials/github-token"
 
     model_config = SettingsConfigDict(env_prefix="CODEX_BRIDGE_AGENT_", env_file=".env")
 

--- a/agent/codex_bridge_agent/forge/__init__.py
+++ b/agent/codex_bridge_agent/forge/__init__.py
@@ -1,0 +1,8 @@
+"""The executor's forge module -- where a `FORGE_OPERATION` actually talks to
+a real code-forge, once something wires it in (that wiring is B3, not this
+package). Structured as a package, mirroring `agent/codex_bridge_agent/runners/`
+(`base.py` plus one file per implementation), so `gitlab.py`/`forgejo.py` can
+be added later without reopening `github.py`.
+"""
+
+from __future__ import annotations

--- a/agent/codex_bridge_agent/forge/base.py
+++ b/agent/codex_bridge_agent/forge/base.py
@@ -1,0 +1,90 @@
+"""The forge-neutral surface any provider module in this package exposes.
+
+WK-20260902-forge-github-module, issue #80/#79 (PR B2). Mirrors
+`agent/codex_bridge_agent/runners/base.py`'s role for `runners/` almost
+exactly: `Runner`/`RunnerCapabilities` there declare what a coding-agent
+provider can do inside its own sandbox; `ForgeOutcome`/`ForgeOperationRunner`
+here declare what a forge provider did OUTSIDE any sandbox, on the executor
+process itself, against real third-party infrastructure.
+
+`ForgeOutcome` is deliberately shaped like `agent.codex_bridge_agent.
+git_delivery.DeliveryOutcome` -- the other executor-side, outside-the-sandbox,
+network-touching operation this codebase already has, and the module this PR
+is instructed to copy property-by-property from. Both are frozen dataclasses
+with an `attempted` flag, a closed `outcome` vocabulary, an optional `reason`
+naming a refusal, and a `to_dict()` for the envelope that eventually reports
+this back (wiring that envelope is B3; nothing here sends one yet).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+
+LogSender = Callable[[str, str], Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ForgeOutcome:
+    """What happened when the executor tried to run one forge operation.
+
+    `outcome` is one of `"succeeded"`, `"skipped"`, `"refused"` -- the same
+    three-way split `DeliveryOutcome.outcome` uses (that one also has
+    `"committed_only"`/`"committed_and_pushed"`, which do not apply here: a
+    forge operation has no partial-success shape, it either ran and its
+    post-condition held, or it did not run at all). `"skipped"` is kept for
+    parity even though no operation in this PR produces it yet -- `DELETE`
+    does not exist in `ForgeOperationKind`, so there is no "nothing to do"
+    case today; a future kind might have one.
+
+    The per-operation result fields below are a union across all four
+    `ForgeOperationKind` members, exactly like `DeliveryOutcome` unions the
+    fields of a commit-only and a commit-and-push result: `issue_number` and
+    `issue_url` are populated by `issue_open` (and `issue_number` echoed back
+    by `issue_comment`/`issue_close`); `issues` only by `issue_list`. A field
+    a given `kind` does not produce is simply left at its default.
+    """
+
+    attempted: bool
+    outcome: str  # "succeeded" | "skipped" | "refused"
+    reason: str | None = None
+    kind: str | None = None
+    repo_identity: str | None = None
+    issue_number: int | None = None
+    issue_url: str | None = None
+    issues: list[dict[str, Any]] = field(default_factory=list)
+    return_code: int | None = None
+    stdout: str | None = None
+    stderr: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "attempted": self.attempted,
+            "outcome": self.outcome,
+            "reason": self.reason,
+            "kind": self.kind,
+            "repo_identity": self.repo_identity,
+            "issue_number": self.issue_number,
+            "issue_url": self.issue_url,
+            "issues": self.issues,
+            "return_code": self.return_code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+        }
+
+
+# The common signature every forge provider module in this package exposes --
+# `github.py`'s `run_forge_operation` today, a future `gitlab.py`/`forgejo.py`
+# tomorrow. A plain `Callable` type alias, not a `typing.Protocol` class: the
+# function takes keyword-only arguments (`project_root`, `operation`,
+# `settings`, `task_id`, `send_log`), which `Protocol.__call__` cannot express
+# precisely, and this package has no dispatch table yet that would need to
+# hold one of these polymorphically -- that routing (which provider a given
+# operation targets) does not exist before B3 wires anything in. Kept here,
+# next to `ForgeOutcome`, purely as the documented contract a new provider
+# module must match.
+ForgeOperationRunner = Callable[..., Awaitable[ForgeOutcome]]
+"""`async def run_forge_operation(*, project_root: Path, operation:
+ForgeOperationRequest, settings: AgentSettings, task_id: str | None,
+send_log: LogSender) -> ForgeOutcome`"""

--- a/agent/codex_bridge_agent/forge/base.py
+++ b/agent/codex_bridge_agent/forge/base.py
@@ -25,6 +25,24 @@ from typing import Any, Awaitable, Callable
 LogSender = Callable[[str, str], Awaitable[None]]
 
 
+# `gh`'s own stdout/stderr is third-party text of unbounded size: it crosses
+# the websocket to the gateway and lands in a stored result blob. The
+# precedent this module mirrors, `DeliveryOutcome`, avoids the question
+# entirely by carrying structured facts only (`commit`, `remote_sha`,
+# `files_changed`) and never a command's raw output. Keeping the output here
+# is a deliberate departure -- a refusal is much harder to diagnose without
+# it, and `gh` reports the forge's own error text nowhere else -- so it is
+# bounded instead of dropped, at the one place every outcome is built.
+MAX_CAPTURED_OUTPUT = 2000
+
+
+def _truncate_captured(text: str | None) -> str | None:
+    if text is None or len(text) <= MAX_CAPTURED_OUTPUT:
+        return text
+    dropped = len(text) - MAX_CAPTURED_OUTPUT
+    return f"{text[:MAX_CAPTURED_OUTPUT]}\n[... {dropped} more characters dropped]"
+
+
 @dataclass(frozen=True)
 class ForgeOutcome:
     """What happened when the executor tried to run one forge operation.
@@ -57,6 +75,14 @@ class ForgeOutcome:
     return_code: int | None = None
     stdout: str | None = None
     stderr: str | None = None
+
+    def __post_init__(self) -> None:
+        # Truncation lives here rather than at each construction site in
+        # `github.py`: there are twenty of them today and every future
+        # operation adds more, so a per-site cap is a rule that holds until
+        # someone forgets it once.
+        object.__setattr__(self, "stdout", _truncate_captured(self.stdout))
+        object.__setattr__(self, "stderr", _truncate_captured(self.stderr))
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/agent/codex_bridge_agent/forge/gh_tool.py
+++ b/agent/codex_bridge_agent/forge/gh_tool.py
@@ -1,0 +1,145 @@
+"""Runs the `gh` CLI as a subprocess, and only that -- the forge-side sibling
+
+of `agent/codex_bridge_agent/git_tools.run_git`. Same shape, same
+reasoning: `asyncio.create_subprocess_exec` with an argv LIST (never a shell
+string, so nothing here can be reinterpreted by a shell), a timeout that
+always applies, and stdout/stderr captured and decoded rather than left to
+inherit the executor's own streams.
+
+`run_gh` additionally owns the one thing `run_git` never had to: resolving
+the `GH_TOKEN` credential and injecting it into the subprocess's own `env=`,
+nowhere else. Two guards make that safe:
+
+  1. `resolve_gh_token` refuses unless the credential path is a SYMLINK whose
+     resolved target sits outside `project_root` -- never a regular file
+     inside the tree the coding agent (running in this same project, in its
+     own sandboxed session) can read. The convention this mirrors already
+     exists in this repo: `.credentials/store` here is itself a symlink to
+     `~/.config/credentials/personal`, and `.gitignore` ignores
+     `.credentials/*` wholesale. If the token's bytes never exist inside the
+     tree, no path the coding agent can read ever holds them.
+  2. `git_delivery._is_forbidden_path` already refuses to stage or commit
+     anything with `.credentials` in its path (`git_delivery.py:56-80`,
+     pre-existing, `AGENTS.md` §7) -- so even if guard 1 above were somehow
+     bypassed, the token could not travel from working tree to commit. This
+     module does not re-implement that guard; it relies on it staying in
+     place, and `tests/unit/test_git_delivery.py` now names the case
+     (`.credentials/github-token`) explicitly as a defense of this feature so
+     it is not mistaken for dead weight and removed later.
+
+`GH_ENV_ALLOWLIST` is a third, disjoint env allowlist alongside
+`runners/codex.py`'s `CODEX_ENV_ALLOWLIST` and `runners/claude.py`'s
+`CLAUDE_ENV_ALLOWLIST` (council finding F08: env custody must never be
+unioned across engines). `GH_TOKEN` belongs on exactly this allowlist and no
+other -- `tests/unit/test_runner_registry.py::
+test_no_registered_engines_env_allowlist_overlaps_another` is extended in
+this PR to prove it never leaks onto a runner's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from shared.security import filtered_environment
+
+
+# `HOME`/`PATH` so `gh` itself can run and find its own config; `GH_TOKEN` is
+# never present in `os.environ` (nothing in this codebase sets it globally --
+# see `config.py`'s own docstring on `forge_credential_relative_path`), it is
+# injected explicitly by `run_gh` below, once, per operation.
+GH_ENV_ALLOWLIST = frozenset({"HOME", "PATH", "GH_TOKEN"})
+
+
+@dataclass(frozen=True)
+class GhResult:
+    """Mirrors `run_git`'s `(code, stdout, stderr)` tuple, plus the one
+    failure mode `run_git` has no equivalent of: a credential that fails the
+    symlink-outside-repo guard before any subprocess is ever spawned.
+    `returncode` is `None` exactly when `refused_reason` is set -- `gh` never
+    ran.
+    """
+
+    returncode: int | None
+    stdout: str
+    stderr: str
+    refused_reason: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.refused_reason is None and self.returncode == 0
+
+
+def resolve_gh_token(project_root: Path, credential_relative_path: str) -> tuple[str | None, str | None]:
+    """Reads the GH token, enforcing the symlink-outside-repo guard.
+
+    Returns `(token, None)` on success, `(None, reason)` on refusal.
+    Deliberately synchronous and side-effect-free beyond the read -- callable
+    on its own from a test that wants to check the guard without spawning a
+    fake `gh` at all.
+    """
+    credential_path = project_root / credential_relative_path
+    if not credential_path.exists() and not credential_path.is_symlink():
+        return None, "forge_credential_missing"
+    if not credential_path.is_symlink():
+        # A regular file living inside the tree: exactly what this guard
+        # exists to refuse. `.is_symlink()` is checked, not `.is_file()` --
+        # a symlink whose target is also a regular file must still pass
+        # through the branch below so its resolved target gets checked
+        # against `project_root`.
+        return None, "forge_credential_must_be_symlink_outside_repo"
+    resolved_target = credential_path.resolve()
+    resolved_root = project_root.resolve()
+    if resolved_target == resolved_root or resolved_root in resolved_target.parents:
+        return None, "forge_credential_must_be_symlink_outside_repo"
+    if not resolved_target.is_file():
+        return None, "forge_credential_target_missing"
+    token = resolved_target.read_text(encoding="utf-8").strip()
+    if not token:
+        return None, "forge_credential_empty"
+    return token, None
+
+
+async def run_gh(
+    project_root: Path,
+    *args: str,
+    gh_bin: str,
+    credential_relative_path: str,
+    timeout_seconds: float,
+) -> GhResult:
+    """Runs one `gh` subcommand in `project_root`, capturing stdout/stderr.
+
+    `args` becomes `gh`'s argv verbatim, as a list -- callers in `github.py`
+    build that list from validated, pattern-checked fields
+    (`shared.protocol.REPO_IDENTITY_PATTERN`) and from temp-file paths this
+    package itself creates, never from raw title/body text placed at a flag
+    position. No shell is ever involved, so nothing here can be reinterpreted
+    by one.
+    """
+    token, refused_reason = resolve_gh_token(project_root, credential_relative_path)
+    if refused_reason is not None:
+        return GhResult(returncode=None, stdout="", stderr="", refused_reason=refused_reason)
+
+    env = filtered_environment(GH_ENV_ALLOWLIST)
+    env["GH_TOKEN"] = token or ""
+
+    process = await asyncio.create_subprocess_exec(
+        gh_bin,
+        *args,
+        cwd=str(project_root),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+        return GhResult(returncode=124, stdout="", stderr="timed out waiting for gh")
+    return GhResult(
+        returncode=process.returncode,
+        stdout=stdout.decode("utf-8", errors="replace"),
+        stderr=stderr.decode("utf-8", errors="replace"),
+    )

--- a/agent/codex_bridge_agent/forge/github.py
+++ b/agent/codex_bridge_agent/forge/github.py
@@ -1,0 +1,400 @@
+"""Runs one `ForgeOperationRequest` against GitHub, via `gh`.
+
+WK-20260902-forge-github-module, issue #80/#79 (PR B2). This module is
+**isolated** on purpose: nothing in `service.py`, nothing in the gateway,
+nothing dispatches a `FORGE_OPERATION` envelope into `run_forge_operation`
+yet. That wiring is a separate PR (B3), for the same reason B1
+(`shared/protocol.py`, `shared/policy.py`) shipped before this one -- each
+slice reviewable on its own, and a module that can reach the real network
+does not exist half-wired in the meantime.
+
+When B3 does wire this in, it belongs on the same side of the boundary
+`agent/codex_bridge_agent/git_delivery.py` already established for
+`deliver_changes`: called by `AgentService` AFTER the coding-agent provider's
+own process has exited (or, for a forge operation, independent of any
+provider process at all -- there is no "coding session" a forge operation
+runs inside), never from inside a runner's sandbox
+(`agent/codex_bridge_agent/runners/`). A forge write needs network, which
+`workspace-write` does not grant, and it carries a credential
+(`gh_tool.run_gh`'s `GH_TOKEN`) that must never enter the sandbox a coding
+agent's own process attaches to.
+
+Every property this module borrows from `git_delivery.py` is named at its
+own point below, in a comment starting `# git_delivery property:` -- so a
+reviewer can check each one against its original rather than trusting a
+paraphrase.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any, Callable
+
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.forge.base import ForgeOutcome, LogSender
+from agent.codex_bridge_agent.forge.gh_tool import GhResult, run_gh
+from shared.protocol import ForgeOperationKind, ForgeOperationRequest, REPO_IDENTITY_PATTERN
+
+
+# `gh issue create`/`gh issue comment` print the created/commented issue's
+# URL to stdout on success -- e.g. "https://github.com/owner/repo/issues/42".
+# Used only for `issue_open`'s post-condition check below: exit 0 alone is
+# not proof an issue exists (# git_delivery property: post-condition
+# verification, `git_delivery.py:311-315` compares the remote sha the same
+# way rather than trusting `push`'s exit code).
+_ISSUE_URL_PATTERN = re.compile(r"/issues/(\d+)\s*$")
+
+# `gh issue list --json ... --limit N`: bounded and explicit rather than
+# relying on `gh`'s own default (which is also 30, as of the CLI versions
+# this codebase has been run against, but an explicit flag does not drift
+# quietly if that default ever changes upstream).
+_ISSUE_LIST_DEFAULT_LIMIT = 30
+_ISSUE_LIST_JSON_FIELDS = "number,title,state,url"
+
+# `ISSUE_LIST`'s only meaningful `state` value when the request leaves it
+# unset -- `gh issue list --state` defaults to "open" too, but this module
+# passes it explicitly for the same reason as the `--limit` above.
+_DEFAULT_ISSUE_STATE = "open"
+
+
+def _refused(
+    reason: str,
+    *,
+    kind: ForgeOperationKind | str | None,
+    repo_identity: str | None,
+    **extra: Any,
+) -> ForgeOutcome:
+    fields: dict[str, Any] = {
+        "kind": kind.value if isinstance(kind, ForgeOperationKind) else kind,
+        "repo_identity": repo_identity,
+    }
+    fields.update(extra)
+    return ForgeOutcome(attempted=True, outcome="refused", reason=reason, **fields)
+
+
+# git_delivery property: re-validation on the executor of what the gateway
+# sent (`git_delivery.py`'s module docstring, point 2 -- checked again here
+# even though the gateway/`ForgeOperationRequest`'s own pydantic validators
+# already checked it, because a compromised or buggy gateway must not be able
+# to grant a write by lying about what it already verified). This
+# intentionally duplicates `ForgeOperationRequest`'s own
+# `@model_validator`/`@field_validator` logic rather than trusting that the
+# object handed to this function actually went through it (e.g. a
+# `model_construct` bypass upstream).
+def _revalidate_locally(operation: ForgeOperationRequest) -> str | None:
+    """Returns a refusal reason, or `None` if the request is coherent."""
+    if not isinstance(operation.kind, ForgeOperationKind):
+        return "invalid_kind"
+    # git_delivery property: `_REMOTE_NAME_PATTERN` reapplied to `remote` even
+    # though the model has no constraint of its own; here
+    # `REPO_IDENTITY_PATTERN` (from B1, `shared/protocol.py`) is reapplied to
+    # `repo_identity` even though `ForgeOperationRequest` already enforces it
+    # at parse time -- the executor never trusts that the object in hand
+    # actually went through that validator.
+    if not REPO_IDENTITY_PATTERN.match(operation.repo_identity):
+        return "invalid_repo_identity"
+    if operation.kind in (ForgeOperationKind.ISSUE_COMMENT, ForgeOperationKind.ISSUE_CLOSE):
+        if operation.issue_number is None or operation.issue_number <= 0:
+            return "invalid_issue_number"
+    if operation.kind is ForgeOperationKind.ISSUE_COMMENT and not operation.body:
+        return "invalid_empty_body"
+    if operation.kind is ForgeOperationKind.ISSUE_OPEN and not operation.title:
+        return "invalid_missing_title"
+    if operation.state is not None and operation.state not in {"open", "closed", "all"}:
+        return "invalid_state"
+    return None
+
+
+async def run_forge_operation(
+    *,
+    project_root: Path,
+    operation: ForgeOperationRequest,
+    settings: AgentSettings,
+    task_id: str | None,
+    send_log: LogSender,
+) -> ForgeOutcome:
+    """Runs `operation` against GitHub via `gh`, and reports what happened.
+
+    Never called by anything in this PR -- see the module docstring. Every
+    caller this signature is written for (B3) is expected to have already
+    checked `shared.policy.forge_operation_policy_level` and gotten a human
+    approval for anything but `ISSUE_LIST`; this function does not re-derive
+    that decision, because -- like `deliver_changes` -- it trusts that the
+    approval gate already ran, and instead re-checks the things a compromised
+    gateway could lie about (see `_revalidate_locally`).
+    """
+    # git_delivery property: machine-level kill switch, off by default,
+    # checked BEFORE anything else touches `gh` (`allow_git_delivery` is
+    # `git_delivery.py`'s analogous check; `git_delivery.py:198`).
+    if not settings.allow_forge_operations:
+        return _refused("executor_forge_disabled", kind=operation.kind, repo_identity=operation.repo_identity)
+
+    invalid_reason = _revalidate_locally(operation)
+    if invalid_reason is not None:
+        return _refused(invalid_reason, kind=operation.kind, repo_identity=operation.repo_identity)
+
+    if operation.kind is ForgeOperationKind.ISSUE_OPEN:
+        return await _run_issue_open(project_root, operation, settings, send_log)
+    if operation.kind is ForgeOperationKind.ISSUE_COMMENT:
+        return await _run_issue_comment(project_root, operation, settings, send_log)
+    if operation.kind is ForgeOperationKind.ISSUE_LIST:
+        return await _run_issue_list(project_root, operation, settings, send_log)
+    if operation.kind is ForgeOperationKind.ISSUE_CLOSE:
+        return await _run_issue_close(project_root, operation, settings, send_log)
+    # Unreachable given `_revalidate_locally`'s `isinstance` check above and
+    # `ForgeOperationKind` being a closed enum -- kept as an explicit refusal
+    # rather than falling off the end of the function silently.
+    return _refused("unknown_kind", kind=operation.kind, repo_identity=operation.repo_identity)
+
+
+# git_delivery property: arbitrary caller-supplied text must never become a
+# flag position (`git_delivery.py`'s own reasoning for `commit -m subject -m
+# body`, applied here to `gh issue create`/`gh issue comment`'s
+# `--body-file`). The temp file this function creates is the only thing that
+# ever reaches that flag's value -- never `body` itself, positionally or
+# otherwise.
+async def _run_gh_with_body_file(
+    project_root: Path,
+    settings: AgentSettings,
+    body: str,
+    argv_builder: Callable[[Path], list[str]],
+) -> tuple[GhResult, list[str]]:
+    """Writes `body` to a temp file, runs `argv_builder(tmp_path)` through
+    `run_gh`, and always removes the temp file -- including when `gh` fails.
+    """
+    tmp_path: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            mode="w", prefix="codexbridge-forge-body-", suffix=".md", delete=False, encoding="utf-8"
+        ) as handle:
+            handle.write(body)
+            tmp_path = Path(handle.name)
+        args = argv_builder(tmp_path)
+        result = await run_gh(
+            project_root,
+            *args,
+            gh_bin=settings.forge_gh_bin,
+            credential_relative_path=settings.forge_credential_relative_path,
+            timeout_seconds=settings.forge_operation_timeout_seconds,
+        )
+        return result, args
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
+async def _run_issue_open(
+    project_root: Path,
+    operation: ForgeOperationRequest,
+    settings: AgentSettings,
+    send_log: LogSender,
+) -> ForgeOutcome:
+    def build(tmp_path: Path) -> list[str]:
+        return [
+            "issue",
+            "create",
+            "--repo",
+            operation.repo_identity,
+            "--title",
+            operation.title or "",
+            "--body-file",
+            str(tmp_path),
+        ]
+
+    result, args = await _run_gh_with_body_file(project_root, settings, operation.body or "", build)
+    await send_log("stderr", f"forge.gh_argv:{' '.join(args)}")
+
+    if result.refused_reason is not None:
+        return _refused(result.refused_reason, kind=operation.kind, repo_identity=operation.repo_identity)
+    if not result.ok:
+        return _refused(
+            "gh_command_failed",
+            kind=operation.kind,
+            repo_identity=operation.repo_identity,
+            return_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+
+    # git_delivery property: post-condition verification
+    # (`git_delivery.py:311-315`) -- exit code 0 is not proof. Confirm the
+    # issue actually exists by parsing its number out of the URL `gh` prints,
+    # rather than trusting the return code alone.
+    match = _ISSUE_URL_PATTERN.search(result.stdout.strip())
+    if match is None:
+        return _refused(
+            "forge_postcondition_failed:no_issue_url_in_output",
+            kind=operation.kind,
+            repo_identity=operation.repo_identity,
+            return_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return ForgeOutcome(
+        attempted=True,
+        outcome="succeeded",
+        kind=operation.kind.value,
+        repo_identity=operation.repo_identity,
+        issue_number=int(match.group(1)),
+        issue_url=result.stdout.strip(),
+        return_code=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+async def _run_issue_comment(
+    project_root: Path,
+    operation: ForgeOperationRequest,
+    settings: AgentSettings,
+    send_log: LogSender,
+) -> ForgeOutcome:
+    issue_number = operation.issue_number
+    assert issue_number is not None  # guaranteed by `_revalidate_locally`
+
+    def build(tmp_path: Path) -> list[str]:
+        return [
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            operation.repo_identity,
+            "--body-file",
+            str(tmp_path),
+        ]
+
+    result, args = await _run_gh_with_body_file(project_root, settings, operation.body or "", build)
+    await send_log("stderr", f"forge.gh_argv:{' '.join(args)}")
+
+    if result.refused_reason is not None:
+        return _refused(result.refused_reason, kind=operation.kind, repo_identity=operation.repo_identity)
+    if not result.ok:
+        return _refused(
+            "gh_command_failed",
+            kind=operation.kind,
+            repo_identity=operation.repo_identity,
+            issue_number=issue_number,
+            return_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return ForgeOutcome(
+        attempted=True,
+        outcome="succeeded",
+        kind=operation.kind.value,
+        repo_identity=operation.repo_identity,
+        issue_number=issue_number,
+        return_code=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+async def _run_issue_close(
+    project_root: Path,
+    operation: ForgeOperationRequest,
+    settings: AgentSettings,
+    send_log: LogSender,
+) -> ForgeOutcome:
+    issue_number = operation.issue_number
+    assert issue_number is not None  # guaranteed by `_revalidate_locally`
+
+    args = ["issue", "close", str(issue_number), "--repo", operation.repo_identity]
+    await send_log("stderr", f"forge.gh_argv:{' '.join(args)}")
+    result = await run_gh(
+        project_root,
+        *args,
+        gh_bin=settings.forge_gh_bin,
+        credential_relative_path=settings.forge_credential_relative_path,
+        timeout_seconds=settings.forge_operation_timeout_seconds,
+    )
+
+    if result.refused_reason is not None:
+        return _refused(result.refused_reason, kind=operation.kind, repo_identity=operation.repo_identity)
+    if not result.ok:
+        return _refused(
+            "gh_command_failed",
+            kind=operation.kind,
+            repo_identity=operation.repo_identity,
+            issue_number=issue_number,
+            return_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return ForgeOutcome(
+        attempted=True,
+        outcome="succeeded",
+        kind=operation.kind.value,
+        repo_identity=operation.repo_identity,
+        issue_number=issue_number,
+        return_code=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+async def _run_issue_list(
+    project_root: Path,
+    operation: ForgeOperationRequest,
+    settings: AgentSettings,
+    send_log: LogSender,
+) -> ForgeOutcome:
+    state = operation.state or _DEFAULT_ISSUE_STATE
+    args = [
+        "issue",
+        "list",
+        "--repo",
+        operation.repo_identity,
+        "--state",
+        state,
+        "--json",
+        _ISSUE_LIST_JSON_FIELDS,
+        "--limit",
+        str(_ISSUE_LIST_DEFAULT_LIMIT),
+    ]
+    await send_log("stderr", f"forge.gh_argv:{' '.join(args)}")
+    result = await run_gh(
+        project_root,
+        *args,
+        gh_bin=settings.forge_gh_bin,
+        credential_relative_path=settings.forge_credential_relative_path,
+        timeout_seconds=settings.forge_operation_timeout_seconds,
+    )
+
+    if result.refused_reason is not None:
+        return _refused(result.refused_reason, kind=operation.kind, repo_identity=operation.repo_identity)
+    if not result.ok:
+        return _refused(
+            "gh_command_failed",
+            kind=operation.kind,
+            repo_identity=operation.repo_identity,
+            return_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    try:
+        issues = json.loads(result.stdout)
+        if not isinstance(issues, list):
+            raise ValueError("gh issue list --json did not return a JSON array")
+    except (json.JSONDecodeError, ValueError):
+        return _refused(
+            "forge_postcondition_failed:not_json_array",
+            kind=operation.kind,
+            repo_identity=operation.repo_identity,
+            return_code=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return ForgeOutcome(
+        attempted=True,
+        outcome="succeeded",
+        kind=operation.kind.value,
+        repo_identity=operation.repo_identity,
+        issues=issues,
+        return_code=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-protocol-and-policy`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-protocol-and-policy map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-github-module`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-github-module map`
 
 ## Summary
 
-- 127 file(s) · 1196 symbol(s) indexed
-- Languages: config (2), python (123), shell (2)
+- 133 file(s) · 1232 symbol(s) indexed
+- Languages: config (2), python (129), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -36,6 +36,11 @@ agent/
     __main__.py
     codex_runner.py  — "Re-export shim."
     config.py
+    forge/
+      __init__.py  — "The executor's forge module -- where a `FORGE_OPERATION` actually talks to"
+      base.py  — "The forge-neutral surface any provider module in this package exposes."
+      gh_tool.py  — "Runs the `gh` CLI as a subprocess, and only that -- the forge-side sibling"
+      github.py  — "Runs one `ForgeOperationRequest` against GitHub, via `gh`."
     git_delivery.py  — "The commit/push step a completed task's own `delivery` block authorizes."
     git_tools.py
     instructions.py  — "Resolves `issue_ref` to file content, and builds the provider prompt with"
@@ -162,7 +167,9 @@ tests/
     test_config_settings.py  — "issue #17 council round 1, "the second caller": `cancel_replay_max_age_seconds`"
     test_discover_projects.py  — "`scripts/discover_projects.py` -- read-only repo discovery."
     test_email_templates.py  — "`gateway.app.services.email_templates` -- pure rendering, no I/O."
+    test_forge_github.py  — "`forge.github.run_forge_operation` -- argv assembly, the kill switch, local"
     test_forge_policy.py  — "The forge vocabulary and policy issue #80/#79 build the write gate on."
+    test_gh_tool.py  — "`gh_tool.run_gh`/`resolve_gh_token` against a fake `gh` subprocess."
     test_git_delivery.py  — "`git_delivery.deliver_changes` against real throwaway git repos."
     test_google_calendar.py  — "`gateway.app.services.google_calendar`, without ever touching Google."
     test_instructions.py  — "`resolve_issue_text` and `build_task_instruction`."
@@ -186,6 +193,28 @@ tests/
 - **`AgentProjectConfig`** *(class)*
 - `load_agent_projects(path)`
 - `resolve_auto_project(project_id, root)` — "Fallback lookup for a `project_id` the static allowlist does not know."
+
+### `agent/codex_bridge_agent/forge/base.py`
+
+> The forge-neutral surface any provider module in this package exposes.
+
+- **`ForgeOutcome`** *(class)* — "What happened when the executor tried to run one forge operation."
+  - `to_dict(self)` *(method)*
+
+### `agent/codex_bridge_agent/forge/gh_tool.py`
+
+> Runs the `gh` CLI as a subprocess, and only that -- the forge-side sibling
+
+- **`GhResult`** *(class)* — "Mirrors `run_git`'s `(code, stdout, stderr)` tuple, plus the one"
+  - `ok` *(property)*
+- `resolve_gh_token(project_root, credential_relative_path)` — "Reads the GH token, enforcing the symlink-outside-repo guard."
+- `run_gh(project_root, *args)` *(async function)* — "Runs one `gh` subcommand in `project_root`, capturing stdout/stderr."
+
+### `agent/codex_bridge_agent/forge/github.py`
+
+> Runs one `ForgeOperationRequest` against GitHub, via `gh`.
+
+- `run_forge_operation()` *(async function)* — "Runs `operation` against GitHub via `gh`, and reports what happened."
 
 ### `agent/codex_bridge_agent/git_delivery.py`
 
@@ -1674,6 +1703,26 @@ tests/
 - `test_no_inline_svg_shipped_in_a_real_email()` — "Outlook's desktop renderer does not support <svg> -- a broken icon in"
 - `test_no_rows_and_no_cta_omits_the_highlight_card()`
 
+### `tests/unit/test_forge_github.py`
+
+> `forge.github.run_forge_operation` -- argv assembly, the kill switch, local
+
+- `test_kill_switch_refuses_before_run_gh_is_ever_called(tmp_path, monkeypatch)` *(async function)*
+- `test_kill_switch_on_lets_a_valid_operation_through(tmp_path, monkeypatch)` *(async function)* — "Positive control for the refusal above."
+- `test_issue_open_builds_the_exact_argv_and_succeeds_on_a_real_postcondition(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_open_exit_zero_without_an_issue_url_is_refused_not_succeeded(tmp_path, monkeypatch)` *(async function)* — "The post-condition check: `git_delivery.py` compares the remote sha"
+- `test_issue_open_body_file_is_deleted_even_when_gh_fails(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_comment_builds_the_exact_argv_and_succeeds(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_comment_without_a_real_issue_number_is_refused_locally_before_run_gh(tmp_path, monkeypatch)` *(async function)* — "Simulates an object that bypassed `ForgeOperationRequest`'s own"
+- `test_issue_close_builds_the_exact_fully_static_argv_and_succeeds(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_close_propagates_a_credential_refusal_from_run_gh(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_list_builds_the_exact_fully_static_argv_with_default_state(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_list_honors_an_explicit_state_and_parses_the_json_result(tmp_path, monkeypatch)` *(async function)*
+- `test_issue_list_non_json_output_is_refused_not_succeeded(tmp_path, monkeypatch)` *(async function)*
+- `test_a_malformed_repo_identity_that_bypassed_pydantic_never_reaches_run_gh(tmp_path, monkeypatch)` *(async function)*
+- `test_a_wellformed_repo_identity_that_bypassed_pydantic_still_reaches_run_gh(tmp_path, monkeypatch)` *(async function)* — "Positive control: `model_construct` alone is not what gets refused --"
+- `test_settings_are_forwarded_to_run_gh(tmp_path, monkeypatch)` *(async function)*
+
 ### `tests/unit/test_forge_policy.py`
 
 > The forge vocabulary and policy issue #80/#79 build the write gate on.
@@ -1691,6 +1740,23 @@ tests/
 - `test_state_outside_the_closed_set_is_refused_at_parse()`
 - `test_forge_message_types_exist_and_are_distinct_from_task_dispatch()` — "Sanity check on the two new `AgentMessageType` members this PR adds."
 
+### `tests/unit/test_gh_tool.py`
+
+> `gh_tool.run_gh`/`resolve_gh_token` against a fake `gh` subprocess.
+
+- `test_resolve_gh_token_refuses_a_regular_file_inside_the_repo(tmp_path)`
+- `test_resolve_gh_token_accepts_a_symlink_resolving_outside_the_repo(tmp_path)` — "Positive control for the test above: same shape, but a symlink whose"
+- `test_resolve_gh_token_refuses_a_symlink_whose_target_is_still_inside_the_repo(tmp_path)` — "A symlink alone is not the guard -- the resolved TARGET must be"
+- `test_resolve_gh_token_refuses_a_missing_credential(tmp_path)`
+- `test_resolve_gh_token_refuses_a_broken_symlink(tmp_path)`
+- `test_run_gh_refuses_a_regular_file_credential_without_spawning_a_process(tmp_path, monkeypatch)` *(async function)*
+- `test_run_gh_runs_the_process_when_the_credential_is_a_valid_symlink(tmp_path, monkeypatch)` *(async function)* — "Positive control for the refusal above."
+- `test_run_gh_injects_gh_token_and_filters_everything_else(tmp_path, monkeypatch)` *(async function)*
+- `test_gh_env_allowlist_is_exactly_home_path_gh_token()`
+- `test_run_gh_calls_create_subprocess_exec_with_a_list_argv_no_shell(tmp_path, monkeypatch)` *(async function)*
+- `test_run_gh_always_passes_the_timeout_to_wait_for(tmp_path, monkeypatch)` *(async function)*
+- `test_run_gh_times_out_and_kills_the_process(tmp_path, monkeypatch)` *(async function)*
+
 ### `tests/unit/test_git_delivery.py`
 
 > `git_delivery.deliver_changes` against real throwaway git repos.
@@ -1701,6 +1767,7 @@ tests/
 - `test_parse_shortstat_missing_fields_default_to_zero()`
 - `test_forbidden_paths_are_named_by_reason(path, expected_reason)`
 - `test_ordinary_source_paths_are_not_forbidden()`
+- `test_forbidden_paths_defend_the_forge_github_token_specifically()` — "WK-20260902-forge-github-module, issue #80/#79 (PR B2): the forge"
 - `test_refuses_main_regardless_of_the_kill_switch(tmp_path)` *(async function)*
 - `test_refuses_a_branch_that_fails_the_pushable_pattern(tmp_path)` *(async function)* — "Defense in depth: even though `DeliveryRequest` itself accepts any"
 - `test_refuses_when_the_executor_kill_switch_is_off(tmp_path)` *(async function)*
@@ -1825,6 +1892,7 @@ tests/
 - `test_codex_satisfies_the_runner_protocol()`
 - `test_codex_declares_an_os_enforced_sandbox()` — "The honest field from `RunnerCapabilities`: Codex's `-s read-only` is a"
 - `test_no_registered_engines_env_allowlist_overlaps_another()` — "Env custody must never be unioned across providers (council finding"
+- `test_gh_token_is_on_the_forge_allowlist_and_nowhere_else()` — "Positive control, spelled out by name rather than left implicit in the"
 - `test_unimplemented_engines_are_declared_not_absent()` — "Every `AgentEngine` value is a registered candidate, whether or not it"
 - `test_pool_defaults_to_codex_and_rejects_unknown_engines()`
 - `test_pool_routes_control_messages_only_to_dispatched_tasks()` *(async function)*

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- 133 file(s) · 1232 symbol(s) indexed
+- 133 file(s) · 1235 symbol(s) indexed
 - Languages: config (2), python (129), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -199,6 +199,7 @@ tests/
 > The forge-neutral surface any provider module in this package exposes.
 
 - **`ForgeOutcome`** *(class)* — "What happened when the executor tried to run one forge operation."
+  - `__post_init__(self)` *(method)*
   - `to_dict(self)` *(method)*
 
 ### `agent/codex_bridge_agent/forge/gh_tool.py`
@@ -1722,6 +1723,8 @@ tests/
 - `test_a_malformed_repo_identity_that_bypassed_pydantic_never_reaches_run_gh(tmp_path, monkeypatch)` *(async function)*
 - `test_a_wellformed_repo_identity_that_bypassed_pydantic_still_reaches_run_gh(tmp_path, monkeypatch)` *(async function)* — "Positive control: `model_construct` alone is not what gets refused --"
 - `test_settings_are_forwarded_to_run_gh(tmp_path, monkeypatch)` *(async function)*
+- `test_captured_output_is_bounded_before_it_leaves_the_executor()` — "`gh` output is third-party text of unbounded size, and it travels."
+- `test_output_within_the_bound_is_left_exactly_as_gh_produced_it()` — "Positive control: the cap must not rewrite ordinary output."
 
 ### `tests/unit/test_forge_policy.py`
 

--- a/tests/unit/test_forge_github.py
+++ b/tests/unit/test_forge_github.py
@@ -1,0 +1,456 @@
+"""`forge.github.run_forge_operation` -- argv assembly, the kill switch, local
+
+re-validation, and the `issue_open` post-condition check. WK-20260902-forge-
+github-module, issue #80/#79 (PR B2).
+
+Nothing here ever calls `gh_tool.run_gh` for real: it is monkeypatched to a
+fake that records every call and returns a scripted `GhResult`, so these
+tests are entirely about what `github.py` BUILDS and DECIDES, never about
+`gh_tool.py`'s own subprocess plumbing (covered by `tests/unit/test_gh_tool.py`).
+Every refusal here is paired with a positive control that reaches the same
+branch successfully, per `docs/napkin-lessons.md`'s 2026-09-01 lesson.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.forge import github
+from agent.codex_bridge_agent.forge.gh_tool import GhResult
+from shared.protocol import ForgeOperationKind, ForgeOperationRequest
+
+
+async def _collect_logs(_name: str, _line: str) -> None:
+    return None
+
+
+def _settings(**overrides) -> AgentSettings:
+    return AgentSettings(allow_forge_operations=True, **overrides)
+
+
+def _make_fake_run_gh(result_factory):
+    """`result_factory` is either a fixed `GhResult` or a callable taking the
+    recorded call dict and returning one -- the latter lets a test answer
+    based on what argv it actually received (e.g. echoing the body-file
+    content back)."""
+    calls: list[dict] = []
+
+    async def fake_run_gh(project_root, *args, gh_bin, credential_relative_path, timeout_seconds):
+        entry: dict = {
+            "project_root": project_root,
+            "args": list(args),
+            "gh_bin": gh_bin,
+            "credential_relative_path": credential_relative_path,
+            "timeout_seconds": timeout_seconds,
+        }
+        if "--body-file" in args:
+            body_path = Path(args[args.index("--body-file") + 1])
+            entry["body_file_path"] = body_path
+            entry["body_file_existed_during_call"] = body_path.exists()
+            entry["body_file_content"] = body_path.read_text(encoding="utf-8") if body_path.exists() else None
+        calls.append(entry)
+        if callable(result_factory):
+            return result_factory(entry)
+        return result_factory
+
+    return fake_run_gh, calls
+
+
+# --------------------------------------------------------------------------
+# The machine-level kill switch: checked before anything touches `gh`
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_refuses_before_run_gh_is_ever_called(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="unused", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=AgentSettings(allow_forge_operations=False),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "refused"
+    assert outcome.reason == "executor_forge_disabled"
+    assert calls == []  # the fake `run_gh` was never invoked
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_on_lets_a_valid_operation_through(tmp_path: Path, monkeypatch):
+    """Positive control for the refusal above."""
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="[]", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "succeeded"
+    assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------
+# issue_open
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_open_builds_the_exact_argv_and_succeeds_on_a_real_postcondition(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(
+        GhResult(returncode=0, stdout="https://github.com/owner/repo/issues/17\n", stderr="")
+    )
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(
+        kind=ForgeOperationKind.ISSUE_OPEN, repo_identity="owner/repo", title="Fix the bug", body="Steps to repro"
+    )
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert len(calls) == 1
+    args = calls[0]["args"]
+    assert args[:-1] == ["issue", "create", "--repo", "owner/repo", "--title", "Fix the bug", "--body-file"]
+    assert Path(args[-1]).name.startswith("codexbridge-forge-body-")
+    assert calls[0]["body_file_existed_during_call"] is True
+    assert calls[0]["body_file_content"] == "Steps to repro"
+    # The temp file must not survive the call, success or not.
+    assert calls[0]["body_file_path"].exists() is False
+
+    assert outcome.outcome == "succeeded"
+    assert outcome.issue_number == 17
+    assert outcome.issue_url == "https://github.com/owner/repo/issues/17"
+
+
+@pytest.mark.asyncio
+async def test_issue_open_exit_zero_without_an_issue_url_is_refused_not_succeeded(tmp_path: Path, monkeypatch):
+    """The post-condition check: `git_delivery.py` compares the remote sha
+    rather than trusting `push`'s exit code; this is the same property
+    applied to `gh issue create` -- exit 0 alone is not proof an issue
+    exists."""
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="nothing issue-shaped here", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_OPEN, repo_identity="owner/repo", title="x")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "refused"
+    assert outcome.reason.startswith("forge_postcondition_failed")
+    assert outcome.issue_number is None
+    # Still cleaned up even though the outcome was refused.
+    assert calls[0]["body_file_path"].exists() is False
+
+
+@pytest.mark.asyncio
+async def test_issue_open_body_file_is_deleted_even_when_gh_fails(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=1, stdout="", stderr="gh: some error"))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_OPEN, repo_identity="owner/repo", title="x")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "refused"
+    assert outcome.reason == "gh_command_failed"
+    assert calls[0]["body_file_existed_during_call"] is True
+    assert calls[0]["body_file_path"].exists() is False
+
+
+# --------------------------------------------------------------------------
+# issue_comment
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_builds_the_exact_argv_and_succeeds(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(
+        GhResult(returncode=0, stdout="https://github.com/owner/repo/issues/9#issuecomment-1\n", stderr="")
+    )
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(
+        kind=ForgeOperationKind.ISSUE_COMMENT, repo_identity="owner/repo", issue_number=9, body="a comment"
+    )
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert len(calls) == 1
+    args = calls[0]["args"]
+    assert args[:-1] == ["issue", "comment", "9", "--repo", "owner/repo", "--body-file"]
+    assert calls[0]["body_file_content"] == "a comment"
+    assert calls[0]["body_file_path"].exists() is False
+
+    assert outcome.outcome == "succeeded"
+    assert outcome.issue_number == 9
+
+
+@pytest.mark.asyncio
+async def test_issue_comment_without_a_real_issue_number_is_refused_locally_before_run_gh(
+    tmp_path: Path, monkeypatch
+):
+    """Simulates an object that bypassed `ForgeOperationRequest`'s own
+    `@model_validator` (e.g. via `model_construct`) -- the executor must not
+    trust that the request in hand actually went through it."""
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="unused", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    bypassed = ForgeOperationRequest.model_construct(
+        kind=ForgeOperationKind.ISSUE_COMMENT,
+        repo_identity="owner/repo",
+        title=None,
+        body="hi",
+        issue_number=None,
+        state=None,
+    )
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=bypassed,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "refused"
+    assert outcome.reason == "invalid_issue_number"
+    assert calls == []
+
+
+# --------------------------------------------------------------------------
+# issue_close
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_close_builds_the_exact_fully_static_argv_and_succeeds(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="closed", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_CLOSE, repo_identity="owner/repo", issue_number=42)
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["args"] == ["issue", "close", "42", "--repo", "owner/repo"]
+    assert outcome.outcome == "succeeded"
+    assert outcome.issue_number == 42
+
+
+@pytest.mark.asyncio
+async def test_issue_close_propagates_a_credential_refusal_from_run_gh(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(
+        GhResult(returncode=None, stdout="", stderr="", refused_reason="forge_credential_must_be_symlink_outside_repo")
+    )
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_CLOSE, repo_identity="owner/repo", issue_number=1)
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert len(calls) == 1
+    assert outcome.outcome == "refused"
+    assert outcome.reason == "forge_credential_must_be_symlink_outside_repo"
+
+
+# --------------------------------------------------------------------------
+# issue_list
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_issue_list_builds_the_exact_fully_static_argv_with_default_state(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="[]", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert calls[0]["args"] == [
+        "issue",
+        "list",
+        "--repo",
+        "owner/repo",
+        "--state",
+        "open",
+        "--json",
+        "number,title,state,url",
+        "--limit",
+        "30",
+    ]
+    assert outcome.outcome == "succeeded"
+    assert outcome.issues == []
+
+
+@pytest.mark.asyncio
+async def test_issue_list_honors_an_explicit_state_and_parses_the_json_result(tmp_path: Path, monkeypatch):
+    payload = '[{"number": 3, "title": "t", "state": "closed", "url": "https://x/3"}]'
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout=payload, stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo", state="closed")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert calls[0]["args"][calls[0]["args"].index("--state") + 1] == "closed"
+    assert outcome.outcome == "succeeded"
+    assert outcome.issues == [{"number": 3, "title": "t", "state": "closed", "url": "https://x/3"}]
+
+
+@pytest.mark.asyncio
+async def test_issue_list_non_json_output_is_refused_not_succeeded(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="not json at all", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo")
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "refused"
+    assert outcome.reason.startswith("forge_postcondition_failed")
+
+
+# --------------------------------------------------------------------------
+# repo_identity re-validation: `REPO_IDENTITY_PATTERN` applied again here,
+# never trusting that the object in hand actually went through the model's
+# own validator (git_delivery property: re-check what the gateway already
+# checked, `_REMOTE_NAME_PATTERN` reapplied to `remote` in `git_delivery.py`).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_repo_identity_that_bypassed_pydantic_never_reaches_run_gh(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="[]", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    bypassed = ForgeOperationRequest.model_construct(
+        kind=ForgeOperationKind.ISSUE_LIST,
+        repo_identity="--flag/x",
+        title=None,
+        body=None,
+        issue_number=None,
+        state=None,
+    )
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=bypassed,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "refused"
+    assert outcome.reason == "invalid_repo_identity"
+    assert calls == []  # never reached run_gh, so "--flag/x" never reached an argv
+
+
+@pytest.mark.asyncio
+async def test_a_wellformed_repo_identity_that_bypassed_pydantic_still_reaches_run_gh(tmp_path: Path, monkeypatch):
+    """Positive control: `model_construct` alone is not what gets refused --
+    only a `repo_identity` that fails `REPO_IDENTITY_PATTERN` does."""
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="[]", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    bypassed = ForgeOperationRequest.model_construct(
+        kind=ForgeOperationKind.ISSUE_LIST,
+        repo_identity="owner/repo",
+        title=None,
+        body=None,
+        issue_number=None,
+        state=None,
+    )
+    outcome = await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=bypassed,
+        settings=_settings(),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert outcome.outcome == "succeeded"
+    assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------
+# Settings are threaded through to run_gh untouched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_settings_are_forwarded_to_run_gh(tmp_path: Path, monkeypatch):
+    fake_run_gh, calls = _make_fake_run_gh(GhResult(returncode=0, stdout="[]", stderr=""))
+    monkeypatch.setattr(github, "run_gh", fake_run_gh)
+
+    operation = ForgeOperationRequest(kind=ForgeOperationKind.ISSUE_LIST, repo_identity="owner/repo")
+    await github.run_forge_operation(
+        project_root=tmp_path,
+        operation=operation,
+        settings=_settings(
+            forge_gh_bin="/opt/gh/gh",
+            forge_credential_relative_path=".credentials/other-token",
+            forge_operation_timeout_seconds=12.5,
+        ),
+        task_id="t1",
+        send_log=_collect_logs,
+    )
+
+    assert calls[0]["gh_bin"] == "/opt/gh/gh"
+    assert calls[0]["credential_relative_path"] == ".credentials/other-token"
+    assert calls[0]["timeout_seconds"] == 12.5

--- a/tests/unit/test_forge_github.py
+++ b/tests/unit/test_forge_github.py
@@ -19,6 +19,7 @@ import pytest
 
 from agent.codex_bridge_agent.config import AgentSettings
 from agent.codex_bridge_agent.forge import github
+from agent.codex_bridge_agent.forge.base import MAX_CAPTURED_OUTPUT, ForgeOutcome
 from agent.codex_bridge_agent.forge.gh_tool import GhResult
 from shared.protocol import ForgeOperationKind, ForgeOperationRequest
 
@@ -454,3 +455,34 @@ async def test_settings_are_forwarded_to_run_gh(tmp_path: Path, monkeypatch):
     assert calls[0]["gh_bin"] == "/opt/gh/gh"
     assert calls[0]["credential_relative_path"] == ".credentials/other-token"
     assert calls[0]["timeout_seconds"] == 12.5
+
+
+def test_captured_output_is_bounded_before_it_leaves_the_executor() -> None:
+    """`gh` output is third-party text of unbounded size, and it travels.
+
+    A `ForgeOutcome` crosses the websocket to the gateway and lands in a
+    stored result blob. `DeliveryOutcome`, the precedent this module mirrors,
+    sidesteps the question by carrying structured facts only and never a
+    command's raw output; keeping the output here is a deliberate departure
+    for diagnosability, so the bound is what keeps it honest.
+    """
+    huge = "x" * (MAX_CAPTURED_OUTPUT + 5_000)
+    outcome = ForgeOutcome(attempted=True, outcome="refused", reason="boom", stdout=huge, stderr=huge)
+
+    assert len(outcome.stdout) < len(huge)
+    assert len(outcome.stderr) < len(huge)
+    assert "5000 more characters dropped" in outcome.stdout
+    assert outcome.to_dict()["stderr"].startswith("x" * 100)
+
+
+def test_output_within_the_bound_is_left_exactly_as_gh_produced_it() -> None:
+    """Positive control: the cap must not rewrite ordinary output.
+
+    Without this, a bug that truncated everything to the empty string would
+    still satisfy the test above.
+    """
+    modest = "https://github.com/owner/repo/issues/42\n"
+    outcome = ForgeOutcome(attempted=True, outcome="succeeded", stdout=modest, stderr="")
+
+    assert outcome.stdout == modest
+    assert outcome.stderr == ""

--- a/tests/unit/test_gh_tool.py
+++ b/tests/unit/test_gh_tool.py
@@ -1,0 +1,298 @@
+"""`gh_tool.run_gh`/`resolve_gh_token` against a fake `gh` subprocess.
+
+WK-20260902-forge-github-module, issue #80/#79 (PR B2). No test here ever
+spawns a real `gh` -- `asyncio.create_subprocess_exec` is monkeypatched to a
+`_FakeProcess`, the same shape `tests/unit/test_codex_runner.py` already uses
+for its own fake process (`_FakeTimeoutProcess`). Every negative case is
+paired with a positive control in the same test or its neighbor, per
+`docs/napkin-lessons.md`'s 2026-09-01 lesson: a refusal test that can never
+actually reach the code it claims to guard proves nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from agent.codex_bridge_agent.forge.gh_tool import GH_ENV_ALLOWLIST, resolve_gh_token, run_gh
+
+
+class _FakeProcess:
+    """Stands in for `asyncio.subprocess.Process`. Records nothing itself --
+    the test records the call to `create_subprocess_exec` that produced it.
+    """
+
+    def __init__(self, *, returncode: int = 0, stdout: bytes = b"", stderr: bytes = b"", hang: bool = False) -> None:
+        self.returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._hang = hang
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        if self._hang:
+            await asyncio.sleep(3600)
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return self.returncode
+
+
+def _fake_create_subprocess_exec(process: _FakeProcess, calls: list[dict]):
+    async def fake(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return process
+
+    return fake
+
+
+def _write_regular_credential(project_root: Path, relative_path: str, token: str = "regular-file-token") -> None:
+    path = project_root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token, encoding="utf-8")
+
+
+def _write_symlink_credential_outside_repo(
+    project_root: Path, relative_path: str, external_dir: Path, token: str = "symlinked-token"
+) -> None:
+    external_dir.mkdir(parents=True, exist_ok=True)
+    target = external_dir / "github-token"
+    target.write_text(token, encoding="utf-8")
+    link = project_root / relative_path
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target)
+
+
+# --------------------------------------------------------------------------
+# resolve_gh_token: the credential guard, in isolation
+# --------------------------------------------------------------------------
+
+
+def test_resolve_gh_token_refuses_a_regular_file_inside_the_repo(tmp_path: Path):
+    _write_regular_credential(tmp_path, ".credentials/github-token")
+    token, reason = resolve_gh_token(tmp_path, ".credentials/github-token")
+    assert token is None
+    assert reason == "forge_credential_must_be_symlink_outside_repo"
+
+
+def test_resolve_gh_token_accepts_a_symlink_resolving_outside_the_repo(tmp_path: Path):
+    """Positive control for the test above: same shape, but a symlink whose
+    target actually resolves outside `project_root` is accepted."""
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    _write_symlink_credential_outside_repo(tmp_path, ".credentials/github-token", external, token="secret-abc")
+    token, reason = resolve_gh_token(tmp_path, ".credentials/github-token")
+    assert reason is None
+    assert token == "secret-abc"
+
+
+def test_resolve_gh_token_refuses_a_symlink_whose_target_is_still_inside_the_repo(tmp_path: Path):
+    """A symlink alone is not the guard -- the resolved TARGET must be
+    outside `project_root`. A symlink pointing at another file in the same
+    tree must be refused exactly like a regular file."""
+    real_file = tmp_path / "nested" / "token-file"
+    real_file.parent.mkdir(parents=True, exist_ok=True)
+    real_file.write_text("inside-repo-token", encoding="utf-8")
+    link = tmp_path / ".credentials" / "github-token"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(real_file)
+
+    token, reason = resolve_gh_token(tmp_path, ".credentials/github-token")
+    assert token is None
+    assert reason == "forge_credential_must_be_symlink_outside_repo"
+
+
+def test_resolve_gh_token_refuses_a_missing_credential(tmp_path: Path):
+    token, reason = resolve_gh_token(tmp_path, ".credentials/github-token")
+    assert token is None
+    assert reason == "forge_credential_missing"
+
+
+def test_resolve_gh_token_refuses_a_broken_symlink(tmp_path: Path):
+    link = tmp_path / ".credentials" / "github-token"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(tmp_path.parent / "nowhere" / "does-not-exist")
+    token, reason = resolve_gh_token(tmp_path, ".credentials/github-token")
+    assert token is None
+    assert reason == "forge_credential_target_missing"
+
+
+# --------------------------------------------------------------------------
+# run_gh: the credential guard applied before any subprocess is spawned
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_gh_refuses_a_regular_file_credential_without_spawning_a_process(tmp_path: Path, monkeypatch):
+    _write_regular_credential(tmp_path, ".credentials/github-token")
+    calls: list[dict] = []
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec(_FakeProcess(), calls))
+
+    result = await run_gh(
+        tmp_path,
+        "issue",
+        "list",
+        gh_bin="gh",
+        credential_relative_path=".credentials/github-token",
+        timeout_seconds=5,
+    )
+
+    assert result.refused_reason == "forge_credential_must_be_symlink_outside_repo"
+    assert result.returncode is None
+    assert calls == []  # the fake subprocess was never invoked
+
+
+@pytest.mark.asyncio
+async def test_run_gh_runs_the_process_when_the_credential_is_a_valid_symlink(tmp_path: Path, monkeypatch):
+    """Positive control for the refusal above."""
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    _write_symlink_credential_outside_repo(tmp_path, ".credentials/github-token", external, token="tok-xyz")
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _fake_create_subprocess_exec(_FakeProcess(returncode=0, stdout=b"ok"), calls),
+    )
+
+    result = await run_gh(
+        tmp_path,
+        "issue",
+        "list",
+        gh_bin="gh",
+        credential_relative_path=".credentials/github-token",
+        timeout_seconds=5,
+    )
+
+    assert result.refused_reason is None
+    assert result.ok is True
+    assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------
+# Env custody: GH_TOKEN reaches the subprocess and nothing else does
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_gh_injects_gh_token_and_filters_everything_else(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-never-leak-to-gh")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "should-never-leak-to-gh-either")
+    monkeypatch.setenv("CODEX_HOME", "/should/not/reach/gh")
+
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    _write_symlink_credential_outside_repo(tmp_path, ".credentials/github-token", external, token="the-gh-token")
+    calls: list[dict] = []
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec(_FakeProcess(), calls))
+
+    await run_gh(
+        tmp_path,
+        "issue",
+        "list",
+        gh_bin="gh",
+        credential_relative_path=".credentials/github-token",
+        timeout_seconds=5,
+    )
+
+    assert len(calls) == 1
+    env = calls[0]["kwargs"]["env"]
+    assert env["GH_TOKEN"] == "the-gh-token"
+    assert set(env) <= GH_ENV_ALLOWLIST
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "CODEX_HOME" not in env
+
+
+def test_gh_env_allowlist_is_exactly_home_path_gh_token():
+    assert GH_ENV_ALLOWLIST == frozenset({"HOME", "PATH", "GH_TOKEN"})
+
+
+# --------------------------------------------------------------------------
+# argv shape: no shell, list argv, cwd is project_root
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_gh_calls_create_subprocess_exec_with_a_list_argv_no_shell(tmp_path: Path, monkeypatch):
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    _write_symlink_credential_outside_repo(tmp_path, ".credentials/github-token", external)
+    calls: list[dict] = []
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec(_FakeProcess(), calls))
+
+    await run_gh(
+        tmp_path,
+        "issue",
+        "close",
+        "42",
+        "--repo",
+        "owner/repo",
+        gh_bin="/usr/local/bin/gh",
+        credential_relative_path=".credentials/github-token",
+        timeout_seconds=5,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["args"] == ("/usr/local/bin/gh", "issue", "close", "42", "--repo", "owner/repo")
+    assert calls[0]["kwargs"]["cwd"] == str(tmp_path)
+    assert calls[0]["kwargs"]["stdout"] is asyncio.subprocess.PIPE
+    assert calls[0]["kwargs"]["stderr"] is asyncio.subprocess.PIPE
+
+
+# --------------------------------------------------------------------------
+# Timeout: always passed, and enforced
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_gh_always_passes_the_timeout_to_wait_for(tmp_path: Path, monkeypatch):
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    _write_symlink_credential_outside_repo(tmp_path, ".credentials/github-token", external)
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", _fake_create_subprocess_exec(_FakeProcess(), [])
+    )
+
+    real_wait_for = asyncio.wait_for
+    seen_timeouts: list[float | None] = []
+
+    async def recording_wait_for(awaitable, timeout=None):
+        seen_timeouts.append(timeout)
+        return await real_wait_for(awaitable, timeout=timeout)
+
+    monkeypatch.setattr(asyncio, "wait_for", recording_wait_for)
+
+    await run_gh(
+        tmp_path,
+        "issue",
+        "list",
+        gh_bin="gh",
+        credential_relative_path=".credentials/github-token",
+        timeout_seconds=42.5,
+    )
+
+    assert seen_timeouts == [42.5]
+
+
+@pytest.mark.asyncio
+async def test_run_gh_times_out_and_kills_the_process(tmp_path: Path, monkeypatch):
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    _write_symlink_credential_outside_repo(tmp_path, ".credentials/github-token", external)
+    hanging = _FakeProcess(hang=True)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec(hanging, []))
+
+    result = await run_gh(
+        tmp_path,
+        "issue",
+        "list",
+        gh_bin="gh",
+        credential_relative_path=".credentials/github-token",
+        timeout_seconds=0.05,
+    )
+
+    assert result.returncode == 124
+    assert hanging.killed is True
+    assert hanging.waited is True

--- a/tests/unit/test_git_delivery.py
+++ b/tests/unit/test_git_delivery.py
@@ -112,6 +112,23 @@ def test_ordinary_source_paths_are_not_forbidden():
     assert _is_forbidden_path("docs/README.md") is None
 
 
+def test_forbidden_paths_defend_the_forge_github_token_specifically():
+    """WK-20260902-forge-github-module, issue #80/#79 (PR B2): the forge
+
+    credential this PR added (`AgentSettings.forge_credential_relative_path`,
+    default `.credentials/github-token`) relies on this pre-existing guard --
+    `_is_forbidden_path`'s `.credentials` check, `git_delivery.py:56-80` --
+    to keep the token's resolved bytes from ever reaching a commit even if
+    `gh_tool.run_gh`'s own symlink-outside-repo guard were somehow bypassed.
+    Named here, by the forge feature, so a future "cleanup" of
+    `_is_forbidden_path` does not remove it for looking unused: this test is
+    what proves it is load-bearing for forge, not only for the generic
+    `.credentials/` case `test_forbidden_paths_are_named_by_reason` above
+    already covers.
+    """
+    assert _is_forbidden_path(".credentials/github-token") == "credentials_dir"
+
+
 # --------------------------------------------------------------------------
 # deliver_changes: refusals
 # --------------------------------------------------------------------------

--- a/tests/unit/test_runner_registry.py
+++ b/tests/unit/test_runner_registry.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.forge.gh_tool import GH_ENV_ALLOWLIST
 from agent.codex_bridge_agent.runners.base import EngineNotImplementedError, Runner
 from agent.codex_bridge_agent.runners.codex import CodexRunner
 from agent.codex_bridge_agent.runners.pool import RunnerPool
@@ -41,12 +42,23 @@ def test_no_registered_engines_env_allowlist_overlaps_another():
     F08): a Codex-only credential (`OPENAI_API_KEY`) must never reach a
     different engine's subprocess, and vice versa. Only implemented engines
     have a real allowlist to check.
+
+    WK-20260902-forge-github-module (issue #80/#79, PR B2) extends this to a
+    THIRD allowlist that is not a `Runner` at all:
+    `forge/gh_tool.GH_ENV_ALLOWLIST`, which is where `GH_TOKEN` -- the forge
+    credential -- may legally appear. This is one of the most important
+    tests in that PR: if `GH_TOKEN` (or any future forge-only variable) ever
+    showed up in a runner's `env_allowlist`, it would reach a coding agent's
+    own sandboxed subprocess, defeating the entire point of keeping the
+    forge credential out of that sandbox (`gh_tool.py`'s own module
+    docstring). This test fails the moment that happens.
     """
     allowlists = {
         name: registration.factory(AgentSettings()).capabilities().env_allowlist
         for name, registration in KNOWN_ENGINES.items()
         if registration.implemented and registration.factory is not None
     }
+    allowlists["forge-github"] = GH_ENV_ALLOWLIST
     engine_specific = {
         name: allowlist - {"HOME", "PATH", "LANG", "LC_ALL"}
         for name, allowlist in allowlists.items()
@@ -56,6 +68,20 @@ def test_no_registered_engines_env_allowlist_overlaps_another():
         for right in names[i + 1 :]:
             overlap = engine_specific[left] & engine_specific[right]
             assert not overlap, f"{left} and {right} share engine-specific env vars: {overlap}"
+
+
+def test_gh_token_is_on_the_forge_allowlist_and_nowhere_else():
+    """Positive control, spelled out by name rather than left implicit in the
+
+    set-overlap loop above: `GH_TOKEN` belongs on `GH_ENV_ALLOWLIST`, and no
+    implemented runner's `env_allowlist` may contain it.
+    """
+    assert "GH_TOKEN" in GH_ENV_ALLOWLIST
+    for name, registration in KNOWN_ENGINES.items():
+        if not registration.implemented or registration.factory is None:
+            continue
+        runner_allowlist = registration.factory(AgentSettings()).capabilities().env_allowlist
+        assert "GH_TOKEN" not in runner_allowlist, name
 
 
 def test_unimplemented_engines_are_declared_not_absent():


### PR DESCRIPTION
Issues #80 and #79, stage 2 of the forge work — stacked on #85, review that first. Still **no wiring**: nothing dispatches a forge operation yet, nothing in `service.py` or the gateway calls this. That is the next PR. This one is the module that actually talks to GitHub, testable on its own.

## Shape
`agent/codex_bridge_agent/forge/` as a package mirroring `runners/`: `gh_tool.py` (`run_gh`, the sibling of `git_tools.run_git`), `github.py` (the four operations), `base.py` (`ForgeOutcome`, mirroring `DeliveryOutcome`).

Every property borrowed from `git_delivery.py` is named at its point of use in a `# git_delivery property:` comment, so a reviewer can check each against its original: argv list and no shell, timeout always applied, machine lock off by default, re-validation on the executor of what the gateway sent, pattern-checked identity that cannot reach flag position, post-condition verification instead of trusting exit 0, and no destructive flag anywhere.

## The credential
`<project_root>/.credentials/github-token` is a **symlink** to the real token outside the tree — the convention this repository already practices (`.credentials/google-calendar-sa.json → ~/.config/credentials/…`, `.gitignore:46`). `run_gh` resolves it per operation and injects `GH_TOKEN` into that subprocess's `env=` only.

Two guards, because the file lives inside the tree a coding agent can read:
1. `resolve_gh_token` **refuses** a regular file inside the repository, and refuses a symlink whose resolved target is inside it. The secret's bytes never exist in the tree.
2. `git_delivery._is_forbidden_path` already refuses any path containing `.credentials` when staging — the net against the token becoming a commit predates this PR. `tests/unit/test_git_delivery.py` now names that case as a defense of this feature, so it is not mistaken for dead weight later.

`GH_ENV_ALLOWLIST` is a third allowlist, and `test_no_registered_engines_env_allowlist_overlaps_another` is extended to include it — `GH_TOKEN` appearing on a runner's allowlist is now a test failure (council finding F08).

## Review fix included
`ForgeOutcome` carried `gh`'s stdout/stderr verbatim and unbounded, on every outcome. `DeliveryOutcome` — the precedent — carries structured facts only and never raw command output. That output is third-party text of uncontrolled size that crosses the websocket into a stored result blob. It is kept (a refusal is hard to diagnose without it) but bounded at 2000 characters, in `__post_init__` rather than at twenty construction sites.

## Validation
`pytest -q`: 809 passed, 7 skipped, 0 failed. `tests/contract/`: green. 31 new unit tests against a fake subprocess — never a real `gh`, no network, no authentication. Every refusal has a positive control in the same file.

## Still missing for a forge operation to actually run
Dispatch, persistence and the approval gate (next PR). `issue_comment`/`issue_close` trust `gh`'s exit code alone; only `issue_open` has an output-based post-condition.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw