### PR TITLE
feat(gh-80,gh-79): wire forge operations, with the human gate in front

### DIFF
--- a/agent/codex_bridge_agent/service.py
+++ b/agent/codex_bridge_agent/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import random
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -8,8 +9,11 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 import websockets
+from pydantic import ValidationError
 
 from agent.codex_bridge_agent.config import AgentSettings, load_agent_projects, resolve_auto_project
+from agent.codex_bridge_agent.forge.base import ForgeOutcome
+from agent.codex_bridge_agent.forge.github import run_forge_operation
 from agent.codex_bridge_agent.git_delivery import deliver_changes
 from agent.codex_bridge_agent.instructions import IssueResolutionError, build_task_instruction, resolve_issue_text
 from agent.codex_bridge_agent.runners.base import EngineNotImplementedError
@@ -21,6 +25,7 @@ from shared.protocol import (
     AgentEnvelope,
     AgentMessageType,
     DeliveryRequest,
+    ForgeOperationRequest,
     PolicyLevel,
     SubmitTaskRequest,
     TaskMode,
@@ -28,6 +33,9 @@ from shared.protocol import (
     TaskState,
 )
 from shared.security import ensure_within_root
+
+
+logger = logging.getLogger(__name__)
 
 
 BASE_PROMPT = (
@@ -107,6 +115,8 @@ class AgentService:
                     envelope = AgentEnvelope.model_validate_json(raw)
                     if envelope.type == AgentMessageType.TASK_DISPATCH:
                         asyncio.create_task(self._handle_dispatch(websocket, envelope))
+                    elif envelope.type == AgentMessageType.FORGE_OPERATION:
+                        asyncio.create_task(self._handle_forge_operation(websocket, envelope))
                     elif envelope.type == AgentMessageType.TASK_CANCEL:
                         task_id = envelope.payload["task_id"]
                         await self.runners.cancel(task_id)
@@ -344,6 +354,132 @@ class AgentService:
             await websocket.send(self._envelope(AgentMessageType.TASK_RESULT, result).model_dump_json())
         finally:
             self.runners.forget(task_id)
+
+    async def _handle_forge_operation(self, websocket, envelope: AgentEnvelope) -> None:
+        """Runs one `FORGE_OPERATION` envelope and reports a
+
+        `FORGE_OPERATION_RESULT`. Parallel to `_handle_dispatch` above --
+        same envelope-in/envelope-out shape, same local-allowlist project
+        resolution, same typed-error-never-traceback posture -- and
+        deliberately UNLIKE it in the one place that matters most:
+        `_handle_dispatch` re-derives `evaluate_task_policy` from the
+        envelope and refuses a SENSITIVE task that reads unapproved, as a
+        second opinion against a compromised or buggy gateway. This handler
+        does NOT re-derive `shared.policy.forge_operation_policy_level` the
+        same way, because that function has no bypass field for any write
+        kind, by design (see its own docstring in `shared/policy.py`) --
+        re-deriving it here would refuse every forge write unconditionally
+        regardless of any human decision the gateway already recorded, which
+        would not defend the gate, it would delete the feature. The gate for
+        a forge write lives entirely on the gateway side
+        (`gateway/app/services/store.py`'s `create_forge_operation`/
+        `decide_forge_operation`, and `AgentHub.dispatch_forge_operation`,
+        which never sends this envelope for a row that is not `approved`);
+        this executor trusts that decision, the same way
+        `agent.codex_bridge_agent.forge.github.run_forge_operation`'s own
+        module docstring says it does. What this handler still defends,
+        independently of anything the gateway claims: which project this
+        executor is willing to touch at all (the exact same local allowlist
+        `_handle_dispatch` resolves against -- reused, not reinvented), and
+        the machine-level `allow_forge_operations` kill switch plus the
+        field-level revalidation `run_forge_operation` itself performs
+        (`_revalidate_locally` in `forge/github.py`) -- both independent of
+        whatever the gateway believes it approved.
+        """
+        operation_id = envelope.payload.get("operation_id")
+        project_id = envelope.payload.get("project_id")
+
+        async def send_result(outcome: ForgeOutcome) -> None:
+            await websocket.send(
+                self._envelope(
+                    AgentMessageType.FORGE_OPERATION_RESULT,
+                    {"operation_id": operation_id, **outcome.to_dict()},
+                ).model_dump_json()
+            )
+
+        raw_kind = envelope.payload.get("kind")
+        raw_repo_identity = envelope.payload.get("repo_identity")
+        try:
+            operation = ForgeOperationRequest(
+                kind=raw_kind,
+                repo_identity=raw_repo_identity,
+                title=envelope.payload.get("title"),
+                body=envelope.payload.get("body"),
+                issue_number=envelope.payload.get("issue_number"),
+                state=envelope.payload.get("state"),
+            )
+        except ValidationError as exc:
+            # Never reached `forge.github.run_forge_operation` at all -- a
+            # malformed envelope from a buggy or compromised gateway, not a
+            # forge operation this executor ever tried. `attempted=False`
+            # marks that distinction; every refusal `run_forge_operation`
+            # itself can produce sets `attempted=True` (it was invoked, even
+            # when it refuses immediately -- see `forge/github.py::_refused`).
+            await send_result(
+                ForgeOutcome(
+                    attempted=False,
+                    outcome="refused",
+                    reason="invalid_forge_operation_payload",
+                    kind=raw_kind if isinstance(raw_kind, str) else None,
+                    repo_identity=raw_repo_identity if isinstance(raw_repo_identity, str) else None,
+                )
+            )
+            return
+
+        # Same allowlist resolution `_handle_dispatch` uses above: a forge
+        # operation only ever runs against a project THIS executor is
+        # configured to operate, static allowlist first and the opt-in
+        # `auto_project_root` fallback second. Reused rather than
+        # reimplemented so the two paths cannot drift on what "this
+        # executor's project" means.
+        project = self.projects.get(project_id)
+        if project is None and self.settings.auto_project_root:
+            project = resolve_auto_project(project_id, self.settings.auto_project_root)
+        if project is None:
+            await send_result(
+                ForgeOutcome(
+                    attempted=False,
+                    outcome="refused",
+                    reason="unknown_project",
+                    kind=operation.kind.value,
+                    repo_identity=operation.repo_identity,
+                )
+            )
+            return
+        root = ensure_within_root(project.path, project.path)
+
+        async def send_log(stream: str, line: str) -> None:
+            # No `TASK_LOG` stream for a forge operation: `task_logs.task_id`
+            # is a real foreign key against `tasks` on Postgres, and
+            # `operation_id` names a `forge_operations` row, never a `tasks`
+            # one -- sending it as a `task_id` would either violate that
+            # constraint or silently attach a forge operation's diagnostic
+            # line to an unrelated task. `run_forge_operation`'s gh-argv
+            # diagnostic already reaches the operator through
+            # `ForgeOutcome.stdout`/`stderr` on the final result; this is
+            # local-only, for an operator tailing the executor's own log.
+            logger.debug("forge.log[%s] %s: %s", operation_id, stream, line)
+
+        try:
+            outcome = await run_forge_operation(
+                project_root=Path(root),
+                operation=operation,
+                settings=self.settings,
+                task_id=None,
+                send_log=send_log,
+            )
+        except Exception as exc:
+            # Typed result, never a bare traceback across the wire -- same
+            # posture `_handle_dispatch` takes toward `runner.run_task`
+            # above.
+            outcome = ForgeOutcome(
+                attempted=True,
+                outcome="refused",
+                reason=f"forge_operation_failed:{exc}",
+                kind=operation.kind.value,
+                repo_identity=operation.repo_identity,
+            )
+        await send_result(outcome)
 
     def _envelope(self, message_type: AgentMessageType, payload: dict) -> AgentEnvelope:
         return AgentEnvelope(

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-github-module`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-github-module map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-wiring-and-gate`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-forge-wiring-and-gate map`
 
 ## Summary
 
-- 133 file(s) · 1235 symbol(s) indexed
-- Languages: config (2), python (129), shell (2)
+- 134 file(s) · 1257 symbol(s) indexed
+- Languages: config (2), python (130), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -145,6 +145,7 @@ tests/
     test_decisions.py  — "Operational decisions — issue #6."
     test_dispatch_payload_engine_and_delivery.py  — "`AgentHub.dispatch_next` forwards engine/issue_ref/delivery to the executor."
     test_epics_issues.py  — "Epics and issues — issue #8."
+    test_forge_wiring.py  — "End-to-end wiring for a forge operation -- issue #80/#79,"
     test_mcp_reminders.py  — "The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
     test_oauth_authorize.py  — "The browser OAuth form — the *other* caller of the password check."
@@ -625,6 +626,7 @@ tests/
 - `mcp_endpoint(request, authorization, session)` *(async function)*
 - `handle_task_ack(session, envelope)` *(async function)* — "Handles one `task.ack` from the `/agent/ws` message loop."
 - `handle_task_cancelled(session, envelope)` *(async function)* — "Handles one `task.cancelled` ack from the `/agent/ws` message loop."
+- `handle_forge_operation_result(session, envelope)` *(async function)* — "Handles one `forge.operation_result` from the `/agent/ws` message loop."
 - `agent_ws(websocket, executor_id, token, x_executor_token)` *(async function)*
 
 ### `gateway/app/mcp/server.py`
@@ -651,6 +653,7 @@ tests/
 - **`ConversationMessageModel`** *(class)* — "One message in a conversation. Immutable once written — no update path."
 - **`ConversationReadStateModel`** *(class)* — "How far one actor has read into one conversation."
 - **`TaskLogModel`** *(class)*
+- **`ForgeOperationModel`** *(class)* — "One request to act on an external forge (GitHub today) -- issue #80/#79,"
 - **`AuditEventModel`** *(class)*
 - **`MessageReceiptModel`** *(class)*
 - **`IdempotencyRecordModel`** *(class)* — "A completed write, keyed so an offline retry replays instead of repeating."
@@ -669,6 +672,7 @@ tests/
   - `send(self, executor_id, envelope)` *(async method)*
   - `dispatch_next(self, executor_id)` *(async method)*
   - `dispatch_available(self, executor_id)` *(async method)* — "Dispatches the next queued/waiting task to `executor_id`, if one is"
+  - `dispatch_forge_operation(self, operation_id)` *(async method)* — "Sends one approved forge operation to its executor, if connected."
   - `mark_task_finished(self, executor_id, task_id)` *(async method)* — "Releases the slot `task_id` held and, if the executor is still"
 - `hub_envelope(executor_id, message_type, payload)` — "Build a message for an executor."
 
@@ -745,6 +749,11 @@ tests/
 - `update_task_state(session, task_id, state, error)` *(async function)*
 - `append_log(session, task_id, offset, stream, line)` *(async function)*
 - `decide_task_approval(session, task_id, decision, reason)` *(async function)*
+- `create_forge_operation(session)` *(async function)* — "Creates a forge operation row, gated exactly like `create_task` gates a"
+- `get_forge_operation(session, operation_id)` *(async function)*
+- `decide_forge_operation(session, operation_id, decision, reason)` *(async function)* — "The human decision a forge write is born waiting for. Mirrors"
+- `mark_forge_operation_dispatched(session, operation_id)` *(async function)* — "Flips an `approved` forge operation to `dispatched`. The gate itself:"
+- `resolve_forge_operation(session, operation_id, outcome)` *(async function)* — "Resolves a forge operation from its `FORGE_OPERATION_RESULT` outcome"
 - `recover_tasks_after_startup(session)` *(async function)*
 - `get_logs(session, task_id, offset, limit)` *(async function)*
 - `store_result(session, task_id, result, final_state)` *(async function)*
@@ -1228,6 +1237,20 @@ tests/
 - `test_the_epic_list_cursor_walks_every_epic_once(api)` *(async function)*
 - `test_list_epics_filters_by_status(api)` *(async function)*
 
+### `tests/integration/test_forge_wiring.py`
+
+> End-to-end wiring for a forge operation -- issue #80/#79,
+
+- `db()` *(async function)* — "A real database and session factory, seeded with one executor/project"
+- `test_forge_write_is_born_awaiting_approval(db)` *(async function)*
+- `test_dispatch_refuses_a_write_still_awaiting_approval(db)` *(async function)* — "THE required test: a forge write cannot be dispatched without passing"
+- `test_rejected_forge_operation_never_dispatches(db)` *(async function)* — "A human `REJECTED` decision is just as terminal as never deciding at"
+- `test_issue_list_read_does_not_stop_at_the_gate(db)` *(async function)* — "Positive control for the two refusals above, and for issue #80/#79's"
+- `test_create_forge_operation_refuses_a_project_not_allowed_for_the_executor(db)` *(async function)* — "The gateway's OWN allowlist check (`executors.metadata_json`), separate"
+- `test_full_pipeline_write_completes_after_a_human_approves(db, tmp_path, monkeypatch)` *(async function)*
+- `test_executor_kill_switch_refuses_even_after_gateway_approval(db, tmp_path, monkeypatch)` *(async function)* — "The two locks are independent: a gateway approval is not, by itself,"
+- `test_project_outside_executor_local_allowlist_refuses_even_after_gateway_approval(db, tmp_path, monkeypatch)` *(async function)* — "The executor's own project allowlist is the second independent gate:"
+
 ### `tests/integration/test_mcp_reminders.py`
 
 > The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer.
@@ -1591,6 +1614,11 @@ tests/
 - `test_handle_dispatch_sends_read_only_for_a_read_mode_task(tmp_path)` *(async function)*
 - `test_handle_dispatch_sends_workspace_write_for_a_write_mode_task(tmp_path)` *(async function)*
 - `test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_path)` *(async function)* — "A write-mode task still only gets `read-only` when this executor's own"
+- `test_forge_operation_runs_when_allowed_and_project_is_known(tmp_path, monkeypatch)` *(async function)* — "Positive control for every refusal test below: with the kill switch on"
+- `test_forge_operation_refuses_when_executor_kill_switch_is_off(tmp_path, monkeypatch)` *(async function)* — "The machine-level trava: off by default, and independent of anything"
+- `test_forge_operation_refuses_for_a_project_outside_the_local_allowlist(tmp_path, monkeypatch)` *(async function)* — "The executor's own project allowlist is a second, independent gate --"
+- `test_forge_operation_refuses_an_invalid_payload_without_touching_gh(tmp_path, monkeypatch)` *(async function)* — "A malformed envelope (unknown `kind`) is refused at parse time, the"
+- `test_forge_operation_write_kind_reaches_gh_when_approved_and_allowed(tmp_path, monkeypatch)` *(async function)* — "Positive control proving a WRITE kind (not just the read-only"
 
 ### `tests/unit/test_apply_migrations.py`
 

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1314,3 +1314,40 @@ falha, e nao por sorte.
 Adendo do mesmo teste: `sandbox_workspace_write.network_access=true` liga a rede
 dentro do sandbox com uma unica flag por invocacao. A facilidade e o argumento
 *contra* usar esse caminho, nao a favor (issue #80).
+
+## 2026-09-02 — um portão de aprovação parecido não é o mesmo portão
+
+A #6 já tinha uma máquina de decisões inteira (`TaskModel.approval_state`,
+`store.decide_task_approval`, `/api/v1/decisions`) quando a #80/#79 precisou
+de um segundo portão humano, desta vez para uma escrita de forge. À primeira
+vista os dois parecem o mesmo problema — "uma ação SENSITIVE nasce esperando
+um humano" — e a tentação natural é reusar a máquina que já existe.
+
+Ela não reusa de graça. `TaskModel` tem `mode`, `instruction`, `engine`,
+`timeout_seconds`, `session_id`, `delivery_json` — todas colunas que
+descrevem uma sessão de agente de código dentro de um sandbox. Uma operação
+de forge não tem nenhuma dessas propriedades: é `kind` + `repo_identity` +
+alguns campos opcionais, roda fora de qualquer sandbox como uma chamada `gh`
+limitada. Pior: `shared.policy.forge_operation_policy_level` é deliberada
+("read the whole module before adding anything near this function") em não
+ter *nenhum* campo de bypass — e `decide_task_approval`'s dispatch reuse
+(`hub.dispatch_available`) manda `task.dispatch`, não `forge.operation`, pra
+um `RunnerPool` que não sabe nada sobre forge. Forçar os dois no mesmo
+caminho exigiria um discriminador `kind` em `tasks`, colunas nulas para todo
+campo que só um lado usa, e um branch em quase toda função de `store.py` que
+toca `TaskModel` — mais acoplamento do que a tabela paralela que ficou
+escolhida (`forge_operations`, `migrations/0012_forge_operations.sql`).
+
+O que valeu a pena reusar não foi o mecanismo, foi o vocabulário:
+`ApprovalDecision` (`approved`/`rejected`/`revision_requested`) e a forma
+"nasce esperando, um humano decide, uma função separada despacha depois" —
+para que um operador que já aprovou uma task antes reconheça a forma aqui,
+mesmo com a tabela sendo outra.
+
+Lição: "parece o mesmo problema" não é o teste certo para decidir se dois
+mecanismos de aprovação devem compartilhar uma tabela. O teste é se os
+CAMPOS do mecanismo existente descrevem o novo caso sem sentinela e sem
+branch condicional em quem já lê essas colunas. Quando não descrevem,
+duplicar honestamente — reusando só o vocabulário que o operador precisa
+reconhecer — é mais barato de manter do que uma coluna emprestada que dois
+domínios brigam para interpretar.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -94,6 +94,8 @@ Mensagens (`AgentMessageType` em `shared/protocol.py`):
 * `task.resume`
 * `task.restart`
 * `task.cancelled`
+* `forge.operation`
+* `forge.operation_result`
 * `error`
 
 Não existe mensagem `task.progress`. O progresso é inferido pelo fluxo de
@@ -162,3 +164,73 @@ compatibilidade com agentes antigos): quando `known` é `false`, o gateway
 resolve a tarefa como `cancelled` e libera a vaga de concorrência, em vez de
 reverter para o estado que o controle assumia (que pressupõe um processo
 vivo em algum lugar, e não há nenhum).
+
+## Operações de forge e o portão humano
+
+Issue #80/#79, `WK-20260902-forge-wiring-and-gate` (PR B3). Uma operação de
+forge (abrir/comentar/fechar/listar issue no GitHub via `gh`) não é uma
+`task.dispatch`: ela roda fora do sandbox do provedor de codificação, como um
+único processo `gh` limitado no próprio executor, e carrega uma credencial
+(`GH_TOKEN`) que nunca entra no sandbox de uma sessão de codificação. Por
+isso tem envelope próprio (`forge.operation`/`forge.operation_result`) em vez
+de virar mais um modo de `task.dispatch` — os dois campos que
+`_sandbox_for`/`RunnerPool` entendem (`mode`, `engine`) não descrevem nada
+sobre uma operação de forge, e forçar um valor sentinela neles ensinaria
+esses módulos a tratar um caso que não é deles.
+
+Persistência é uma tabela própria no gateway, `forge_operations`
+(`migrations/0012_forge_operations.sql`), **não** uma linha em `tasks`: as
+colunas de `tasks` (`mode`, `instruction`, `engine`, `timeout_seconds`,
+`session_id`, `delivery_json`) descrevem uma sessão de agente de código, e
+`shared.policy.forge_operation_policy_level` é explícita que a classificação
+`SENSITIVE` de uma escrita de forge não tem — e nunca deve ter — um campo de
+bypass, ao contrário de `delivery_json`'s push (`push_is_preauthorized`).
+Ver a docstring de `ForgeOperationModel`
+(`gateway/app/models/entities.py`) e o corpo do commit desta PR para a
+justificativa completa dessa decisão, incluindo por que ela não reusa a
+superfície `/api/v1/decisions` da issue #6.
+
+Ciclo de vida de uma linha `forge_operations.state`:
+
+1. `awaiting_approval` — nasce assim toda ESCRITA (`issue_open`,
+   `issue_comment`, `issue_close`): `forge_operation_policy_level` devolveu
+   `SENSITIVE`. `issue_list` (leitura) nasce direto em `approved` — nunca
+   passa pelo portão.
+2. `approved` — um humano decidiu (`store.decide_forge_operation`, mesmo
+   vocabulário `ApprovalDecision` da issue #6: `approved`/`rejected`/
+   `revision_requested`), ou a operação era `issue_list`.
+3. `dispatched` — `AgentHub.dispatch_forge_operation` enviou o envelope
+   `forge.operation` para o executor. Esta função É o portão do lado do
+   gateway: recusa (levanta `ValueError`) para qualquer estado que não seja
+   `approved`, antes de tocar em `self.connections` ou enviar qualquer
+   coisa — não existe caminho por onde um `forge.operation` sai do gateway
+   para uma linha ainda `awaiting_approval`.
+4. `completed`/`failed` — um `forge.operation_result` voltou
+   (`gateway/app/main.py:handle_forge_operation_result`, que chama
+   `store.resolve_forge_operation`).
+
+Ou termina sem nunca despachar: `rejected`/`revision_requested`, uma decisão
+humana negativa — este protocolo não tem mensagem que reabra uma operação de
+forge para edição, a mesma lacuna que `routes/decisions.py` já documenta
+para `TaskModel`.
+
+O executor (`AgentService._handle_forge_operation`,
+`agent/codex_bridge_agent/service.py`) **não** re-deriva
+`forge_operation_policy_level` a partir do envelope, ao contrário do que
+`_handle_dispatch` faz com `evaluate_task_policy` para uma task. A diferença
+é deliberada: como a política de forge não tem campo de bypass, re-derivá-la
+no executor recusaria toda escrita incondicionalmente, mesmo depois de uma
+aprovação humana real — apagaria a funcionalidade em vez de defendê-la. O
+executor confia que o gateway só manda `forge.operation` para uma linha
+`approved`, e defende, de forma independente, só o que um gateway
+comprometido ou com bug ainda poderia mentir: o projeto está na allowlist
+local deste executor (a mesma resolução de `_handle_dispatch`, reaproveitada)
+e a trava de máquina `allow_forge_operations` (default `False`) — as duas
+travas são independentes; ambas precisam estar ligadas para `gh` rodar de
+verdade.
+
+Nesta PR (B3) o único jeito de criar/aprovar/despachar uma operação de forge
+é chamando `store.create_forge_operation`/`store.decide_forge_operation`/
+`AgentHub.dispatch_forge_operation` diretamente — não existe rota REST nem
+ferramenta MCP ainda (por isso o contrato OpenAPI não muda nesta PR). Expor
+isso para o operador via ChatGPT é B4.

--- a/gateway/app/db/schema_guard.py
+++ b/gateway/app/db/schema_guard.py
@@ -52,6 +52,8 @@ REQUIRED_TABLES: dict[str, str] = {
     "scm_associations": "0009_control_plane.sql",
     "project_authorizations": "0009_control_plane.sql",
     "discovered_resources": "0009_control_plane.sql",
+    # Issue #80/#79's human approval gate for a forge write.
+    "forge_operations": "0012_forge_operations.sql",
 }
 
 REQUIRED_COLUMNS: dict[str, dict[str, str]] = {

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -720,6 +720,48 @@ async def handle_task_cancelled(session: AsyncSession, envelope: AgentEnvelope) 
     await hub.mark_task_finished(envelope.executor_id, task_id)
 
 
+async def handle_forge_operation_result(session: AsyncSession, envelope: AgentEnvelope) -> None:
+    """Handles one `forge.operation_result` from the `/agent/ws` message loop.
+
+    Issue #80/#79, WK-20260902-forge-wiring-and-gate (PR B3). Standalone for
+    the same reason `handle_task_ack`/`handle_task_cancelled` are: directly
+    testable against a real session and a constructed envelope, without
+    driving a real websocket through it. There is no ownership check to
+    mirror `handle_task_ack`'s ("an executor may only ack tasks assigned to
+    it") because `store.resolve_forge_operation` does not branch on
+    `executor_id` at all -- a forge operation, unlike a task, never changes
+    which executor holds it, so there is nothing here for a forged
+    `operation_id` to redirect. A missing or unknown `operation_id` raises
+    `ValueError` from `store.resolve_forge_operation` and is logged rather
+    than crashing the message loop, the same posture
+    `handle_task_ack` takes toward a malformed payload.
+    """
+    operation_id = envelope.payload.get("operation_id")
+    if operation_id is None:
+        logging.getLogger(__name__).warning(
+            "forge.operation_result with no operation_id from executor %s", envelope.executor_id
+        )
+        return
+    try:
+        await store.resolve_forge_operation(session, operation_id, envelope.payload)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "forge.operation_result for unknown operation %s from executor %s",
+            operation_id,
+            envelope.executor_id,
+        )
+        await session.rollback()
+        return
+    await record_event(
+        session,
+        "forge_operation",
+        operation_id,
+        "forge_operation.result_received",
+        {"executor_id": envelope.executor_id, "outcome": envelope.payload.get("outcome")},
+    )
+    await session.commit()
+
+
 @app.websocket("/agent/ws")
 async def agent_ws(
     websocket: WebSocket,
@@ -810,5 +852,7 @@ async def agent_ws(
                     await notify_task_finished(session, task, settings)
                 elif envelope.type == AgentMessageType.TASK_CANCELLED:
                     await handle_task_cancelled(session, envelope)
+                elif envelope.type == AgentMessageType.FORGE_OPERATION_RESULT:
+                    await handle_forge_operation_result(session, envelope)
     except WebSocketDisconnect:
         await hub.unregister(executor_id)

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -380,6 +380,75 @@ class TaskLogModel(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
 
+class ForgeOperationModel(Base):
+    """One request to act on an external forge (GitHub today) -- issue #80/#79,
+    WK-20260902-forge-wiring-and-gate (PR B3).
+
+    Deliberately its OWN table, not a `TaskModel` row, even though the two
+    look similar at a glance (both name a project/executor, both can sit
+    `awaiting_approval`, both resolve to a stored result). `TaskModel`'s
+    columns -- `mode`, `instruction`, `engine`, `timeout_seconds`,
+    `session_id`, `delivery_json` -- all encode one specific thing: a
+    coding-agent session running inside a sandbox on the executor. A forge
+    operation has none of that shape: it is `kind` + `repo_identity` + a
+    handful of optional fields, it runs OUTSIDE any sandbox as one bounded
+    `gh` subprocess call, and `shared.policy.forge_operation_policy_level`'s
+    own docstring is explicit that a forge write's `SENSITIVE` classification
+    has no bypass field, structurally, unlike `TaskModel`'s
+    `push_is_preauthorized`. Reusing `TaskModel` would mean inventing sentinel
+    `TaskMode`/`engine` values nothing else in this codebase understands, or
+    teaching `AgentHub.dispatch_next`/`RunnerPool` to special-case a `kind` no
+    coding session has -- a worse coupling than the small parallel table this
+    is. See `docs/protocol.md` and this migration's own commit message for
+    the fuller writeup of that decision.
+
+    What IS reused, deliberately, is the *vocabulary*: `state` values below
+    read like `TaskState` (`awaiting_approval`, `approved`, `dispatched`,
+    `completed`, `failed`) plus the two rejection outcomes
+    `shared.protocol.ApprovalDecision` already names (`rejected`,
+    `revision_requested`) -- an operator who has approved/rejected a task
+    decision before sees the same shape here, never a third semantics to
+    learn. `TaskState` itself is not imported: no forge operation is ever
+    `QUEUED`/`RUNNING`/`PAUSED`/etc, so importing it would invite a branch on
+    a value that can never occur here.
+
+    Lifecycle: a row is born `awaiting_approval` (a write --
+    `shared.policy.forge_operation_policy_level` returned `SENSITIVE`) or
+    `approved` (a read, i.e. `issue_list` -- never gated at all) ->
+    `approved` (a human decided, via `store.decide_forge_operation`) ->
+    `dispatched` (the `FORGE_OPERATION` envelope left the gateway, via
+    `AgentHub.dispatch_forge_operation`) -> `completed`/`failed` (a
+    `FORGE_OPERATION_RESULT` came back). Or terminal without ever
+    dispatching: `rejected`/`revision_requested`, set once by
+    `decide_task_approval`'s forge sibling and never revisited -- this
+    protocol has no message that reopens a forge operation, the same gap
+    `routes/decisions.py` documents for `TaskModel`.
+    """
+
+    __tablename__ = "forge_operations"
+
+    id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    project_id: Mapped[str] = mapped_column(String(128), ForeignKey("projects.id"))
+    executor_id: Mapped[str] = mapped_column(String(128), ForeignKey("executors.id"))
+    kind: Mapped[str] = mapped_column(String(32))
+    repo_identity: Mapped[str] = mapped_column(String(200))
+    # The full `ForgeOperationRequest`, serialized -- `title`/`body`/
+    # `issue_number`/`state` all live here rather than as their own columns,
+    # the same "one JSON blob, not five nullable columns" choice
+    # `TaskModel.delivery_json` already makes for `DeliveryRequest`.
+    payload_json: Mapped[str] = mapped_column(Text, default="{}")
+    state: Mapped[str] = mapped_column(String(32))
+    # `ForgeOutcome.to_dict()`, once a `FORGE_OPERATION_RESULT` resolves this
+    # row. Null until then -- same "what happened, not what was asked"
+    # split `TaskModel.result_json` already has against `payload_json` above.
+    result_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    requested_by_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    requested_by_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    approval_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class AuditEventModel(Base):
     __tablename__ = "audit_events"
 

--- a/gateway/app/services/agent_hub.py
+++ b/gateway/app/services/agent_hub.py
@@ -161,6 +161,47 @@ class AgentHub:
                 hub_envelope(executor_id, AgentMessageType.TASK_DISPATCH.value, dispatch_payload),
             )
 
+    async def dispatch_forge_operation(self, operation_id: str) -> bool:
+        """Sends one approved forge operation to its executor, if connected.
+
+        Issue #80/#79, WK-20260902-forge-wiring-and-gate (PR B3). This IS the
+        gate on the gateway side: it reads the row's `state` and refuses --
+        raising, never silently no-op'ing -- unless it already reads
+        `"approved"` (`store.decide_forge_operation` is the only thing that
+        ever puts it there for a write; `store.create_forge_operation` does
+        for a read). A caller cannot get an envelope sent for a row still
+        `awaiting_approval` by any path through this method, which is the
+        property `tests/integration/test_forge_wiring.py` exercises directly
+        against this function -- not just against
+        `shared.policy.forge_operation_policy_level` in isolation -- because
+        that pure function has no bypass field to begin with; the real risk
+        is a bypass added HERE, or to
+        `agent.codex_bridge_agent.service.AgentService._handle_forge_operation`,
+        later.
+
+        Connectivity is checked BEFORE `store.mark_forge_operation_dispatched`
+        runs, the same ordering `dispatch_next` already uses for a task: a
+        row must never read `dispatched` when no envelope actually left this
+        process.
+        """
+        async with self.session_factory() as session:
+            row = await store.get_forge_operation(session, operation_id)
+            if row is None:
+                raise ValueError("unknown_forge_operation")
+            if row.state != "approved":
+                raise ValueError("forge_operation_not_approved")
+            if row.executor_id not in self.connections:
+                return False
+            row = await store.mark_forge_operation_dispatched(session, operation_id)
+        payload = json.loads(row.payload_json)
+        payload["operation_id"] = row.id
+        payload["project_id"] = row.project_id
+        await self.send(
+            row.executor_id,
+            hub_envelope(row.executor_id, AgentMessageType.FORGE_OPERATION.value, payload),
+        )
+        return True
+
     async def mark_task_finished(self, executor_id: str, task_id: str) -> None:
         """Releases the slot `task_id` held and, if the executor is still
         connected, immediately dispatches whatever is next in its queue.

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -15,6 +15,7 @@ from gateway.app.models.entities import (
     ConversationReadStateModel,
     EpicModel,
     ExecutorModel,
+    ForgeOperationModel,
     IssueModel,
     MessageReceiptModel,
     OAuthAccessTokenModel,
@@ -40,12 +41,13 @@ from gateway.app.services.issue_types import (
     ISSUE_STATUSES,
     IssuePlanningError,
 )
-from shared.policy import evaluate_task_policy
+from shared.policy import evaluate_task_policy, forge_operation_policy_level
 from shared.protocol import (
     ApprovalDecision,
     DEFAULT_CANCEL_REPLAY_MAX_AGE_SECONDS,
     DEFAULT_CONTROL_REPLAY_MAX_AGE_SECONDS,
     ExecutorRegistration,
+    ForgeOperationRequest,
     PolicyLevel,
     ProjectRegistration,
     STOPPABLE_TASK_STATES,
@@ -572,6 +574,202 @@ async def decide_task_approval(
     await session.commit()
     await session.refresh(task)
     return task
+
+
+# --------------------------------------------------------------------------
+# Forge operations -- issue #80/#79, WK-20260902-forge-wiring-and-gate (PR B3)
+#
+# A deliberately SEPARATE approval path from `create_task`/`decide_task_approval`
+# above, not a reuse of them. See `gateway/app/models/entities.py::ForgeOperationModel`'s
+# docstring for the reasoning against folding this into `TaskModel`, and this
+# work's own commit message for the fuller writeup. What IS shared with the
+# task path: the vocabulary (`ApprovalDecision`, the same "awaiting_approval
+# born SENSITIVE, resolved by a human" shape `create_task`/`decide_task_approval`
+# already established for issue #6) -- an operator who has approved or rejected
+# a task decision before sees the same shape here, never a third semantics.
+#
+# `shared.policy.forge_operation_policy_level` is the other half of the gate
+# these two functions enforce: it returns SENSITIVE for every write kind,
+# unconditionally, with no field anywhere that can change that -- so
+# `create_forge_operation` below has no equivalent of `create_task`'s
+# `push_preauthorized`/`can_approve_push` branch, on purpose. A forge write
+# ALWAYS starts `awaiting_approval`; the only way out is a real human
+# decision through `decide_forge_operation`.
+# --------------------------------------------------------------------------
+
+FORGE_OPERATION_DECIDABLE_STATE = "awaiting_approval"
+
+# `ApprovalDecision` value -> the `forge_operations.state` it resolves to.
+# `REVISION_REQUESTED` gets its own terminal value rather than collapsing
+# into `rejected`, the same distinction `ApprovalDecision`'s own docstring
+# draws for `TaskModel` ("tell an operator 'send this back for changes' apart
+# from 'this will not run'") -- even though, like there, this protocol has no
+# message that reopens a forge operation for editing, so both still just stop.
+_FORGE_DECISION_TO_STATE: dict[ApprovalDecision, str] = {
+    ApprovalDecision.APPROVED: "approved",
+    ApprovalDecision.REJECTED: "rejected",
+    ApprovalDecision.REVISION_REQUESTED: "revision_requested",
+}
+
+
+async def create_forge_operation(
+    session: AsyncSession,
+    *,
+    executor_id: str,
+    project_id: str,
+    operation: ForgeOperationRequest,
+    requested_by_user_id: str | None = None,
+    requested_by_email: str | None = None,
+) -> ForgeOperationModel:
+    """Creates a forge operation row, gated exactly like `create_task` gates a
+
+    sensitive task -- same checks, same audit shape, different table. A write
+    (`forge_operation_policy_level(operation.kind) is SENSITIVE`) is born
+    `awaiting_approval`; a read (`issue_list`) is born `approved` -- ready to
+    dispatch immediately, because `shared.policy.forge_operation_policy_level`
+    never gates it at all.
+    """
+    executor = await session.get(ExecutorModel, executor_id)
+    if executor is None or not executor.enabled:
+        raise ValueError("unknown_or_disabled_executor")
+    project = await session.get(ProjectModel, project_id)
+    if project is None or not project.enabled:
+        raise ValueError("unknown_or_disabled_project")
+    executor_metadata = json.loads(executor.metadata_json)
+    if project_id not in executor_metadata.get("allowed_projects", []):
+        raise ValueError("project_not_allowed_for_executor")
+
+    level = forge_operation_policy_level(operation.kind)
+    state = FORGE_OPERATION_DECIDABLE_STATE if level == PolicyLevel.SENSITIVE else "approved"
+
+    row = ForgeOperationModel(
+        id=str(uuid4()),
+        project_id=project_id,
+        executor_id=executor_id,
+        kind=operation.kind.value,
+        repo_identity=operation.repo_identity,
+        payload_json=operation.model_dump_json(),
+        state=state,
+        requested_by_user_id=requested_by_user_id,
+        requested_by_email=requested_by_email,
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(row)
+    await record_event(
+        session,
+        "forge_operation",
+        row.id,
+        "forge_operation.created",
+        {
+            "state": row.state,
+            "policy_level": level.value,
+            "kind": row.kind,
+            "repo_identity": row.repo_identity,
+            "requested_by_user_id": requested_by_user_id,
+            "requested_by_email": requested_by_email,
+        },
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def get_forge_operation(session: AsyncSession, operation_id: str) -> ForgeOperationModel | None:
+    return await session.get(ForgeOperationModel, operation_id)
+
+
+async def decide_forge_operation(
+    session: AsyncSession,
+    operation_id: str,
+    decision: ApprovalDecision,
+    reason: str | None = None,
+) -> ForgeOperationModel:
+    """The human decision a forge write is born waiting for. Mirrors
+
+    `decide_task_approval`'s shape (same precondition, same audit event
+    style) without sharing its table or its dispatch side effect: approving
+    here only flips `state` to `approved` -- it is `AgentHub.dispatch_forge_operation`,
+    called separately, that actually sends the `FORGE_OPERATION` envelope,
+    the same separation `decide_task_approval`/`hub.dispatch_available` have
+    for tasks (`gateway/app/api/routes/decisions.py:_resolve` is what glues
+    them there; nothing in this PR adds that glue at the route level -- see
+    this work's own commit message).
+    """
+    row = await session.get(ForgeOperationModel, operation_id)
+    if row is None:
+        raise ValueError("unknown_forge_operation")
+    if row.state != FORGE_OPERATION_DECIDABLE_STATE:
+        raise ValueError("forge_operation_not_awaiting_approval")
+    row.approval_reason = reason
+    row.state = _FORGE_DECISION_TO_STATE[decision]
+    if row.state != "approved":
+        row.resolved_at = datetime.now(timezone.utc)
+    await record_event(
+        session,
+        "forge_operation",
+        row.id,
+        "forge_operation.approval_decision",
+        {"decision": decision.value, "reason": reason, "state": row.state},
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def mark_forge_operation_dispatched(session: AsyncSession, operation_id: str) -> ForgeOperationModel:
+    """Flips an `approved` forge operation to `dispatched`. The gate itself:
+
+    raises rather than flipping a row that is not `approved`, so a caller
+    cannot send a `FORGE_OPERATION` envelope by construction unless a human
+    (or, for a read, nobody -- see `create_forge_operation`) already put this
+    row in the one state that means "safe to run". Called by
+    `AgentHub.dispatch_forge_operation` AFTER it has already confirmed the
+    executor is connected -- so a row never reads `dispatched` while no
+    envelope was actually sent.
+    """
+    row = await session.get(ForgeOperationModel, operation_id)
+    if row is None:
+        raise ValueError("unknown_forge_operation")
+    if row.state != "approved":
+        raise ValueError("forge_operation_not_approved")
+    row.state = "dispatched"
+    await record_event(
+        session,
+        "forge_operation",
+        row.id,
+        "forge_operation.dispatched",
+        {"executor_id": row.executor_id},
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def resolve_forge_operation(session: AsyncSession, operation_id: str, outcome: dict) -> ForgeOperationModel:
+    """Resolves a forge operation from its `FORGE_OPERATION_RESULT` outcome
+
+    (`agent.codex_bridge_agent.forge.base.ForgeOutcome.to_dict()`). `state`
+    becomes `completed` when the executor reports `outcome == "succeeded"`,
+    `failed` for `"refused"`/`"skipped"`/anything else -- the same two-way
+    split `store_result` draws for a task's `final_state`, just against the
+    forge vocabulary instead of `TaskState`.
+    """
+    row = await session.get(ForgeOperationModel, operation_id)
+    if row is None:
+        raise ValueError("unknown_forge_operation")
+    row.result_json = json.dumps(outcome, ensure_ascii=True)
+    row.state = "completed" if outcome.get("outcome") == "succeeded" else "failed"
+    row.resolved_at = datetime.now(timezone.utc)
+    await record_event(
+        session,
+        "forge_operation",
+        row.id,
+        "forge_operation.result",
+        {"state": row.state, "outcome": outcome.get("outcome"), "reason": outcome.get("reason")},
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
 
 
 async def recover_tasks_after_startup(session: AsyncSession) -> dict[str, int]:

--- a/migrations/0012_forge_operations.sql
+++ b/migrations/0012_forge_operations.sql
@@ -1,0 +1,56 @@
+-- WK-20260902-forge-wiring-and-gate / issue #80, #79 (PR B3)
+--
+-- Persistence for one forge operation (open/comment/close/list an issue on
+-- GitHub via `gh`) and the human approval gate a forge WRITE must clear
+-- before it is ever dispatched to an executor. `0010`/`0011` are reserved for
+-- other tracks of this orchestration -- this migration is `0012` by explicit
+-- instruction, not the next free number.
+--
+-- `forge_operations` is deliberately its OWN table, not a column added to
+-- `tasks`. See `gateway/app/models/entities.py::ForgeOperationModel`'s own
+-- docstring for the full reasoning; the short version is that `tasks`'
+-- columns (`mode`, `instruction`, `engine`, `timeout_seconds`, `session_id`,
+-- `delivery_json`) all encode a coding-agent session, which a forge
+-- operation is not, and `shared.policy.forge_operation_policy_level` is
+-- explicit that a forge write's SENSITIVE classification has no bypass
+-- field the way `tasks.delivery_json`'s push pre-authorization does --
+-- forcing the two into one table would need one of them to grow an escape
+-- hatch that must never exist.
+--
+-- Portability: plain `create table`/`create index`, `varchar`, `text`,
+-- `timestamptz`, no `alter table` on an existing table -- follows 0009's
+-- own style (itself following 0005/0008), valid on SQLite and PostgreSQL.
+--
+-- Apply with `python3 scripts/apply_migrations.py`.
+
+create table if not exists forge_operations (
+  id varchar(128) primary key,
+  project_id varchar(128) not null references projects(id),
+  executor_id varchar(128) not null references executors(id),
+  -- `shared.protocol.ForgeOperationKind` value: issue_open/issue_comment/
+  -- issue_list/issue_close. Not a foreign key or a check constraint --
+  -- the enum is the single source of truth (shared/protocol.py), the same
+  -- posture `tasks.mode`/`tasks.engine` already take toward their own enums.
+  kind varchar(32) not null,
+  repo_identity varchar(200) not null,
+  -- The full `ForgeOperationRequest`, serialized -- title/body/issue_number/
+  -- state live here rather than as their own nullable columns, the same
+  -- choice `tasks.delivery_json` already makes for `DeliveryRequest`.
+  payload_json text not null default '{}',
+  -- awaiting_approval | approved | dispatched | completed | failed |
+  -- rejected | revision_requested. See ForgeOperationModel's docstring for
+  -- the full lifecycle; not a check constraint for the same reason `tasks.state`
+  -- has none -- `shared/protocol.py`/application code is the source of truth.
+  state varchar(32) not null,
+  -- `ForgeOutcome.to_dict()`, once a FORGE_OPERATION_RESULT resolves this row.
+  result_json text null,
+  requested_by_user_id varchar(255) null,
+  requested_by_email varchar(255) null,
+  approval_reason text null,
+  created_at timestamptz not null,
+  resolved_at timestamptz null
+);
+
+create index if not exists forge_operations_project_idx on forge_operations (project_id);
+create index if not exists forge_operations_executor_idx on forge_operations (executor_id);
+create index if not exists forge_operations_state_idx on forge_operations (state);

--- a/tests/integration/test_forge_wiring.py
+++ b/tests/integration/test_forge_wiring.py
@@ -1,0 +1,396 @@
+"""End-to-end wiring for a forge operation -- issue #80/#79,
+
+WK-20260902-forge-wiring-and-gate (PR B3). Everything B1
+(`shared/protocol.py`, `shared/policy.py`) and B2
+(`agent/codex_bridge_agent/forge/`) shipped sat unconnected until this PR: no
+module called `run_forge_operation`, nothing built a `FORGE_OPERATION`
+envelope, and no table recorded a forge request at all. This suite proves the
+full internal path works, end to end, without any of it going through a real
+websocket or a real `gh`:
+
+    store.create_forge_operation   -- born awaiting_approval (a write) or
+                                       approved (a read, issue_list)
+    hub.dispatch_forge_operation   -- THE gate: refuses, structurally, unless
+                                       state == "approved"
+    store.decide_forge_operation   -- the human decision a write waits for
+    AgentService._handle_forge_operation -- the real executor handler (not
+                                       just forge.github.run_forge_operation
+                                       in isolation), run against a fake `gh`
+    main.handle_forge_operation_result -- resolves the row from what the
+                                       executor actually reported
+
+Every test that calls `hub.dispatch_forge_operation` calls the REAL function,
+never `shared.policy.forge_operation_policy_level` in isolation (that has its
+own exhaustive suite, `tests/unit/test_forge_policy.py`) -- the risk this
+suite defends against is a bypass added to the real dispatch/decide/handler
+code later, not a regression in the pure policy function, which has no
+bypass field to begin with (docs/napkin-lessons.md, 2026-09-01: "a narrow
+test on a pure function stays green while the real path grows a bypass").
+Every refusal is paired with a positive control in this same file.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.forge import github as forge_github
+from agent.codex_bridge_agent.forge.gh_tool import GhResult
+from agent.codex_bridge_agent.service import AgentService
+from gateway.app.db.base import Base
+from gateway.app.main import handle_forge_operation_result
+from gateway.app.models.entities import ForgeOperationModel
+from gateway.app.services import store
+from gateway.app.services.agent_hub import AgentHub
+from shared.protocol import (
+    AgentEnvelope,
+    AgentMessageType,
+    ApprovalDecision,
+    ExecutorRegistration,
+    ForgeOperationKind,
+    ForgeOperationRequest,
+    ProjectRegistration,
+)
+
+
+class _DummyGatewayWebSocket:
+    """Stands in for the executor's websocket on the gateway side of
+
+    `AgentHub` -- same shape `tests/integration/test_decisions.py` already
+    uses for the same purpose."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+class _DummyExecutorWebSocket:
+    """Stands in for the gateway's websocket on the executor side --
+
+    `tests/unit/test_agent_service.py`'s own `DummyWebSocket` shape
+    (`AgentService` calls `.send(str)`, not `.send_json(dict)`: the executor
+    serializes its own envelope)."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(self, payload: str) -> None:
+        self.messages.append(payload)
+
+
+@pytest.fixture
+async def db():
+    """A real database and session factory, seeded with one executor/project
+
+    pair -- same pattern `tests/integration/test_push_preauthorization.py`
+    uses. Yields `(session_factory, session)`: most calls use the shared
+    `session`, and `AgentHub`/`decide`/`dispatch` open their own via the
+    factory, exactly as they do in production.
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        await store.upsert_registry(
+            session,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="T610",
+                    display_name="T610",
+                    machine_token="token-1",
+                    allowed_projects=["p1"],
+                )
+            ],
+            projects=[
+                ProjectRegistration(project_id="p1", name="Projeto 1", path="/srv/p1"),
+            ],
+        )
+        yield session_factory, session
+    await engine.dispose()
+
+
+def _write_request(**overrides) -> ForgeOperationRequest:
+    fields = {
+        "kind": ForgeOperationKind.ISSUE_OPEN,
+        "repo_identity": "acme/widgets",
+        "title": "Bug found",
+        "body": "Steps to reproduce...",
+    }
+    fields.update(overrides)
+    return ForgeOperationRequest(**fields)
+
+
+def _read_request(**overrides) -> ForgeOperationRequest:
+    fields = {"kind": ForgeOperationKind.ISSUE_LIST, "repo_identity": "acme/widgets"}
+    fields.update(overrides)
+    return ForgeOperationRequest(**fields)
+
+
+# --------------------------------------------------------------------------
+# The gate itself: a write is born awaiting_approval, and dispatch refuses
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_forge_write_is_born_awaiting_approval(db) -> None:
+    _, session = db
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_write_request()
+    )
+    assert row.state == "awaiting_approval"
+    assert row.resolved_at is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_a_write_still_awaiting_approval(db) -> None:
+    """THE required test: a forge write cannot be dispatched without passing
+
+    the gate. Calls the real `AgentHub.dispatch_forge_operation`, not the
+    pure policy function -- see this module's own docstring."""
+    session_factory, session = db
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_write_request()
+    )
+    hub = AgentHub(session_factory)
+    websocket = _DummyGatewayWebSocket()
+    await hub.register("T610", websocket)
+    websocket.sent.clear()  # drop hello/replay bookkeeping noise from register()
+
+    with pytest.raises(ValueError, match="forge_operation_not_approved"):
+        await hub.dispatch_forge_operation(row.id)
+
+    assert websocket.sent == []  # no envelope reached the executor
+
+
+@pytest.mark.asyncio
+async def test_rejected_forge_operation_never_dispatches(db) -> None:
+    """A human `REJECTED` decision is just as terminal as never deciding at
+
+    all -- the gate does not reopen for a second dispatch attempt."""
+    session_factory, session = db
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_write_request()
+    )
+    row = await store.decide_forge_operation(session, row.id, ApprovalDecision.REJECTED, reason="not now")
+    assert row.state == "rejected"
+    assert row.resolved_at is not None
+
+    hub = AgentHub(session_factory)
+    websocket = _DummyGatewayWebSocket()
+    await hub.register("T610", websocket)
+    websocket.sent.clear()
+
+    with pytest.raises(ValueError, match="forge_operation_not_approved"):
+        await hub.dispatch_forge_operation(row.id)
+    assert websocket.sent == []
+
+
+@pytest.mark.asyncio
+async def test_issue_list_read_does_not_stop_at_the_gate(db) -> None:
+    """Positive control for the two refusals above, and for issue #80/#79's
+
+    own requirement: `issue_list` is READ and is never gated -- it is born
+    `approved`, ready to dispatch on the same turn it is created."""
+    session_factory, session = db
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_read_request()
+    )
+    assert row.state == "approved"
+
+    hub = AgentHub(session_factory)
+    websocket = _DummyGatewayWebSocket()
+    await hub.register("T610", websocket)
+    websocket.sent.clear()
+
+    dispatched = await hub.dispatch_forge_operation(row.id)
+    assert dispatched is True
+    assert len(websocket.sent) == 1
+    assert websocket.sent[0]["type"] == AgentMessageType.FORGE_OPERATION.value
+    assert websocket.sent[0]["payload"]["operation_id"] == row.id
+
+
+@pytest.mark.asyncio
+async def test_create_forge_operation_refuses_a_project_not_allowed_for_the_executor(db) -> None:
+    """The gateway's OWN allowlist check (`executors.metadata_json`), separate
+
+    from the executor's local one exercised in
+    `tests/unit/test_agent_service.py`. Positive control is
+    `test_forge_write_is_born_awaiting_approval` above, which uses the
+    allowed pair."""
+    _, session = db
+    await store.upsert_registry(
+        session,
+        executors=[],
+        projects=[ProjectRegistration(project_id="p2", name="Projeto 2", path="/srv/p2")],
+    )
+    with pytest.raises(ValueError, match="project_not_allowed_for_executor"):
+        await store.create_forge_operation(
+            session, executor_id="T610", project_id="p2", operation=_write_request()
+        )
+
+
+# --------------------------------------------------------------------------
+# Full pipeline: request -> awaiting_approval -> approval -> dispatch ->
+# FORGE_OPERATION_RESULT -> resolved row
+# --------------------------------------------------------------------------
+
+
+async def _dispatch_and_capture_envelope(hub: AgentHub, websocket: _DummyGatewayWebSocket, operation_id: str) -> AgentEnvelope:
+    dispatched = await hub.dispatch_forge_operation(operation_id)
+    assert dispatched is True
+    return AgentEnvelope.model_validate(websocket.sent[-1])
+
+
+async def _run_on_executor(service: AgentService, envelope: AgentEnvelope) -> AgentEnvelope:
+    executor_ws = _DummyExecutorWebSocket()
+    await service._handle_forge_operation(executor_ws, envelope)
+    return AgentEnvelope.model_validate_json(executor_ws.messages[-1])
+
+
+@pytest.mark.asyncio
+async def test_full_pipeline_write_completes_after_a_human_approves(db, tmp_path: Path, monkeypatch) -> None:
+    session_factory, session = db
+    await store.upsert_registry(
+        session,
+        executors=[],
+        projects=[ProjectRegistration(project_id="p1", name="Projeto 1", path=str(tmp_path))],
+    )
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_write_request()
+    )
+    assert row.state == "awaiting_approval"
+
+    row = await store.decide_forge_operation(session, row.id, ApprovalDecision.APPROVED, reason="looks fine")
+    assert row.state == "approved"
+
+    hub = AgentHub(session_factory)
+    gateway_ws = _DummyGatewayWebSocket()
+    await hub.register("T610", gateway_ws)
+    gateway_ws.sent.clear()
+    dispatch_envelope = await _dispatch_and_capture_envelope(hub, gateway_ws, row.id)
+    assert dispatch_envelope.type == AgentMessageType.FORGE_OPERATION
+    assert dispatch_envelope.payload["operation_id"] == row.id
+
+    async def fake_run_gh(*a, **k):
+        return GhResult(returncode=0, stdout="https://github.com/acme/widgets/issues/7\n", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=True))
+    service.projects = {
+        "p1": ProjectRegistration(project_id="p1", name="Projeto 1", path=str(tmp_path))
+    }
+    result_envelope = await _run_on_executor(service, dispatch_envelope)
+    assert result_envelope.type == AgentMessageType.FORGE_OPERATION_RESULT
+    assert result_envelope.payload["outcome"] == "succeeded"
+    assert result_envelope.payload["issue_number"] == 7
+
+    async with session_factory() as resolve_session:
+        await handle_forge_operation_result(resolve_session, result_envelope)
+
+    async with session_factory() as check_session:
+        resolved = await check_session.get(ForgeOperationModel, row.id)
+        assert resolved.state == "completed"
+        assert resolved.resolved_at is not None
+        assert '"issue_number": 7' in resolved.result_json
+
+
+@pytest.mark.asyncio
+async def test_executor_kill_switch_refuses_even_after_gateway_approval(db, tmp_path: Path, monkeypatch) -> None:
+    """The two locks are independent: a gateway approval is not, by itself,
+
+    enough to make `gh` run. `allow_forge_operations=False` on the executor
+    refuses regardless -- and the gateway still resolves the row (as
+    `failed`), because a `FORGE_OPERATION_RESULT` came back either way."""
+    session_factory, session = db
+    await store.upsert_registry(
+        session,
+        executors=[],
+        projects=[ProjectRegistration(project_id="p1", name="Projeto 1", path=str(tmp_path))],
+    )
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_write_request()
+    )
+    row = await store.decide_forge_operation(session, row.id, ApprovalDecision.APPROVED)
+
+    hub = AgentHub(session_factory)
+    gateway_ws = _DummyGatewayWebSocket()
+    await hub.register("T610", gateway_ws)
+    gateway_ws.sent.clear()
+    dispatch_envelope = await _dispatch_and_capture_envelope(hub, gateway_ws, row.id)
+
+    calls: list[object] = []
+
+    async def fake_run_gh(*a, **k):
+        calls.append((a, k))
+        return GhResult(returncode=0, stdout="https://github.com/acme/widgets/issues/7\n", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=False))  # the trava, OFF
+    service.projects = {
+        "p1": ProjectRegistration(project_id="p1", name="Projeto 1", path=str(tmp_path))
+    }
+    result_envelope = await _run_on_executor(service, dispatch_envelope)
+    assert result_envelope.payload["outcome"] == "refused"
+    assert result_envelope.payload["reason"] == "executor_forge_disabled"
+    assert calls == []  # gh was never invoked despite the gateway's approval
+
+    async with session_factory() as resolve_session:
+        await handle_forge_operation_result(resolve_session, result_envelope)
+    async with session_factory() as check_session:
+        resolved = await check_session.get(ForgeOperationModel, row.id)
+        assert resolved.state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_project_outside_executor_local_allowlist_refuses_even_after_gateway_approval(
+    db, tmp_path: Path, monkeypatch
+) -> None:
+    """The executor's own project allowlist is the second independent gate:
+
+    a gateway-approved operation for a project this executor was never
+    configured to touch still never reaches `gh`. Positive control is
+    `test_full_pipeline_write_completes_after_a_human_approves` above, which
+    registers `p1` on the executor."""
+    session_factory, session = db
+    await store.upsert_registry(
+        session,
+        executors=[],
+        projects=[ProjectRegistration(project_id="p1", name="Projeto 1", path=str(tmp_path))],
+    )
+    row = await store.create_forge_operation(
+        session, executor_id="T610", project_id="p1", operation=_write_request()
+    )
+    row = await store.decide_forge_operation(session, row.id, ApprovalDecision.APPROVED)
+
+    hub = AgentHub(session_factory)
+    gateway_ws = _DummyGatewayWebSocket()
+    await hub.register("T610", gateway_ws)
+    gateway_ws.sent.clear()
+    dispatch_envelope = await _dispatch_and_capture_envelope(hub, gateway_ws, row.id)
+
+    calls: list[object] = []
+
+    async def fake_run_gh(*a, **k):
+        calls.append((a, k))
+        return GhResult(returncode=0, stdout="https://github.com/acme/widgets/issues/7\n", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=True))
+    service.projects = {}  # p1 not registered locally, and no auto_project_root
+    result_envelope = await _run_on_executor(service, dispatch_envelope)
+    assert result_envelope.payload["outcome"] == "refused"
+    assert result_envelope.payload["reason"] == "unknown_project"
+    assert calls == []
+
+    async with session_factory() as resolve_session:
+        await handle_forge_operation_result(resolve_session, result_envelope)
+    async with session_factory() as check_session:
+        resolved = await check_session.get(ForgeOperationModel, row.id)
+        assert resolved.state == "failed"

--- a/tests/unit/test_agent_service.py
+++ b/tests/unit/test_agent_service.py
@@ -730,3 +730,191 @@ async def test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_
     await service._handle_dispatch(DummyWebSocket(), _dispatch_envelope(task_id="t-locked", mode="implement"))
 
     assert runner.sandboxes == ["read-only"]
+
+
+# --------------------------------------------------------------------------
+# `_handle_forge_operation` -- issue #80/#79, WK-20260902-forge-wiring-and-gate
+# (PR B3). Parallel to the `_handle_dispatch` tests above: this suite proves
+# the REAL handler refuses/succeeds by calling it directly with a fake
+# websocket, not by unit-testing `shared.policy.forge_operation_policy_level`
+# or `forge.github.run_forge_operation` in isolation (both already have their
+# own exhaustive suites -- `test_forge_policy.py`, `test_forge_github.py`).
+# Every negative case here is paired with a positive control in this same
+# file, per `docs/napkin-lessons.md`'s 2026-09-01 lesson.
+#
+# `github.run_gh` (not `gh_tool.run_gh`) is what gets monkeypatched, exactly
+# like `test_forge_github.py` does: it is the last seam before a real
+# subprocess, so a fake here proves this handler reaches all the way through
+# `run_forge_operation`'s own gate and revalidation without ever touching a
+# real `gh` binary or a real credential file.
+# --------------------------------------------------------------------------
+
+from agent.codex_bridge_agent.forge import github as forge_github  # noqa: E402
+from agent.codex_bridge_agent.forge.gh_tool import GhResult  # noqa: E402
+
+
+def _forge_envelope(*, operation_id: str, project_id: str, kind: str = "issue_list", **payload_fields) -> AgentEnvelope:
+    return AgentEnvelope(
+        message_id=f"forge-{operation_id}",
+        executor_id="devel3",
+        sent_at=datetime.now(timezone.utc),
+        type=AgentMessageType.FORGE_OPERATION,
+        payload={
+            "operation_id": operation_id,
+            "project_id": project_id,
+            "kind": kind,
+            "repo_identity": "acme/widgets",
+            **payload_fields,
+        },
+    )
+
+
+def _last_forge_result(websocket: "DummyWebSocket") -> AgentEnvelope:
+    result = AgentEnvelope.model_validate_json(websocket.messages[-1])
+    assert result.type == AgentMessageType.FORGE_OPERATION_RESULT
+    return result
+
+
+@pytest.mark.asyncio
+async def test_forge_operation_runs_when_allowed_and_project_is_known(tmp_path: Path, monkeypatch) -> None:
+    """Positive control for every refusal test below: with the kill switch on
+
+    and the project in this executor's own allowlist, the real handler
+    reaches all the way through `run_forge_operation` to a (faked) `gh` and
+    reports success."""
+    async def fake_run_gh(*a, **k):
+        return GhResult(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=True))
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+    websocket = DummyWebSocket()
+
+    await service._handle_forge_operation(
+        websocket, _forge_envelope(operation_id="op-1", project_id="codexbridge", kind="issue_list")
+    )
+
+    result = _last_forge_result(websocket)
+    assert result.payload["operation_id"] == "op-1"
+    assert result.payload["outcome"] == "succeeded"
+    assert result.payload["issues"] == []
+
+
+@pytest.mark.asyncio
+async def test_forge_operation_refuses_when_executor_kill_switch_is_off(tmp_path: Path, monkeypatch) -> None:
+    """The machine-level trava: off by default, and independent of anything
+
+    the gateway believes it approved -- this handler never re-derives
+    `forge_operation_policy_level` (see the handler's own docstring), so the
+    ONLY thing standing between an approved write and `gh` running is this
+    setting plus `run_forge_operation`'s own revalidation."""
+    calls: list[object] = []
+
+    async def fake_run_gh(*a, **k):
+        calls.append((a, k))
+        return GhResult(returncode=0, stdout="unused", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=False))
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+    websocket = DummyWebSocket()
+
+    await service._handle_forge_operation(
+        websocket, _forge_envelope(operation_id="op-2", project_id="codexbridge", kind="issue_list")
+    )
+
+    result = _last_forge_result(websocket)
+    assert result.payload["outcome"] == "refused"
+    assert result.payload["reason"] == "executor_forge_disabled"
+    assert calls == []  # gh was never invoked
+
+
+@pytest.mark.asyncio
+async def test_forge_operation_refuses_for_a_project_outside_the_local_allowlist(tmp_path: Path, monkeypatch) -> None:
+    """The executor's own project allowlist is a second, independent gate --
+
+    reused verbatim from `_handle_dispatch`'s own resolution, not reinvented.
+    Kill switch is ON here so the refusal can only be coming from the
+    project check, not from `allow_forge_operations`."""
+    calls: list[object] = []
+
+    async def fake_run_gh(*a, **k):
+        calls.append((a, k))
+        return GhResult(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=True))
+    service.projects = {}  # nothing registered, and no auto_project_root
+    websocket = DummyWebSocket()
+
+    await service._handle_forge_operation(
+        websocket, _forge_envelope(operation_id="op-3", project_id="not-registered", kind="issue_list")
+    )
+
+    result = _last_forge_result(websocket)
+    assert result.payload["outcome"] == "refused"
+    assert result.payload["reason"] == "unknown_project"
+    assert result.payload["attempted"] is False
+    assert calls == []  # never reached run_forge_operation at all
+
+
+@pytest.mark.asyncio
+async def test_forge_operation_refuses_an_invalid_payload_without_touching_gh(tmp_path: Path, monkeypatch) -> None:
+    """A malformed envelope (unknown `kind`) is refused at parse time, the
+
+    same way `ForgeOperationRequest` itself would refuse it on the gateway --
+    this executor re-validates rather than trusting the envelope's shape."""
+    calls: list[object] = []
+
+    async def fake_run_gh(*a, **k):
+        calls.append((a, k))
+        return GhResult(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=True))
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+    websocket = DummyWebSocket()
+
+    await service._handle_forge_operation(
+        websocket, _forge_envelope(operation_id="op-4", project_id="codexbridge", kind="issue_delete")
+    )
+
+    result = _last_forge_result(websocket)
+    assert result.payload["outcome"] == "refused"
+    assert result.payload["reason"] == "invalid_forge_operation_payload"
+    assert result.payload["attempted"] is False
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_forge_operation_write_kind_reaches_gh_when_approved_and_allowed(tmp_path: Path, monkeypatch) -> None:
+    """Positive control proving a WRITE kind (not just the read-only
+
+    `issue_list` used above) also completes the full pipeline once it
+    reaches this handler -- the handler itself draws no distinction between
+    read and write; that distinction is entirely the gateway-side gate's
+    job (`tests/integration/test_forge_wiring.py`)."""
+    async def fake_run_gh(*a, **k):
+        return GhResult(returncode=0, stdout="https://github.com/acme/widgets/issues/42\n", stderr="")
+
+    monkeypatch.setattr(forge_github, "run_gh", fake_run_gh)
+    service = AgentService(AgentSettings(allow_forge_operations=True))
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+    websocket = DummyWebSocket()
+
+    await service._handle_forge_operation(
+        websocket,
+        _forge_envelope(operation_id="op-5", project_id="codexbridge", kind="issue_open", title="Bug", body="Details"),
+    )
+
+    result = _last_forge_result(websocket)
+    assert result.payload["outcome"] == "succeeded"
+    assert result.payload["issue_number"] == 42


### PR DESCRIPTION
Issues #80 and #79, stage 3 — stacked on #86, review that first. This is the wiring: an approved forge operation now actually reaches the executor and comes back.

## What changes
- `AgentService._handle_forge_operation` on the executor, parallel to `_handle_dispatch`, resolving `project_root` through the same local allowlist and returning `FORGE_OPERATION_RESULT`.
- `forge_operations` table (`migrations/0012`), entity, `schema_guard` entry.
- `AgentHub.dispatch_forge_operation` — **this is the gate on the gateway side**. It raises, never silently no-ops, unless the row already reads `approved`. The tests exercise that function directly rather than only the pure policy function: `forge_operation_policy_level` has no bypass field to begin with, so the real risk is a bypass added here or in the executor handler later.

Two independent locks, both required: the gateway's approval **and** the executor's `allow_forge_operations`. A test proves the executor still refuses an operation the gateway already approved when its own lock is off.

## The design decision, and the follow-up it creates
The approval path for forge operations is **separate** from `create_task`/`decide_task_approval`. `TaskModel`'s columns (`mode`, `instruction`, `engine`, `session_id`, `delivery_json`) all encode a coding-agent session; a forge operation is `kind` + `repo_identity` running outside any sandbox, and forcing it in would need sentinel enum values and would route through `hub.dispatch_available`, which sends `task.dispatch` to a `RunnerPool` that knows nothing about forge. What is reused is the vocabulary — `ApprovalDecision`, and the "born awaiting_approval, human decides, dispatched separately" shape — not the mechanism.

**That storage split is accepted. The operator-facing split is not, and must be closed.** `gateway/app/api/routes/decisions.py` says in its own first line that "a decision is not a new domain object — it is a `TaskModel`", so as things stand a forge write awaiting approval will never appear in the Decision Center the mobile client reads. Two approval inboxes is not a product this should ship. The follow-up work (B4, or an issue filed from it) must project forge operations into `/api/v1/decisions` alongside tasks, or explicitly decide otherwise with the operator.

## Not here
No REST route, no MCP tool — so the OpenAPI contract and `API_CONTRACT_VERSION` are untouched. There is still no way for an operator to create or approve a forge operation from ChatGPT; that is the next PR.

## Validation
`pytest -q`: **822 passed, 7 skipped, 0 failed** (809 + 13 new). `tests/contract/`: green. `tests/integration/test_forge_wiring.py` covers the full pipeline — request → approve → dispatch → the real executor handler against a faked `gh` → result → resolved row — plus a write refused before decision, a write refused after rejection, `issue_list` skipping the gate, and a disallowed project refused on each side independently.

## Residual
Forge dispatch has no concurrency throttling. Every write still costs a human approval and each `gh` call is timeout-bounded, so the exposure is small, but it is unbounded by design today.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw