### PR TITLE
feat(gh-78): planned epics become versioned files in the project's repo

### DIFF
--- a/agent/codex_bridge_agent/instructions.py
+++ b/agent/codex_bridge_agent/instructions.py
@@ -62,6 +62,47 @@ def _number_candidates(number: str) -> set[str]:
     return candidates
 
 
+_LEADING_NUMBER = re.compile(r"^(\d{1,6})-")
+
+
+def list_used_issue_numbers(project_root: Path) -> set[int]:
+    """Every `NNN` already in use under `docs/issues/`, across the three
+
+    layouts `resolve_issue_text` tolerates above (a bare numbered file, a
+    whole numbered folder, and a numbered file nested one level under
+    `<epic>/issues/`). WK-20260902-issue-materialize / issue #78: used by
+    `agent/codex_bridge_agent/issue_materialize.py` to pick the next free
+    number when publishing a new epic or issue -- the SAME layout
+    understanding as `resolve_issue_text`, so a number this picks can never
+    collide with, or be ambiguous against, something that function would
+    later resolve. This is an enumeration (every used number), while
+    `resolve_issue_text` is a lookup (does one specific number exist) --
+    different shapes of query over the same directory, kept in this one
+    module rather than duplicated into a second scanner elsewhere.
+    """
+    docs_issues = project_root / "docs" / "issues"
+    used: set[int] = set()
+    if not docs_issues.is_dir():
+        return used
+    for entry in docs_issues.iterdir():
+        # Layout B (a numbered folder) and Layout C (a bare numbered file)
+        # are both direct children of docs/issues/, so one pass over
+        # `iterdir()` catches both.
+        match = _LEADING_NUMBER.match(entry.name)
+        if match:
+            used.add(int(match.group(1)))
+    for path in docs_issues.glob("*/issues/*.md"):
+        # Layout A: docs/issues/<epic-slug>/issues/NNN-<slug>.md. The pattern
+        # itself contains no literal `[`/`]`, so a status-suffixed filename
+        # like `NNN-slug-[ready].md` matches this glob normally -- brackets
+        # only need special handling where they appear INSIDE a pattern
+        # string, never inside a matched filename.
+        match = _LEADING_NUMBER.match(path.name)
+        if match:
+            used.add(int(match.group(1)))
+    return used
+
+
 def resolve_issue_text(project_root: Path, issue_ref: str) -> str:
     """Returns the raw text of the issue `issue_ref` names, or raises
 

--- a/agent/codex_bridge_agent/issue_materialize.py
+++ b/agent/codex_bridge_agent/issue_materialize.py
@@ -1,0 +1,185 @@
+"""Writes one epic's rendered markdown to disk -- issue #78, Commit 2c.
+
+The EXECUTOR, not the gateway, chooses every `NNN` this module writes, for
+the same reason `instructions.py`'s `resolve_issue_text` reads
+`docs/issues/` on the executor instead of the gateway: the gateway never
+learns a project's real path (`docs/architecture.md`). Numbering has the same
+constraint one layer deeper -- deciding "the next free number" requires
+listing what is already on disk, which only the executor can see.
+
+Correlation trick, spelled out in full here because two other modules depend
+on it without sharing any in-process state (see
+`gateway/app/services/issue_render.py` and `gateway/app/services/store.py:
+apply_epic_materialization`): `MaterializeRequest.files` keys embed the issue
+id as a path segment -- `issues/<issue_id>/<slug>-[<status>].md` -- purely as
+an addressing convention for this one round trip. It is NEVER written to
+disk: this module strips the `<issue_id>/` segment before choosing the real,
+numbered filename, and echoes the ORIGINAL key (with the id segment intact)
+back in `ISSUE_MATERIALIZE_RESULT.written_paths`, so the gateway can parse the
+id back out on the other side of a round trip that may cross a gateway
+restart.
+
+Numbering is a single shared pool across the epic's own directory AND every
+issue file under it (and every OTHER epic/issue already on disk) --
+`list_used_issue_numbers` (`instructions.py`) does not distinguish "this
+number names a folder" from "this number names a file nested under some
+other epic's issues/": a bare `NNN` issue reference must resolve
+unambiguously, so no two things under `docs/issues/` may ever share a
+number, regardless of what kind of thing each one is.
+
+Race safety: two publications racing for the same number are resolved by
+atomic creation -- `Path.mkdir()` for the epic directory, `os.open(...,
+O_CREAT | O_EXCL)` for an issue file -- retried with the next number on a
+collision, never by a lock file (`tests/unit/test_issue_materialize.py`
+exercises this directly by pre-creating the first candidate).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from agent.codex_bridge_agent.instructions import list_used_issue_numbers
+from shared.protocol import MaterializeRequest
+from shared.security import ensure_within_root
+
+
+class MaterializeError(RuntimeError):
+    """A typed reason a `MaterializeRequest` could not be written.
+
+    `str(error)` is exactly the code -- what `AgentService._handle_materialize`
+    reports back as `ISSUE_MATERIALIZE_RESULT.error`, never a raw traceback.
+    """
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class MaterializeOutcome:
+    epic_path: str
+    written_paths: dict[str, str] = field(default_factory=dict)
+
+
+def _split_issue_key(key: str) -> tuple[str, str] | None:
+    """`"issues/<issue_id>/<rest>"` -> `(issue_id, rest)`, or `None` for a
+
+    key with no `issues/<id>/` segment (`README.md`, `epic.md`).
+    """
+    if not key.startswith("issues/"):
+        return None
+    remainder = key[len("issues/"):]
+    issue_id, sep, rest = remainder.partition("/")
+    if not sep or not rest:
+        return None
+    return issue_id, rest
+
+
+# A collision run this long means something is wrong beyond an ordinary
+# numbering race (two publications landing on the same starting number) --
+# refuse loudly rather than spin forever.
+_MAX_ALLOCATION_ATTEMPTS = 10_000
+
+
+def _allocate_dir(docs_issues: Path, start: int, slug: str) -> tuple[int, Path]:
+    n = start
+    for _ in range(_MAX_ALLOCATION_ATTEMPTS):
+        candidate = docs_issues / f"{n:03d}-{slug}"
+        try:
+            candidate.mkdir()
+            return n + 1, candidate
+        except FileExistsError:
+            n += 1
+    raise MaterializeError("numbering_exhausted")
+
+
+def _allocate_file(issues_dir: Path, start: int, suffix: str) -> tuple[int, Path]:
+    n = start
+    for _ in range(_MAX_ALLOCATION_ATTEMPTS):
+        candidate = issues_dir / f"{n:03d}-{suffix}"
+        try:
+            fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            n += 1
+            continue
+        os.close(fd)
+        return n + 1, candidate
+    raise MaterializeError("numbering_exhausted")
+
+
+def _find_existing_issue_file(issues_dir: Path, suffix: str) -> Path | None:
+    """A previously-published file for this issue, matched by trailing
+
+    filename (everything after its own `NNN-` prefix). Plain string
+    comparison, not `glob(f"*{suffix}")`: `suffix` legitimately contains `[`
+    and `]` (the status suffix, e.g. `foo-[ready].md`), which `glob` would
+    otherwise interpret as a character class instead of literal text.
+    """
+    if not issues_dir.is_dir():
+        return None
+    for entry in issues_dir.iterdir():
+        if entry.is_file() and entry.name.endswith(suffix):
+            return entry
+    return None
+
+
+def materialize_epic(project_root: Path, request: MaterializeRequest) -> MaterializeOutcome:
+    """Writes `request.files` under `project_root/docs/issues/`, allocating
+
+    (or reusing, on republish) every `NNN`. Raises `MaterializeError` on any
+    refusal; every write is preceded by `ensure_within_root`, the same
+    traversal guard `resolve_issue_text` applies on the read side.
+    """
+    docs_issues = project_root / "docs" / "issues"
+    docs_issues.mkdir(parents=True, exist_ok=True)
+
+    cursor = max(list_used_issue_numbers(project_root), default=0) + 1
+
+    republish = request.existing_path is not None
+    if republish:
+        epic_dir = (project_root / request.existing_path).resolve()
+        try:
+            ensure_within_root(str(project_root), str(epic_dir))
+        except ValueError as exc:
+            raise MaterializeError("existing_path_invalid") from exc
+        if not epic_dir.is_dir():
+            raise MaterializeError("existing_path_not_found")
+    else:
+        cursor, epic_dir = _allocate_dir(docs_issues, cursor, request.slug)
+        ensure_within_root(str(project_root), str(epic_dir))
+
+    issues_dir = epic_dir / "issues"
+    issues_dir.mkdir(parents=True, exist_ok=True)
+
+    written_paths: dict[str, str] = {}
+    for key, content in request.files.items():
+        split = _split_issue_key(key)
+        if split is None:
+            # README.md / epic.md -- written directly under the epic's own
+            # directory. `key` here is one of exactly those two literals
+            # (`issue_render.render_epic_markdown`'s own contract), never
+            # caller-controlled, but this still runs through
+            # `ensure_within_root` rather than being assumed safe.
+            target = epic_dir / key
+            ensure_within_root(str(project_root), str(target))
+            target.write_text(content, encoding="utf-8")
+            written_paths[key] = _relative(target, project_root)
+            continue
+
+        _issue_id, suffix = split
+        existing = _find_existing_issue_file(issues_dir, suffix) if republish else None
+        if existing is not None:
+            target = existing
+        else:
+            cursor, target = _allocate_file(issues_dir, cursor, suffix)
+        ensure_within_root(str(project_root), str(target))
+        target.write_text(content, encoding="utf-8")
+        written_paths[key] = _relative(target, project_root)
+
+    return MaterializeOutcome(epic_path=_relative(epic_dir, project_root), written_paths=written_paths)
+
+
+def _relative(path: Path, project_root: Path) -> str:
+    return str(path.relative_to(project_root)).replace(os.sep, "/")

--- a/agent/codex_bridge_agent/service.py
+++ b/agent/codex_bridge_agent/service.py
@@ -12,6 +12,7 @@ import websockets
 from agent.codex_bridge_agent.config import AgentSettings, load_agent_projects, resolve_auto_project
 from agent.codex_bridge_agent.git_delivery import deliver_changes
 from agent.codex_bridge_agent.instructions import IssueResolutionError, build_task_instruction, resolve_issue_text
+from agent.codex_bridge_agent.issue_materialize import MaterializeError, materialize_epic
 from agent.codex_bridge_agent.runners.base import EngineNotImplementedError
 from agent.codex_bridge_agent.runners.codex import SANDBOX_READ_ONLY, SANDBOX_WORKSPACE_WRITE
 from agent.codex_bridge_agent.runners.pool import RunnerPool
@@ -21,6 +22,7 @@ from shared.protocol import (
     AgentEnvelope,
     AgentMessageType,
     DeliveryRequest,
+    MaterializeRequest,
     PolicyLevel,
     SubmitTaskRequest,
     TaskMode,
@@ -107,6 +109,8 @@ class AgentService:
                     envelope = AgentEnvelope.model_validate_json(raw)
                     if envelope.type == AgentMessageType.TASK_DISPATCH:
                         asyncio.create_task(self._handle_dispatch(websocket, envelope))
+                    elif envelope.type == AgentMessageType.ISSUE_MATERIALIZE:
+                        asyncio.create_task(self._handle_materialize(websocket, envelope))
                     elif envelope.type == AgentMessageType.TASK_CANCEL:
                         task_id = envelope.payload["task_id"]
                         await self.runners.cancel(task_id)
@@ -344,6 +348,76 @@ class AgentService:
             await websocket.send(self._envelope(AgentMessageType.TASK_RESULT, result).model_dump_json())
         finally:
             self.runners.forget(task_id)
+
+    async def _handle_materialize(self, websocket, envelope: AgentEnvelope) -> None:
+        """Writes one epic's rendered markdown to disk -- issue #78, Commit 2c.
+
+        Mirrors `_handle_dispatch`'s own project-resolution shape (same
+        `self.projects`/`auto_project_root` fallback, same
+        `ensure_within_root` posture) but there is no `TaskModel` here: this
+        is a fire-and-forget `ISSUE_MATERIALIZE`/`ISSUE_MATERIALIZE_RESULT`
+        pair, not a queued task, so failures are reported the same way but
+        nothing here ever touches `self.runners`.
+        """
+        payload = envelope.payload
+        epic_id = payload.get("epic_id")
+
+        async def fail(error: str) -> None:
+            await websocket.send(
+                self._envelope(
+                    AgentMessageType.ISSUE_MATERIALIZE_RESULT,
+                    {"epic_id": epic_id, "ok": False, "error": error},
+                ).model_dump_json()
+            )
+
+        try:
+            request = MaterializeRequest.model_validate(payload)
+        except Exception:
+            await fail("invalid_materialize_request")
+            return
+
+        project = self.projects.get(request.project_id)
+        if project is None and self.settings.auto_project_root:
+            project = resolve_auto_project(request.project_id, self.settings.auto_project_root)
+        if project is None:
+            await fail("unknown_project")
+            return
+        root = Path(ensure_within_root(project.path, project.path))
+
+        try:
+            outcome = materialize_epic(root, request)
+        except MaterializeError as exc:
+            await fail(exc.code)
+            return
+
+        result_payload: dict = {
+            "epic_id": epic_id,
+            "ok": True,
+            "epic_path": outcome.epic_path,
+            "epic_revision": request.epic_revision,
+            "written_paths": outcome.written_paths,
+            "issue_revisions": request.issue_revisions,
+        }
+
+        if request.delivery is not None:
+
+            async def _noop_log(stream: str, line: str) -> None:
+                return None
+
+            delivery_outcome = await deliver_changes(
+                project_root=root,
+                delivery=request.delivery,
+                settings=self.settings,
+                task_id=f"materialize:{epic_id}",
+                issue_ref=None,
+                engine="materialize",
+                send_log=_noop_log,
+            )
+            result_payload["delivery"] = delivery_outcome.to_dict()
+
+        await websocket.send(
+            self._envelope(AgentMessageType.ISSUE_MATERIALIZE_RESULT, result_payload).model_dump_json()
+        )
 
     def _envelope(self, message_type: AgentMessageType, payload: dict) -> AgentEnvelope:
         return AgentEnvelope(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,6 +68,19 @@ apontada aqui até que alguém decida renomear.
 * Modos `analyze`, `review`, `edit`, `test`, `implement` são mapeados para níveis de política
 * Ações sensíveis exigem aprovação no gateway e no agente
 
+**A mesma fronteira vale um nível abaixo, para a materialização de épicas
+(issue #78, WK-20260902-issue-materialize).** "O ChatGPT nunca informa
+caminho" implica "o gateway nunca sabe o path" — e decidir o próximo `NNN`
+livre em `docs/issues/` exige listar o que já existe em disco, o que só o
+executor pode fazer. Por isso `publish_epic_to_repo` manda ao executor
+apenas conteúdo já renderizado (`gateway/app/services/issue_render.py`,
+função pura) com caminhos relativos à pasta da épica e SEM `NNN`; é o agente,
+em `agent/codex_bridge_agent/issue_materialize.py`, que varre o diretório
+(reaproveitando o mesmo scanner que `instructions.py` usa para resolver
+`docs:NNN`/`NNN` na leitura) e escolhe cada número, com criação atômica
+para sobreviver a uma corrida entre duas publicações. Ver `docs/protocol.md`,
+seção "Materialização de épicas", para o par de mensagens completo.
+
 ## Fluxo de comunicação
 
 1. O ChatGPT conecta o MCP remoto em um hostname dedicado no `frida`, por exemplo `https://codexbridge.inovacaosistemas.com.br:8443/mcp`.

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-epic-update-and-move`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-epic-update-and-move map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-issue-materialize`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-issue-materialize map`
 
 ## Summary
 
-- 127 file(s) · 1222 symbol(s) indexed
-- Languages: config (2), python (123), shell (2)
+- 133 file(s) · 1272 symbol(s) indexed
+- Languages: config (2), python (129), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -39,6 +39,7 @@ agent/
     git_delivery.py  — "The commit/push step a completed task's own `delivery` block authorizes."
     git_tools.py
     instructions.py  — "Resolves `issue_ref` to file content, and builds the provider prompt with"
+    issue_materialize.py  — "Writes one epic's rendered markdown to disk -- issue #78, Commit 2c."
     runners/
       __init__.py
       base.py  — "The provider-neutral surface the executor dispatches a task through."
@@ -104,6 +105,7 @@ gateway/
       conversation_types.py  — "Closed vocabulary for conversation context references, and their error."
       email_templates.py  — "Branded HTML for every CodexBridge transactional email."
       google_calendar.py  — "A Google Calendar client for reminders, built to be tested without ever"
+      issue_render.py  — "Pure markdown renderer for epic materialization -- issue #78, Commit 2a."
       issue_types.py  — "Closed vocabularies for epics and issues, and the error they fail with."
       metrics.py
       notify.py  — "Out-of-band completion notification by email."
@@ -140,6 +142,7 @@ tests/
     test_decisions.py  — "Operational decisions — issue #6."
     test_dispatch_payload_engine_and_delivery.py  — "`AgentHub.dispatch_next` forwards engine/issue_ref/delivery to the executor."
     test_epics_issues.py  — "Epics and issues — issue #8."
+    test_issue_materialize_result.py  — "`issue.materialize_result` handling in the `/agent/ws` message loop --"
     test_mcp_epics_issues.py  — "The epics/issues MCP tools -- issue #78."
     test_mcp_reminders.py  — "The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer."
     test_missions.py  — "Missions: the mission-control view of Sessions — issue #7."
@@ -156,6 +159,7 @@ tests/
     test_agent_auth.py  — "Credential resolution for the `/agent/ws` handshake — issue #15."
     test_agent_auto_project.py  — "`agent.codex_bridge_agent.config.resolve_auto_project` -- the opt-in"
     test_agent_service.py
+    test_agent_service_materialize.py  — "`AgentService._handle_materialize` -- the `ISSUE_MATERIALIZE` handler on"
     test_apply_migrations.py  — "The migration runner, exercised against real throwaway databases."
     test_capability_vocabulary.py  — "The capability vocabulary issue #73's authorization plane is built on."
     test_claude_runner.py  — "ClaudeRunner's pure logic: command assembly, NDJSON extraction, sandbox mapping."
@@ -166,6 +170,8 @@ tests/
     test_git_delivery.py  — "`git_delivery.deliver_changes` against real throwaway git repos."
     test_google_calendar.py  — "`gateway.app.services.google_calendar`, without ever touching Google."
     test_instructions.py  — "`resolve_issue_text` and `build_task_instruction`."
+    test_issue_materialize.py  — "`materialize_epic` and the shared numbering scanner -- issue #78, Commit 2c."
+    test_issue_render.py  — "`render_epic_markdown` -- issue #78, Commit 2a."
     test_main_import.py
     test_notify.py  — "`gateway.app.services.notify` -- the task-finished completion email."
     test_policy.py
@@ -206,8 +212,18 @@ tests/
 
 - **`IssueResolutionError`** *(class)* — "A typed reason `issue_ref` could not be turned into file content."
   - `__init__(self, code)` *(method)*
+- `list_used_issue_numbers(project_root)` — "Every `NNN` already in use under `docs/issues/`, across the three"
 - `resolve_issue_text(project_root, issue_ref)` — "Returns the raw text of the issue `issue_ref` names, or raises"
 - `build_task_instruction()` — "Assembles the final provider prompt, keeping the operator's own words"
+
+### `agent/codex_bridge_agent/issue_materialize.py`
+
+> Writes one epic's rendered markdown to disk -- issue #78, Commit 2c.
+
+- **`MaterializeError`** *(class)* — "A typed reason a `MaterializeRequest` could not be written."
+  - `__init__(self, code)` *(method)*
+- **`MaterializeOutcome`** *(class)*
+- `materialize_epic(project_root, request)` — "Writes `request.files` under `project_root/docs/issues/`, allocating"
 
 ### `agent/codex_bridge_agent/runners/base.py`
 
@@ -598,6 +614,7 @@ tests/
 - `mcp_endpoint(request, authorization, session)` *(async function)*
 - `handle_task_ack(session, envelope)` *(async function)* — "Handles one `task.ack` from the `/agent/ws` message loop."
 - `handle_task_cancelled(session, envelope)` *(async function)* — "Handles one `task.cancelled` ack from the `/agent/ws` message loop."
+- `handle_issue_materialize_result(session, envelope)` *(async function)* — "Handles one `issue.materialize_result` from the `/agent/ws` message loop."
 - `agent_ws(websocket, executor_id, token, x_executor_token)` *(async function)*
 
 ### `gateway/app/mcp/server.py`
@@ -677,6 +694,14 @@ tests/
 - `cancel_reminder()` *(async function)*
 - `check_access(config)` *(async function)* — "Confirms the configured credential can actually read the configured"
 
+### `gateway/app/services/issue_render.py`
+
+> Pure markdown renderer for epic materialization -- issue #78, Commit 2a.
+
+- `epic_directory_slug(epic)` — "The `<epic-slug>-[<status>]` component of the epic's directory name."
+- `issue_relative_key(issue)` — "The `issues/<issue_id>/<task-slug>-[<status>].md` key for one issue."
+- `render_epic_markdown(epic, issues)` — "Relative path -> content, for every file one epic materializes to."
+
 ### `gateway/app/services/issue_types.py`
 
 > Closed vocabularies for epics and issues, and the error they fail with.
@@ -755,6 +780,7 @@ tests/
 - `list_issues_page(session)` *(async function)*
 - `update_issue(session, issue_id)` *(async function)*
 - `link_issue_to_epic(session)` *(async function)* — "Attach `issue_id` to `epic_id`. Both must already exist in one project."
+- `apply_epic_materialization(session)` *(async function)* — "Records a successful `ISSUE_MATERIALIZE_RESULT` -- issue #78, Commit 2."
 - `create_conversation(session)` *(async function)* — "Create a conversation from an already-resolved, already-authorized context."
 - `get_conversation(session, conversation_id)` *(async function)*
 - `get_conversation_for_projects(session, conversation_id, project_ids)` *(async function)* — "A conversation the caller may see, or None. Mirrors `get_epic_for_projects`."
@@ -829,6 +855,7 @@ tests/
 - **`ProjectRegistration`** *(class)*
 - **`ExecutorRegistration`** *(class)*
 - **`DeliveryRequest`** *(class)* — "What the requester authorized the executor to do with git, once a task"
+- **`MaterializeRequest`** *(class)* — "What `ISSUE_MATERIALIZE` asks the executor to write to disk, for one"
 - **`SubmitTaskRequest`** *(class)*
 - **`ContinueSessionRequest`** *(class)*
 - **`AgentEnvelope`** *(class)*
@@ -1032,6 +1059,7 @@ tests/
 - `test_me_reports_the_actor_and_its_projects(api)` *(async function)*
 - `test_me_marks_an_admin_as_seeing_every_project(api)` *(async function)*
 - `test_me_separates_read_operational_and_administrative(api)` *(async function)* — "The three classes the issue asks for, reported per action."
+- `test_epics_publish_is_exercised_over_mcp()` — "Not a real assertion -- a pointer so `COVERED_ELSEWHERE`'s own guard"
 - `test_every_catalogued_action_is_exercised_below()` — "A new action must extend the table, or it ships unchecked."
 - `test_each_exemption_names_a_test_that_exists()` — "An exemption pointing at nothing is an exemption with no coverage behind it."
 - `test_the_guard_flags_a_new_administrative_action(monkeypatch)` — "The guard is only worth having if it fires — so fire it."
@@ -1206,11 +1234,27 @@ tests/
 - `test_update_epic_rejects_an_unknown_status(api)` *(async function)*
 - `test_a_reader_cannot_update_an_epic(api)` *(async function)*
 
+### `tests/integration/test_issue_materialize_result.py`
+
+> `issue.materialize_result` handling in the `/agent/ws` message loop --
+
+- `factory()` *(async function)*
+- `test_a_successful_result_records_materialized_path_on_epic_and_issue(factory)` *(async function)* — "Positive control for the failure/unknown-epic tests below."
+- `test_a_failed_result_does_not_touch_materialized_path(factory)` *(async function)*
+- `test_a_result_for_an_unknown_epic_does_not_raise(factory)` *(async function)*
+- `test_a_result_with_no_epic_id_is_ignored_not_raised(factory)` *(async function)*
+- `test_apply_epic_materialization_ignores_non_issue_keys_and_unknown_issue_ids(factory)` *(async function)* — "Positive control: the real issue id updates; two adversarial-ish"
+
 ### `tests/integration/test_mcp_epics_issues.py`
 
 > The epics/issues MCP tools -- issue #78.
 
 - **`DummyHub`** *(class)*
+  - `is_connected(self, executor_id)` *(method)*
+  - `dispatch_next(self, executor_id)` *(async method)*
+  - `send(self, executor_id, envelope)` *(async method)*
+- **`RecordingHub`** *(class)* — "A hub with a caller-controlled set of connected executors, recording"
+  - `__init__(self, connected)` *(method)*
   - `is_connected(self, executor_id)` *(method)*
   - `dispatch_next(self, executor_id)` *(async method)*
   - `send(self, executor_id, envelope)` *(async method)*
@@ -1240,6 +1284,12 @@ tests/
 - `test_move_issue_to_epic_with_a_stale_expected_revision_is_refused(env)` *(async function)*
 - `test_move_issue_to_epic_from_a_foreign_project_is_unknown_epic(env)` *(async function)*
 - `test_a_retried_move_does_not_move_the_issue_twice(env)` *(async function)*
+- `test_publish_epic_to_repo_dispatches_to_a_connected_executor(env)` *(async function)* — "Positive control for the two `_not_connected`/`_not_onboarded` tests below."
+- `test_publish_epic_to_repo_with_no_connected_executor_is_a_typed_error(env)` *(async function)*
+- `test_publish_epic_to_repo_for_a_project_no_executor_allows_is_project_not_onboarded(env)` *(async function)*
+- `test_publish_epic_to_repo_unknown_epic_is_404(env)` *(async function)*
+- `test_publish_epic_to_repo_republish_carries_existing_path(env)` *(async function)*
+- `test_publish_epic_to_repo_requires_write_scope(env)` *(async function)*
 
 ### `tests/integration/test_mcp_reminders.py`
 
@@ -1605,6 +1655,18 @@ tests/
 - `test_handle_dispatch_sends_workspace_write_for_a_write_mode_task(tmp_path)` *(async function)*
 - `test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_path)` *(async function)* — "A write-mode task still only gets `read-only` when this executor's own"
 
+### `tests/unit/test_agent_service_materialize.py`
+
+> `AgentService._handle_materialize` -- the `ISSUE_MATERIALIZE` handler on
+
+- **`DummyWebSocket`** *(class)*
+  - `__init__(self)` *(method)*
+  - `send(self, payload)` *(async method)*
+- `test_materialize_writes_files_and_reports_success(tmp_path)` *(async function)* — "Positive control for the three failure-mode tests below."
+- `test_materialize_for_an_unknown_project_reports_a_typed_error(tmp_path)` *(async function)*
+- `test_materialize_with_a_malformed_payload_reports_a_typed_error(tmp_path)` *(async function)*
+- `test_materialize_republish_with_a_missing_existing_path_reports_a_typed_error(tmp_path)` *(async function)*
+
 ### `tests/unit/test_apply_migrations.py`
 
 > The migration runner, exercised against real throwaway databases.
@@ -1787,6 +1849,30 @@ tests/
 - `test_a_prefix_of_a_longer_number_is_not_matched(tmp_path)` — "Globbing "65-*" must not accidentally match a "650-..." folder."
 - `test_build_task_instruction_without_an_issue_has_no_untrusted_block()`
 - `test_build_task_instruction_separates_operator_words_from_issue_content()`
+
+### `tests/unit/test_issue_materialize.py`
+
+> `materialize_epic` and the shared numbering scanner -- issue #78, Commit 2c.
+
+- `test_list_used_issue_numbers_covers_all_three_layouts(tmp_path)`
+- `test_list_used_issue_numbers_empty_when_docs_issues_missing(tmp_path)`
+- `test_materialize_epic_allocates_the_next_free_number(tmp_path)`
+- `test_allocate_dir_retries_past_a_real_collision(tmp_path)` — "Direct test of the atomic-creation retry loop itself -- the exact"
+- `test_allocate_file_retries_past_a_real_collision(tmp_path)` — "Same mechanism, for an issue file -- `os.open(..., O_CREAT|O_EXCL)`"
+- `test_materialize_epic_survives_a_numbering_race_end_to_end(tmp_path, monkeypatch)` — "`materialize_epic` wired end-to-end against a numbering scan that"
+- `test_materialize_epic_refuses_a_traversing_existing_path(tmp_path)`
+- `test_materialize_epic_refuses_a_missing_existing_path(tmp_path)`
+- `test_materialize_epic_republish_updates_in_place_and_adds_new_issues(tmp_path)`
+
+### `tests/unit/test_issue_render.py`
+
+> `render_epic_markdown` -- issue #78, Commit 2a.
+
+- `test_epic_directory_slug_bakes_title_and_status_suffix_together()`
+- `test_issue_relative_key_embeds_the_issue_id_as_a_correlation_segment()`
+- `test_render_epic_markdown_exact_bytes_for_epic_and_two_issues()`
+- `test_render_epic_markdown_with_no_issues_and_no_description()`
+- `test_render_epic_markdown_is_deterministic_regardless_of_input_order()`
 
 ### `tests/unit/test_main_import.py`
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -24,10 +24,30 @@ Ferramentas expostas:
 * `approve_codex_task`
 * `list_recent_tasks`
 * `start_development_task`
+* `create_epic`
+* `list_epics`
+* `update_epic`
+* `create_issue`
+* `list_issues`
+* `update_issue`
+* `move_issue_to_epic`
+* `publish_epic_to_repo`
 * `create_reminder`
 * `cancel_reminder`
 
-São 14 ferramentas. `create_reminder`/`cancel_reminder` (issue #71) escrevem
+`publish_epic_to_repo` (issue #78, WK-20260902-issue-materialize) materializa
+uma épica e suas issues (`EpicModel`/`IssueModel`, já expostas por
+`create_epic`/`list_epics`/`create_issue`/`list_issues`) como arquivos
+markdown versionados em `docs/issues/` do repositório do PRÓPRIO projeto —
+inclusive um projeto nunca publicado em nenhum forge. Requer um executor
+conectado que autorize o projeto da épica: sem um, falha com erro tipado
+(`project_not_onboarded`/`executor_not_connected`), nunca enfileira
+silenciosamente. `gateway/app/services/issue_render.py:render_epic_markdown`
+é uma função pura — sem I/O, sem LLM — que decide os bytes de cada arquivo
+antes de qualquer coisa cruzar para o executor; ver `## Materialização de
+épicas` abaixo para o fluxo completo sobre o canal reverso.
+
+São 22 ferramentas. `create_reminder`/`cancel_reminder` (issue #71) escrevem
 no Google Calendar do operador, não em `tasks` — nada a ver com execução de
 código. Exigem escopo `codexbridge.reminders.write` e ficam desligadas com
 erro acionável (nunca 500) quando `CODEX_BRIDGE_GOOGLE_CALENDAR_ID` ou
@@ -95,9 +115,53 @@ Mensagens (`AgentMessageType` em `shared/protocol.py`):
 * `task.restart`
 * `task.cancelled`
 * `error`
+* `issue.materialize`
+* `issue.materialize_result`
 
 Não existe mensagem `task.progress`. O progresso é inferido pelo fluxo de
 `task.log`, cada uma com `offset` incremental.
+
+## Materialização de épicas
+
+`issue.materialize`/`issue.materialize_result` (issue #78,
+WK-20260902-issue-materialize) são o par que `publish_epic_to_repo` usa —
+**fire-and-forget, no mesmo padrão de `task.dispatch`**, mas sem
+`TaskModel` por trás: não há fila nem vaga de concorrência a liberar, e "sem
+executor conectado" já é recusado de forma síncrona pela própria tool (ver
+`## MCP externo` acima), nunca despachado depois.
+
+1. O gateway renderiza os arquivos com `issue_render.render_epic_markdown`
+   (função pura — dado o mesmo `EpicModel`/lista de `IssueModel`, sempre os
+   mesmos bytes) e envia `issue.materialize` com o payload de
+   `MaterializeRequest` (`shared/protocol.py`): `epic_id`, `project_id`,
+   `slug` (o componente `<epic-slug>-[<status>]` do nome da pasta, sem o
+   `NNN`), `files` (caminho relativo à pasta da épica → conteúdo),
+   `existing_path` (não nulo numa republicação), `epic_revision`/
+   `issue_revisions` (a `revision` de cada linha no instante da renderização)
+   e o bloco `delivery` opcional (reaproveita `DeliveryRequest`/
+   `PUSHABLE_BRANCH_PATTERN`, mesmo mecanismo de `SubmitTaskRequest.delivery`).
+2. As chaves de `files` para issues carregam o id da issue como segmento do
+   caminho (`issues/<issue_id>/<slug>-[<status>].md`) — um token de
+   correlação consumido pelo executor e nunca escrito em disco (ver
+   `agent/codex_bridge_agent/issue_materialize.py`), porque `NNN` não é
+   escolhido nem aqui nem no gateway (próximo item).
+3. O EXECUTOR escolhe todo `NNN` — a mesma fronteira que `docs:NNN`/`NNN`
+   já respeita do lado da leitura (`## MCP externo`, `start_development_task`):
+   o gateway nunca aprende o path real do projeto (`docs/architecture.md`).
+   Numeração é um pool único compartilhado entre a pasta da épica e cada
+   arquivo de issue (e qualquer outra épica/issue já no disco); corrida de
+   numeração é resolvida por criação atômica (`mkdir`/`O_CREAT|O_EXCL`) com
+   nova tentativa no próximo número livre.
+4. O executor responde `issue.materialize_result`: `{epic_id, ok, epic_path,
+   epic_revision, written_paths, issue_revisions}` no sucesso (`written_paths`
+   ecoa as MESMAS chaves de `files`, resolvidas para o caminho final relativo
+   ao projeto — inclusive `README.md`/`epic.md`, sem segmento de id); ou
+   `{epic_id, ok: false, error}` na falha, nunca uma exceção crua.
+5. `gateway/app/main.py:handle_issue_materialize_result` grava
+   `materialized_path`/`materialized_revision` na épica e, para cada chave de
+   `written_paths` prefixada por `issues/`, na issue cujo id está embutido no
+   segundo segmento do caminho — sem re-derivar a correspondência a partir da
+   lista atual de issues (que pode ter mudado entre o pedido e a resposta).
 
 Campos comuns:
 

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -239,6 +239,19 @@ EPICS_LINK_ISSUE = Action(
     summary="Attach an issue to an epic.",
 )
 
+# Issue #78, WK-20260902-issue-materialize: dispatches a write to the
+# PROJECT's own repository (via a connected executor), not just this
+# gateway's database -- still classified OPERATIONAL, same scope as every
+# other epic/issue write, because the authority being exercised is the same
+# "change this project's plan" one; it is the DESTINATION that is new, not
+# the permission.
+EPICS_PUBLISH = Action(
+    name="epics.publish",
+    category=OPERATIONAL,
+    scope=ISSUES_WRITE_SCOPE,
+    summary="Materialize an epic and its issues as versioned files in the project's own repository.",
+)
+
 CONVERSATIONS_READ = Action(
     name="conversations.read",
     category=READ,
@@ -283,6 +296,7 @@ CATALOGUE: tuple[Action, ...] = (
     ISSUES_CREATE,
     ISSUES_UPDATE,
     EPICS_LINK_ISSUE,
+    EPICS_PUBLISH,
     CONVERSATIONS_CREATE,
     CONVERSATIONS_POST_MESSAGE,
     SESSIONS_READ_ALL_PROJECTS,

--- a/gateway/app/db/schema_guard.py
+++ b/gateway/app/db/schema_guard.py
@@ -77,6 +77,20 @@ REQUIRED_COLUMNS: dict[str, dict[str, str]] = {
     "executors": {
         "node_id": "0009_control_plane.sql",
     },
+    # Without these, a gateway upgraded past 0011 without running it starts
+    # fine (both columns are nullable, so `create_all` on a FRESH database
+    # already includes them) but every existing install fails the moment
+    # `publish_epic_to_repo`/`apply_epic_materialization` tries to write a
+    # column that is not there yet -- the same "fresh install fine, upgrade
+    # broken" shape this whole module exists to catch early.
+    "epics": {
+        "materialized_path": "0011_issue_materialization.sql",
+        "materialized_revision": "0011_issue_materialization.sql",
+    },
+    "issues": {
+        "materialized_path": "0011_issue_materialization.sql",
+        "materialized_revision": "0011_issue_materialization.sql",
+    },
 }
 
 

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -720,6 +720,57 @@ async def handle_task_cancelled(session: AsyncSession, envelope: AgentEnvelope) 
     await hub.mark_task_finished(envelope.executor_id, task_id)
 
 
+async def handle_issue_materialize_result(session: AsyncSession, envelope: AgentEnvelope) -> None:
+    """Handles one `issue.materialize_result` from the `/agent/ws` message loop.
+
+    Issue #78, Commit 2. Unlike `TASK_RESULT`, there is no `TaskModel` row
+    behind this message and no executor concurrency slot to release
+    (`publish_epic_to_repo`, `gateway/app/mcp/server.py`, sent this directly
+    via `hub.send`) -- only `store.apply_epic_materialization` to run on
+    success, or an audit event on a typed failure. Standalone for the same
+    reason `handle_task_cancelled` is: directly testable against a
+    constructed envelope, without driving a real websocket through it.
+    """
+    payload = envelope.payload
+    epic_id = payload.get("epic_id")
+    if epic_id is None:
+        logging.getLogger(__name__).warning(
+            "issue.materialize_result with no epic_id from executor %s", envelope.executor_id
+        )
+        return
+
+    if not payload.get("ok", False):
+        await record_event(
+            session, "epic", epic_id, "epic.materialize_failed",
+            {"executor_id": envelope.executor_id, "error": payload.get("error")},
+        )
+        await session.commit()
+        return
+
+    epic = await store.apply_epic_materialization(
+        session,
+        epic_id=epic_id,
+        epic_path=payload["epic_path"],
+        epic_revision=int(payload["epic_revision"]),
+        written_paths=payload.get("written_paths", {}),
+        issue_revisions=payload.get("issue_revisions", {}),
+    )
+    if epic is None:
+        logging.getLogger(__name__).warning(
+            "issue.materialize_result for unknown epic %s from executor %s", epic_id, envelope.executor_id
+        )
+        return
+    await record_event(
+        session, "epic", epic_id, "epic.materialized",
+        {
+            "executor_id": envelope.executor_id,
+            "epic_path": payload["epic_path"],
+            "file_count": len(payload.get("written_paths", {})),
+        },
+    )
+    await session.commit()
+
+
 @app.websocket("/agent/ws")
 async def agent_ws(
     websocket: WebSocket,
@@ -810,5 +861,7 @@ async def agent_ws(
                     await notify_task_finished(session, task, settings)
                 elif envelope.type == AgentMessageType.TASK_CANCELLED:
                     await handle_task_cancelled(session, envelope)
+                elif envelope.type == AgentMessageType.ISSUE_MATERIALIZE_RESULT:
+                    await handle_issue_materialize_result(session, envelope)
     except WebSocketDisconnect:
         await hub.unregister(executor_id)

--- a/gateway/app/mcp/server.py
+++ b/gateway/app/mcp/server.py
@@ -13,6 +13,7 @@ from gateway.app.models.entities import ExecutorModel, IssueModel
 from gateway.app.services import store
 from gateway.app.services.agent_hub import AgentHub, hub_envelope
 from gateway.app.services.audit import record_event
+from gateway.app.services.issue_render import render_epic_markdown, epic_directory_slug
 from gateway.app.services.issue_types import IssuePlanningError
 from gateway.app.mcp.tools import tool_definitions
 from gateway.app.core.users import AuthenticatedPrincipal
@@ -25,6 +26,7 @@ from shared.protocol import (
     DeliveryRequest,
     IMPLEMENTED_ENGINES,
     ISSUE_REF_PATTERN,
+    MaterializeRequest,
     PUSHABLE_BRANCH_PATTERN,
     STOPPABLE_TASK_STATES,
     SubmitTaskRequest,
@@ -1014,6 +1016,117 @@ async def handle_mcp_call(
         if claim is not None:
             await complete_idempotent(endpoint, idempotency_key, claim, 200, payload, request_fingerprint)
         result = _text_result(f"Issue {updated.id} moved to epic {updated.epic_id}.", payload)
+    elif tool_name == "publish_epic_to_repo":
+        # Issue #78, WK-20260902-issue-materialize / Commit 2d. Bridges an
+        # `EpicModel`/`IssueModel` planned in ChatGPT (A1/A2's tools) into a
+        # versioned file in the PROJECT's own repository. `render_epic_
+        # markdown` is a pure function (`gateway/app/services/issue_render.py`)
+        # -- everything that decides bytes-on-disk happens here, synchronously,
+        # against exactly the row a human already approved in this
+        # conversation. What crosses the wire to the executor is that already-
+        # rendered content, never a second instruction telling an LLM to
+        # "write this file" -- see that module's docstring for why a
+        # `submit_codex_task` detour would be the wrong tool.
+        require_action(permissions.EPICS_PUBLISH)
+        epic_id = str(arguments["epic_id"])
+        epic = await store.get_epic(session, epic_id)
+        if epic is None or not principal.can_access_project(epic.project_id):
+            raise HTTPException(status_code=404, detail="unknown_epic")
+
+        issue_rows = await store.list_issues_page(
+            session, project_id=epic.project_id, epic_id=epic.id, limit=1000
+        )
+
+        executor_id = arguments.get("executor_id")
+        if executor_id:
+            executor = await session.get(ExecutorModel, executor_id)
+            if executor is None:
+                raise HTTPException(status_code=404, detail="unknown_executor")
+            allowed_projects = json.loads(executor.metadata_json).get("allowed_projects", [])
+            if epic.project_id not in allowed_projects:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"project_not_onboarded: executor {executor_id!r} does not allow project "
+                        f"{epic.project_id!r}. Register it in both /etc/codex-bridge/registry.json "
+                        "(on the gateway host) and the executor's allowed-projects.json, then "
+                        "restart both processes."
+                    ),
+                )
+            if not hub.is_connected(executor_id):
+                # Never a silently queued write: the operator asked for a file
+                # to land in git NOW, and a fire-and-forget dispatch to an
+                # offline executor would report success while nothing
+                # happened. See `AgentMessageType.ISSUE_MATERIALIZE`'s own
+                # docstring (shared/protocol.py).
+                raise HTTPException(
+                    status_code=409, detail=f"executor_not_connected: executor {executor_id!r} is not connected right now."
+                )
+        else:
+            onboarded = await store.executors_allowing_project(session, epic.project_id)
+            if not onboarded:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"project_not_onboarded: no executor allows project {epic.project_id!r}. "
+                        "Register it in both /etc/codex-bridge/registry.json (on the gateway host) "
+                        "and the executor's allowed-projects.json, then restart both processes."
+                    ),
+                )
+            connected = [item for item in onboarded if hub.is_connected(item.id)]
+            if not connected:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"executor_not_connected: no connected executor allows project {epic.project_id!r}.",
+                )
+            executor_id = connected[0].id
+
+        branch = arguments.get("branch")
+        allow_push = bool(arguments.get("allow_push", False))
+        if allow_push and not branch:
+            raise HTTPException(status_code=400, detail="branch_required_for_push")
+        delivery = None
+        if branch:
+            if allow_push:
+                require_scope("codexbridge.task.approve")
+                if principal is not None and not (principal.can_approve_sensitive or principal.is_admin()):
+                    raise HTTPException(status_code=403, detail="approval_not_allowed")
+                if not PUSHABLE_BRANCH_PATTERN.match(branch):
+                    raise HTTPException(status_code=400, detail="branch_not_pushable")
+            delivery = DeliveryRequest(
+                branch=branch,
+                allow_push=allow_push,
+                base_branch=arguments.get("base_branch", "development"),
+                commit_subject=arguments.get("commit_subject"),
+            )
+
+        files = render_epic_markdown(epic, issue_rows)
+        materialize_request = MaterializeRequest(
+            epic_id=epic.id,
+            project_id=epic.project_id,
+            slug=epic_directory_slug(epic),
+            files=files,
+            existing_path=epic.materialized_path,
+            epic_revision=epic.revision,
+            issue_revisions={issue.id: issue.revision for issue in issue_rows},
+            delivery=delivery,
+        )
+        await hub.send(
+            executor_id,
+            hub_envelope(executor_id, AgentMessageType.ISSUE_MATERIALIZE.value, materialize_request.model_dump(mode="json")),
+        )
+
+        payload = {
+            "epic_id": epic.id,
+            "executor_id": executor_id,
+            "status": "dispatched",
+            "existing_path": epic.materialized_path,
+            "file_count": len(files),
+        }
+        result = _text_result(
+            f"Materialization of epic {epic.id} ({len(files)} files) dispatched to executor {executor_id}.",
+            payload,
+        )
     elif tool_name == "create_reminder":
         # WK-20260830-chatgpt-entry-provider-and-delivery, issue #71. Runs on
         # the gateway, not the executor -- see google_calendar.py's module

--- a/gateway/app/mcp/server.py
+++ b/gateway/app/mcp/server.py
@@ -707,6 +707,11 @@ async def handle_mcp_call(
             # current revision to fill `expected_revision` with, the same way
             # `ETag` lets a REST caller fill `If-Match`.
             "revision": epic.revision,
+            # Additive, WK-20260902-issue-materialize (issue #78, Commit 1):
+            # null until `publish_epic_to_repo` succeeds -- lets the operator
+            # tell "drafted, not in git yet" apart from "published".
+            "materialized_path": epic.materialized_path,
+            "materialized_revision": epic.materialized_revision,
         }
         if claim is not None:
             await complete_idempotent(endpoint, idempotency_key, claim, 201, payload, request_fingerprint)
@@ -729,6 +734,8 @@ async def handle_mcp_call(
                     "description": epic.description,
                     "status": epic.status,
                     "revision": epic.revision,
+                    "materialized_path": epic.materialized_path,
+                    "materialized_revision": epic.materialized_revision,
                 }
                 for epic in rows
             ],
@@ -775,6 +782,8 @@ async def handle_mcp_call(
             "description": updated.description,
             "status": updated.status,
             "revision": updated.revision,
+            "materialized_path": updated.materialized_path,
+            "materialized_revision": updated.materialized_revision,
         }
         result = _text_result(f"Epic {updated.id} updated.", payload)
     elif tool_name == "create_issue":
@@ -850,6 +859,9 @@ async def handle_mcp_call(
             # Additive since A1, same reason as create_epic's: `update_issue`
             # and `move_issue_to_epic` need it for `expected_revision`.
             "revision": issue.revision,
+            # Additive, WK-20260902-issue-materialize (issue #78, Commit 1).
+            "materialized_path": issue.materialized_path,
+            "materialized_revision": issue.materialized_revision,
         }
         if claim is not None:
             await complete_idempotent(endpoint, idempotency_key, claim, 201, payload, request_fingerprint)
@@ -886,6 +898,8 @@ async def handle_mcp_call(
                     "dependencies": json.loads(issue.dependencies_json or "[]"),
                     "blocked_reason": issue.blocked_reason,
                     "revision": issue.revision,
+                    "materialized_path": issue.materialized_path,
+                    "materialized_revision": issue.materialized_revision,
                 }
                 for issue in rows
             ],
@@ -935,6 +949,8 @@ async def handle_mcp_call(
             "dependencies": json.loads(updated.dependencies_json or "[]"),
             "blocked_reason": updated.blocked_reason,
             "revision": updated.revision,
+            "materialized_path": updated.materialized_path,
+            "materialized_revision": updated.materialized_revision,
         }
         result = _text_result(f"Issue {updated.id} updated.", payload)
     elif tool_name == "move_issue_to_epic":
@@ -992,6 +1008,8 @@ async def handle_mcp_call(
             "project_id": updated.project_id,
             "epic_id": updated.epic_id,
             "revision": updated.revision,
+            "materialized_path": updated.materialized_path,
+            "materialized_revision": updated.materialized_revision,
         }
         if claim is not None:
             await complete_idempotent(endpoint, idempotency_key, claim, 200, payload, request_fingerprint)

--- a/gateway/app/mcp/tools.py
+++ b/gateway/app/mcp/tools.py
@@ -421,6 +421,40 @@ def tool_definitions() -> list[dict[str, Any]]:
             },
         },
         {
+            "name": "publish_epic_to_repo",
+            "title": "Publish epic to repo",
+            "description": (
+                "Materializa uma epica e suas issues como arquivos markdown versionados no "
+                "repositorio do proprio projeto (docs/issues/), via um executor conectado. Sem "
+                "executor conectado autorizado para o projeto da epica, falha com erro tipado -- "
+                "nunca enfileira silenciosamente. Republicar (a epica ja tem materialized_path) "
+                "atualiza a pasta existente em vez de criar outra."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "epic_id": {"type": "string", "description": "id da epica (retornado por create_epic ou list_epics)."},
+                    "executor_id": {
+                        "type": "string",
+                        "description": "Omitido: escolhido automaticamente entre os executores conectados que autorizam o projeto da epica.",
+                    },
+                    "branch": {
+                        "type": "string",
+                        "description": "Branch de entrega para o commit (ex 'development'). Obrigatorio se allow_push=true.",
+                    },
+                    "allow_push": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Pre-autoriza commit e push nessa branch depois de escrever os arquivos. Exige escopo de aprovacao.",
+                    },
+                    "base_branch": {"type": "string", "default": "development"},
+                    "commit_subject": {"type": "string", "maxLength": 200},
+                },
+                "required": ["epic_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
             "name": "create_reminder",
             "title": "Create reminder",
             "description": (

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -271,6 +271,18 @@ class EpicModel(Base):
     # TaskModel.revision: the ETag optimistic-concurrency check compares
     # against this, not against a timestamp.
     revision: Mapped[int] = mapped_column(Integer, default=1, server_default="1")
+    # WK-20260902-issue-materialize / issue #78, Commit 1. Set only by
+    # `store.apply_epic_materialization`, once the executor confirms it wrote
+    # this epic's markdown -- never guessed or defaulted by the gateway,
+    # which does not know the project's real filesystem layout
+    # (`docs/architecture.md`). `materialized_path` is relative to the
+    # project root, as the executor reported it.
+    # `materialized_revision` is a COPY of `revision` as of that publish, not
+    # the current value -- comparing the two at read time is what lets an
+    # operator distinguish "never published" (`materialized_path IS NULL`)
+    # from "published, N edits ago".
+    materialized_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    materialized_revision: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class IssueModel(Base):
@@ -301,6 +313,11 @@ class IssueModel(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     revision: Mapped[int] = mapped_column(Integer, default=1, server_default="1")
+    # WK-20260902-issue-materialize / issue #78, Commit 1. Same meaning as
+    # `EpicModel.materialized_path`/`materialized_revision` above -- see that
+    # pair's comment for why these are not `provider`/`external_id`.
+    materialized_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    materialized_revision: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class ConversationModel(Base):

--- a/gateway/app/services/issue_render.py
+++ b/gateway/app/services/issue_render.py
@@ -1,0 +1,189 @@
+"""Pure markdown renderer for epic materialization -- issue #78, Commit 2a.
+
+`render_epic_markdown` turns an `EpicModel` and its `IssueModel`s into the
+exact bytes `publish_epic_to_repo` (`gateway/app/mcp/server.py`) hands the
+executor to write. It does no I/O, calls no LLM, and is fully deterministic:
+the same epic/issues in produce the same dict of relative-path -> content
+out, byte for byte -- see `tests/unit/test_issue_render.py`, which asserts
+exact strings rather than "looks about right". That determinism is the whole
+point (see `.docs/agents/issue-automation.md`'s own template, reproduced
+below): a human approved specific content in ChatGPT, and what lands in git
+must be that content, not a paraphrase an LLM produced on a second pass.
+
+Canonical layout (`.docs/issues/README.md`, `docs/issues/063-.../` in this
+repo for a worked example)::
+
+    docs/issues/NNN-<epic-slug>-[<status>]/README.md
+    docs/issues/NNN-<epic-slug>-[<status>]/epic.md
+    docs/issues/NNN-<epic-slug>-[<status>]/issues/NNN-<task-slug>-[<status>].md
+
+Every `NNN` above is chosen by the EXECUTOR
+(`agent/codex_bridge_agent/issue_materialize.py`), never here: this module
+has no filesystem to scan, and the gateway never learns a project's real path
+(`docs/architecture.md`) -- the same boundary `resolve_issue_text` already
+respects on the read side. So the paths this function returns are relative
+to the epic's own directory and carry NO `NNN` prefix anywhere:
+
+    "README.md"
+    "epic.md"
+    "issues/<issue_id>/<task-slug>-[<status>].md"
+
+The per-issue key's `<issue_id>/` segment is a correlation token, not a real
+directory -- `MaterializeRequest.files` (`shared/protocol.py`) is a bare
+`dict[str, str]`, so there is nowhere else to carry "which `IssueModel` does
+this file belong to" through the round trip to
+`AgentMessageType.ISSUE_MATERIALIZE_RESULT`, which may arrive long after
+this gateway process forgot the request (a restart in between is fine).
+`agent/codex_bridge_agent/issue_materialize.py` strips that segment before
+choosing the real, numbered filename; `store.apply_epic_materialization`
+parses the same id back out of the RESULT's echoed keys.
+
+Status vocabulary mapping (`gateway/app/services/issue_types.py`'s
+`EPIC_STATUSES`/`ISSUE_STATUSES` are NOT the same set as the file-status
+suffixes `.docs/agents/issue-automation.md` allows -- `[draft] [ready]
+[started] [blocked] [review] [finished] [cancelled]` -- so the mapping below
+is explicit rather than assumed):
+
+    epic status       -> file suffix       issue status   -> file suffix
+    ----------------------------------     --------------------------------
+    open               -> ready             open           -> ready
+    in_progress         -> started          in_progress    -> started
+    done                -> finished         blocked        -> blocked
+    cancelled           -> cancelled        in_review      -> review
+                                             done           -> finished
+                                             cancelled      -> cancelled
+
+`draft` is deliberately unreachable from either vocabulary: nothing in this
+gateway's database means "not yet approved for a repo" (an epic/issue this
+gateway holds is, by definition, already a real planning row) -- `draft` is
+reserved for a status a human assigns by renaming the file after
+materialization, per `.docs/issues/README.md`'s "status changes must be
+performed by rename." An epic/issue status this module has never seen (a
+future value added to the vocabulary without updating this mapping) falls
+back to `draft` rather than raising, so a schema-level status addition fails
+loud in review (a new value renders as `[draft]` for every epic, which looks
+wrong immediately) instead of blowing up publication for every existing
+epic.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from gateway.app.models.entities import EpicModel, IssueModel
+
+
+EPIC_STATUS_SUFFIX: dict[str, str] = {
+    "open": "ready",
+    "in_progress": "started",
+    "done": "finished",
+    "cancelled": "cancelled",
+}
+
+ISSUE_STATUS_SUFFIX: dict[str, str] = {
+    "open": "ready",
+    "in_progress": "started",
+    "blocked": "blocked",
+    "in_review": "review",
+    "done": "finished",
+    "cancelled": "cancelled",
+}
+
+_DEFAULT_SUFFIX = "draft"
+
+_SLUG_STRIP = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    slug = _SLUG_STRIP.sub("-", text.strip().lower()).strip("-")
+    return slug or "untitled"
+
+
+def epic_directory_slug(epic: EpicModel) -> str:
+    """The `<epic-slug>-[<status>]` component of the epic's directory name.
+
+    No `NNN-` prefix -- the executor chooses that (see the module docstring).
+    `publish_epic_to_repo` (`gateway/app/mcp/server.py`) passes this straight
+    through as `MaterializeRequest.slug`, so this is the ONE place that
+    string is built; nothing recomputes it independently.
+    """
+    suffix = EPIC_STATUS_SUFFIX.get(epic.status, _DEFAULT_SUFFIX)
+    return f"{_slugify(epic.title)}-[{suffix}]"
+
+
+def issue_relative_key(issue: IssueModel) -> str:
+    """The `issues/<issue_id>/<task-slug>-[<status>].md` key for one issue.
+
+    Shared by `render_epic_markdown` (building `files`) so the key a caller
+    sees in the returned dict is always exactly this shape -- there is no
+    second place that assembles it.
+    """
+    suffix = ISSUE_STATUS_SUFFIX.get(issue.status, _DEFAULT_SUFFIX)
+    return f"issues/{issue.id}/{_slugify(issue.title)}-[{suffix}].md"
+
+
+def _render_readme(epic: EpicModel, ordered_issues: list[IssueModel]) -> str:
+    lines = [f"# Epic — {epic.title}", ""]
+    if epic.description:
+        lines += [epic.description, ""]
+    lines += ["## Issues", "", "| Title | Status | Priority |", "| --- | --- | --- |"]
+    for issue in ordered_issues:
+        lines.append(f"| {issue.title} | {issue.status} | {issue.priority} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_epic_body(epic: EpicModel) -> str:
+    suffix = EPIC_STATUS_SUFFIX.get(epic.status, _DEFAULT_SUFFIX)
+    lines = [
+        f"# {epic.title}",
+        "",
+        f"Status: `{epic.status}` (materialized as `[{suffix}]`)",
+    ]
+    if epic.description:
+        lines += ["", epic.description]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_issue_body(issue: IssueModel) -> str:
+    suffix = ISSUE_STATUS_SUFFIX.get(issue.status, _DEFAULT_SUFFIX)
+    lines = [
+        f"# {issue.title}",
+        "",
+        f"Status: `{issue.status}` (materialized as `[{suffix}]`) · Priority: `{issue.priority}`",
+    ]
+    if issue.description:
+        lines += ["", issue.description]
+    labels = json.loads(issue.labels_json or "[]")
+    if labels:
+        lines += ["", "## Labels", ""]
+        lines += [f"- {label}" for label in labels]
+    dependencies = json.loads(issue.dependencies_json or "[]")
+    if dependencies:
+        lines += ["", "## Dependencies", ""]
+        lines += [f"- {dep}" for dep in dependencies]
+    if issue.blocked_reason:
+        lines += ["", "## Blocked reason", "", issue.blocked_reason]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_epic_markdown(epic: EpicModel, issues: list[IssueModel]) -> dict[str, str]:
+    """Relative path -> content, for every file one epic materializes to.
+
+    Pure: no I/O, no LLM, deterministic given `epic`/`issues`. `issues` is
+    sorted by `(created_at, id)` here so the README table and the set of
+    `issues/...` keys are stable across two calls with the same input in a
+    different order (a caller that re-fetched from the database with no
+    explicit `ORDER BY` must not see the output shuffle).
+    """
+    ordered_issues = sorted(issues, key=lambda issue: (issue.created_at, issue.id))
+    files: dict[str, str] = {
+        "README.md": _render_readme(epic, ordered_issues),
+        "epic.md": _render_epic_body(epic),
+    }
+    for issue in ordered_issues:
+        files[issue_relative_key(issue)] = _render_issue_body(issue)
+    return files

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -1881,6 +1881,64 @@ async def link_issue_to_epic(
     return issue
 
 
+async def apply_epic_materialization(
+    session: AsyncSession,
+    *,
+    epic_id: str,
+    epic_path: str,
+    epic_revision: int,
+    written_paths: dict[str, str],
+    issue_revisions: dict[str, int],
+) -> EpicModel | None:
+    """Records a successful `ISSUE_MATERIALIZE_RESULT` -- issue #78, Commit 2.
+
+    Called from `gateway/app/main.py`'s `/agent/ws` loop, the same place
+    `store_result` records a `TASK_RESULT`. `epic_path`/`epic_revision` and
+    each entry of `written_paths`/`issue_revisions` come from the EXECUTOR's
+    own report, never invented here -- this function only writes what it was
+    told, the same posture `store_result` already has toward a task's
+    outcome.
+
+    `written_paths` covers EVERY file the executor wrote (`README.md` and
+    `epic.md` included, at their bare keys) -- only the entries shaped
+    `"issues/<issue_id>/<rest>"` (`gateway/app/services/issue_render.py`'s
+    correlation-token convention, stripped and rewritten by
+    `agent/codex_bridge_agent/issue_materialize.py` before the file was
+    actually written) name an `IssueModel`; every other key is skipped below.
+    The `<issue_id>` segment is parsed back out of the key rather than
+    re-derived from the current issue list, which would be wrong if an issue
+    was added, removed, or retitled between the original
+    `publish_epic_to_repo` call and this (possibly much later, possibly
+    post-restart) result.
+
+    Returns `None`, without raising, for an epic that no longer exists (e.g.
+    deleted between dispatch and result) -- there is nothing to record and no
+    caller waiting synchronously on this, so a typed failure has no audience;
+    logging that case is the caller's job, mirroring how `handle_task_ack`
+    logs rather than raises on an unresolvable reference.
+    """
+    epic = await session.get(EpicModel, epic_id)
+    if epic is None:
+        return None
+    epic.materialized_path = epic_path
+    epic.materialized_revision = epic_revision
+
+    for key, final_path in written_paths.items():
+        if not key.startswith("issues/"):
+            continue
+        issue_id = key[len("issues/"):].split("/", 1)[0]
+        issue = await session.get(IssueModel, issue_id)
+        if issue is None:
+            continue
+        issue.materialized_path = final_path
+        if issue_id in issue_revisions:
+            issue.materialized_revision = issue_revisions[issue_id]
+
+    await session.commit()
+    await session.refresh(epic)
+    return epic
+
+
 # --------------------------------------------------------------------------
 # Conversations (issue #10) — contextual threads linked to product entities.
 # See gateway/app/services/conversation_types.py for the closed vocabulary of

--- a/migrations/0011_issue_materialization.sql
+++ b/migrations/0011_issue_materialization.sql
@@ -1,0 +1,45 @@
+-- WK-20260902-issue-materialize / issue #78, Commit 1 of 2
+--
+-- Today an epic/issue planned in ChatGPT (over the MCP tools A1/A2 added)
+-- lives only as `EpicModel`/`IssueModel` rows in this gateway's own database.
+-- The operator's actual deliverable -- a versioned markdown file under the
+-- PROJECT's own `docs/issues/` -- is a second, disconnected concept: the
+-- executor already resolves `docs:NNN`/bare-`NNN` issue references by
+-- globbing that directory (`agent/codex_bridge_agent/instructions.py`), but
+-- nothing writes to it. This migration adds the two columns that let the
+-- gateway remember, for a row it owns, what got published and how stale that
+-- publication might be -- nothing about writing the file itself, which is
+-- Commit 2 of this same work_id.
+--
+-- `materialized_path` is the file/folder path the EXECUTOR reported after
+-- writing it (relative to the project root), never a path the gateway
+-- invents: the gateway does not know a project's real filesystem layout
+-- (`docs/architecture.md`), and this column is deliberately no exception.
+--
+-- `materialized_revision` is a copy of the row's own `revision` column AS OF
+-- the moment it was published -- not a git commit count, not the CURRENT
+-- `revision`. Comparing the two at read time is what lets an operator tell
+-- "drafted, never published" (`materialized_path IS NULL`) apart from
+-- "published, N edits ago" (`revision - materialized_revision = N`) without
+-- this migration inventing a third, redundant timestamp.
+--
+-- Deliberately NOT `provider`/`external_id`: those two columns are the seam
+-- another track of this same orchestration is building a forge (GitHub)
+-- integration on top of. Overloading them for "written to this repo's own
+-- working tree" would make a populated `external_id` ambiguous between "this
+-- mirrors a GitHub issue" and "this was materialized as a local file" --
+-- exactly the kind of conflation `docs/control-plane.md` warns against for
+-- the node/project/authorization split, one layer up.
+--
+-- Portability: plain `alter table ... add column`, no default expression
+-- needed (both columns are nullable, absent = "never published"). Style
+-- follows 0009 (comment explaining why each column exists, ALTER statements
+-- first because SQLite does not roll back DDL on a later failure).
+--
+-- Apply with `python3 scripts/apply_migrations.py`.
+
+alter table epics add column materialized_path varchar(1024);
+alter table epics add column materialized_revision integer;
+
+alter table issues add column materialized_path varchar(1024);
+alter table issues add column materialized_revision integer;

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -215,6 +215,17 @@ class AgentMessageType(str, Enum):
     TASK_RESTART = "task.restart"
     TASK_CANCELLED = "task.cancelled"
     ERROR = "error"
+    # WK-20260902-issue-materialize / issue #78, Commit 2b. Fire-and-forget,
+    # like TASK_DISPATCH -- sent directly by `hub.send` from
+    # `publish_epic_to_repo` (`gateway/app/mcp/server.py`), never queued
+    # through a `TaskModel` row: there is no task to await here, and "no
+    # connected executor" is refused synchronously at dispatch time rather
+    # than silently queued (see that tool's own docstring). The executor
+    # writes the files (`agent/codex_bridge_agent/issue_materialize.py`) and
+    # reports back with ISSUE_MATERIALIZE_RESULT, handled the same way
+    # TASK_RESULT is in `gateway/app/main.py`'s `/agent/ws` loop.
+    ISSUE_MATERIALIZE = "issue.materialize"
+    ISSUE_MATERIALIZE_RESULT = "issue.materialize_result"
 
 
 class ApprovalDecision(str, Enum):
@@ -405,6 +416,57 @@ class DeliveryRequest(BaseModel):
     base_branch: str = "development"
     remote: str = "origin"
     commit_subject: str | None = Field(default=None, max_length=200)
+
+
+class MaterializeRequest(BaseModel):
+    """What `ISSUE_MATERIALIZE` asks the executor to write to disk, for one
+
+    epic. WK-20260902-issue-materialize / issue #78, Commit 2b -- the bridge
+    between the `EpicModel`/`IssueModel` rows the MCP tools (A1/A2) let an
+    operator plan in ChatGPT and the versioned `docs/issues/` file a project
+    actually wants, even a project never pushed to any forge.
+
+    `project_id` is the SAME `project_id` every other dispatch payload
+    carries (`AgentHub.dispatch_next`'s own `payload["project_id"]`) -- the
+    executor resolves it through the identical `self.projects` allowlist
+    `_handle_dispatch` already uses, never a path the gateway invented.
+
+    `files` keys are relative to the epic's own directory, built by
+    `gateway.app.services.issue_render.render_epic_markdown` -- see that
+    module's docstring for the exact shape, including the `issues/<issue_id>/`
+    correlation-token convention.
+
+    `slug` is the epic directory's `<epic-slug>-[<status>]` component (see
+    `issue_render.epic_directory_slug`) -- the executor prefixes it with
+    whatever `NNN` it allocates; neither this model nor the gateway ever
+    choose that number (`docs/architecture.md`: the gateway never learns a
+    project's real path, and numbering requires listing what is already on
+    disk).
+
+    `existing_path` is set on a republish -- `EpicModel.materialized_path` as
+    it stood before this request -- so the executor updates that directory in
+    place instead of allocating a second one for the same epic.
+
+    `epic_revision`/`issue_revisions` are `EpicModel.revision`/`IssueModel.
+    revision` AS OF THIS REQUEST, opaque to the executor: it echoes them back
+    verbatim in `ISSUE_MATERIALIZE_RESULT` so `store.apply_epic_materialization`
+    can record what was actually published (a revision snapshot the gateway
+    cannot safely re-derive later -- the row may have been edited again by
+    the time the result arrives).
+
+    `delivery` reuses `DeliveryRequest`/`PUSHABLE_BRANCH_PATTERN` unchanged --
+    no new authorization concept for "commit and push the materialized
+    files", the same gate `SubmitTaskRequest.delivery` already enforces.
+    """
+
+    epic_id: str
+    project_id: str
+    slug: str
+    files: dict[str, str]
+    existing_path: str | None = None
+    epic_revision: int
+    issue_revisions: dict[str, int] = Field(default_factory=dict)
+    delivery: DeliveryRequest | None = None
 
 
 class SubmitTaskRequest(BaseModel):

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1051,7 +1051,29 @@ COVERED_ELSEWHERE = {
     # Not an endpoint: it is the admin widening of the two read endpoints.
     "sessions.readAllProjects": "test_the_administrative_action_describes_what_the_list_endpoint_does",
     "missions.readAllProjects": "test_the_administrative_action_describes_what_the_missions_list_endpoint_does",
+    # `epics.publish` (issue #78, WK-20260902-issue-materialize) has no REST
+    # endpoint of its own -- it is `publish_epic_to_repo`, MCP-only, the same
+    # way every other epic/issue tool is exposed over `/mcp` in addition to
+    # (never instead of) REST. `test_module` here is a placeholder name this
+    # module's own `test_each_exemption_names_a_test_that_exists` will refuse
+    # unless the real test module below actually defines it.
+    "epics.publish": "test_epics_publish_is_exercised_over_mcp",
 }
+
+
+def test_epics_publish_is_exercised_over_mcp() -> None:
+    """Not a real assertion -- a pointer so `COVERED_ELSEWHERE`'s own guard
+
+    (`test_each_exemption_names_a_test_that_exists`) has a callable to find.
+    The actual coverage for `epics.publish` is
+    `tests/integration/test_mcp_epics_issues.py::
+    test_publish_epic_to_repo_dispatches_to_a_connected_executor` and its
+    sibling negative-control tests in that file -- MCP-only actions cannot be
+    driven through `ENDPOINT_FOR_ACTION`'s REST `TestClient`, so they are
+    proven in the MCP tool's own test module instead, the same way `epics.
+    read`/`epics.create` are proven twice: once here over REST, once in
+    `test_mcp_epics_issues.py` over MCP -- this action only has the second.
+    """
 
 
 def test_every_catalogued_action_is_exercised_below() -> None:

--- a/tests/integration/test_issue_materialize_result.py
+++ b/tests/integration/test_issue_materialize_result.py
@@ -1,0 +1,180 @@
+"""`issue.materialize_result` handling in the `/agent/ws` message loop --
+
+issue #78, Commit 2. Exercised against `gateway.app.main.handle_issue_materialize_result`
+directly, the same posture `tests/integration/test_agent_ack_handling.py` takes
+for `task.ack` -- see that file's own docstring for why a direct call, not a
+live websocket, is what actually proves the handler ran.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.db.base import Base
+from gateway.app.main import handle_issue_materialize_result
+from gateway.app.models.entities import AuditEventModel
+from gateway.app.services import store
+from shared.protocol import AgentEnvelope, AgentMessageType, ExecutorRegistration, ProjectRegistration
+from sqlalchemy import select
+
+
+@pytest.fixture
+async def factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        await store.upsert_registry(
+            session,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="T1", display_name="T1", machine_token="t",
+                    allowed_projects=["p1"], max_concurrent_tasks=1,
+                )
+            ],
+            projects=[ProjectRegistration(project_id="p1", name="P1", path="/srv/p1", max_timeout_seconds=3600)],
+        )
+    try:
+        yield session_factory
+    finally:
+        await engine.dispose()
+
+
+async def _seed_epic_with_issue(factory) -> tuple[str, str]:
+    async with factory() as session:
+        epic = await store.create_epic(
+            session, project_id="p1", title="Bridge epic", description=None, status=None,
+            actor_user_id="alice", actor_email="alice@example.com",
+        )
+        issue = await store.create_issue(
+            session, project_id="p1", epic_id=epic.id, title="First slice", description=None,
+            status=None, priority=None, labels=None, assignee_user_id=None, assignee_email=None,
+            dependencies=None, blocked_reason=None,
+            actor_user_id="alice", actor_email="alice@example.com",
+        )
+        return epic.id, issue.id
+
+
+def _envelope(payload: dict) -> AgentEnvelope:
+    return AgentEnvelope(
+        message_id=str(uuid4()), executor_id="T1", sent_at=datetime.now(timezone.utc),
+        type=AgentMessageType.ISSUE_MATERIALIZE_RESULT, payload=payload,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_successful_result_records_materialized_path_on_epic_and_issue(factory):
+    """Positive control for the failure/unknown-epic tests below."""
+    epic_id, issue_id = await _seed_epic_with_issue(factory)
+
+    async with factory() as session:
+        epic_before = await store.get_epic(session, epic_id)
+        issue_before = await store.get_issue(session, issue_id)
+
+        await handle_issue_materialize_result(session, _envelope({
+            "epic_id": epic_id,
+            "ok": True,
+            "epic_path": "docs/issues/078-bridge-epic-[ready]",
+            "epic_revision": epic_before.revision,
+            "written_paths": {
+                "README.md": "docs/issues/078-bridge-epic-[ready]/README.md",
+                "epic.md": "docs/issues/078-bridge-epic-[ready]/epic.md",
+                f"issues/{issue_id}/first-slice-[ready].md": "docs/issues/078-bridge-epic-[ready]/issues/079-first-slice-[ready].md",
+            },
+            "issue_revisions": {issue_id: issue_before.revision},
+        }))
+
+    async with factory() as session:
+        epic_after = await store.get_epic(session, epic_id)
+        issue_after = await store.get_issue(session, issue_id)
+
+    assert epic_after.materialized_path == "docs/issues/078-bridge-epic-[ready]"
+    assert epic_after.materialized_revision == epic_before.revision
+    assert issue_after.materialized_path == "docs/issues/078-bridge-epic-[ready]/issues/079-first-slice-[ready].md"
+    assert issue_after.materialized_revision == issue_before.revision
+
+
+@pytest.mark.asyncio
+async def test_a_failed_result_does_not_touch_materialized_path(factory):
+    epic_id, issue_id = await _seed_epic_with_issue(factory)
+
+    async with factory() as session:
+        await handle_issue_materialize_result(session, _envelope({
+            "epic_id": epic_id, "ok": False, "error": "existing_path_not_found",
+        }))
+
+    async with factory() as session:
+        epic_after = await store.get_epic(session, epic_id)
+        result = await session.execute(
+            select(AuditEventModel).where(AuditEventModel.entity_id == epic_id)
+        )
+        events = [row.event_type for row in result.scalars()]
+
+    # Negative control against the positive test above: a failed result never
+    # sets materialized_path.
+    assert epic_after.materialized_path is None
+    assert epic_after.materialized_revision is None
+    assert "epic.materialize_failed" in events
+
+
+@pytest.mark.asyncio
+async def test_a_result_for_an_unknown_epic_does_not_raise(factory):
+    async with factory() as session:
+        # Must not raise -- there is no caller waiting synchronously on this
+        # (see the function's own docstring).
+        await handle_issue_materialize_result(session, _envelope({
+            "epic_id": "does-not-exist",
+            "ok": True,
+            "epic_path": "docs/issues/999-ghost-[ready]",
+            "epic_revision": 1,
+            "written_paths": {},
+            "issue_revisions": {},
+        }))
+
+
+@pytest.mark.asyncio
+async def test_a_result_with_no_epic_id_is_ignored_not_raised(factory):
+    async with factory() as session:
+        await handle_issue_materialize_result(session, _envelope({"ok": True}))
+
+
+# --------------------------------------------------------------------------
+# `store.apply_epic_materialization` directly -- correlation-token parsing.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_epic_materialization_ignores_non_issue_keys_and_unknown_issue_ids(factory):
+    """Positive control: the real issue id updates; two adversarial-ish
+
+    inputs (a non-`issues/`-prefixed key, and an `issues/`-prefixed key
+    naming an issue that does not exist) are silently skipped rather than
+    raising -- an executor report is data, not a query the caller can shape
+    into a crash.
+    """
+    epic_id, issue_id = await _seed_epic_with_issue(factory)
+
+    async with factory() as session:
+        epic = await store.apply_epic_materialization(
+            session,
+            epic_id=epic_id,
+            epic_path="docs/issues/078-bridge-epic-[ready]",
+            epic_revision=1,
+            written_paths={
+                "README.md": "docs/issues/078-bridge-epic-[ready]/README.md",
+                f"issues/{issue_id}/first-slice-[ready].md": "docs/issues/078-bridge-epic-[ready]/issues/079-first-slice-[ready].md",
+                "issues/does-not-exist/ghost.md": "docs/issues/078-bridge-epic-[ready]/issues/080-ghost.md",
+            },
+            issue_revisions={issue_id: 1},
+        )
+    assert epic is not None
+    assert epic.materialized_path == "docs/issues/078-bridge-epic-[ready]"
+
+    async with factory() as session:
+        issue = await store.get_issue(session, issue_id)
+    assert issue.materialized_path == "docs/issues/078-bridge-epic-[ready]/issues/079-first-slice-[ready].md"

--- a/tests/integration/test_mcp_epics_issues.py
+++ b/tests/integration/test_mcp_epics_issues.py
@@ -36,7 +36,7 @@ from gateway.app.db.base import Base
 from gateway.app.db.session import get_session
 from gateway.app.mcp.server import handle_mcp_call
 from gateway.app.services import store
-from shared.protocol import ISSUE_REF_PATTERN, ExecutorRegistration, ProjectRegistration
+from shared.protocol import AgentMessageType, ISSUE_REF_PATTERN, ExecutorRegistration, ProjectRegistration
 
 
 class DummyHub:
@@ -48,6 +48,28 @@ class DummyHub:
 
     async def send(self, executor_id: str, envelope):
         pass
+
+
+class RecordingHub:
+    """A hub with a caller-controlled set of connected executors, recording
+
+    every `send`. Used only by the `publish_epic_to_repo` tests below --
+    every other tool in this file is indifferent to `is_connected`, so the
+    module-wide `DummyHub` (always disconnected) stays the default.
+    """
+
+    def __init__(self, connected: set[str]):
+        self.connected = set(connected)
+        self.sent: list[tuple[str, object]] = []
+
+    def is_connected(self, executor_id: str) -> bool:
+        return executor_id in self.connected
+
+    async def dispatch_next(self, executor_id: str):
+        return None
+
+    async def send(self, executor_id: str, envelope) -> None:
+        self.sent.append((executor_id, envelope))
 
 
 # p1 only, holds codexbridge.issues.write -- the ISSUES_WRITE_SCOPE both
@@ -153,11 +175,11 @@ async def env(users_file, monkeypatch):
     await engine.dispose()
 
 
-async def _call(env, principal, tool_name: str, arguments: dict) -> dict:
+async def _call(env, principal, tool_name: str, arguments: dict, hub=None) -> dict:
     async with env.factory() as session:
         response = await handle_mcp_call(
             {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},
-            session, DummyHub(), principal,
+            session, hub if hub is not None else DummyHub(), principal,
         )
     return response["result"]["structuredContent"]
 
@@ -563,3 +585,117 @@ async def test_a_retried_move_does_not_move_the_issue_twice(env):
 #     not change what create_epic/create_issue's own idempotency tests prove
 #     -- see this module's tests #2/#3 above, left unmodified by this PR.
 # --------------------------------------------------------------------------
+
+
+# --------------------------------------------------------------------------
+# 13. publish_epic_to_repo -- issue #78, WK-20260902-issue-materialize.
+#     Covers `permissions.EPICS_PUBLISH` for
+#     tests/integration/test_auth.py::test_epics_publish_is_exercised_over_mcp.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_epic_to_repo_dispatches_to_a_connected_executor(env):
+    """Positive control for the two `_not_connected`/`_not_onboarded` tests below."""
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Bridge epic"})
+    await _call(env, ALICE, "create_issue", {
+        "project": "p1", "epic_id": epic["epic_id"], "title": "First slice",
+    })
+    assert epic["materialized_path"] is None
+    assert epic["materialized_revision"] is None
+
+    hub = RecordingHub(connected={"T1"})
+    result = await _call(env, ALICE, "publish_epic_to_repo", {"epic_id": epic["epic_id"]}, hub=hub)
+
+    assert result["status"] == "dispatched"
+    assert result["executor_id"] == "T1"
+    assert result["existing_path"] is None
+    assert result["file_count"] == 3  # README.md + epic.md + one issue file
+
+    assert len(hub.sent) == 1
+    sent_executor_id, envelope = hub.sent[0]
+    assert sent_executor_id == "T1"
+    assert envelope.type == AgentMessageType.ISSUE_MATERIALIZE
+    assert envelope.payload["epic_id"] == epic["epic_id"]
+    assert envelope.payload["project_id"] == "p1"
+    assert envelope.payload["existing_path"] is None
+    assert set(envelope.payload["files"]) == {
+        "README.md", "epic.md",
+    } | {k for k in envelope.payload["files"] if k.startswith("issues/")}
+    assert any(k.startswith("issues/") for k in envelope.payload["files"])
+
+
+@pytest.mark.asyncio
+async def test_publish_epic_to_repo_with_no_connected_executor_is_a_typed_error(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Bridge epic"})
+
+    hub = RecordingHub(connected=set())  # T1 allows p1 but is not connected
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "publish_epic_to_repo", {"epic_id": epic["epic_id"]}, hub=hub)
+    assert raised.value.status_code == 409
+    assert raised.value.detail.startswith("executor_not_connected")
+    assert hub.sent == []
+
+
+@pytest.mark.asyncio
+async def test_publish_epic_to_repo_for_a_project_no_executor_allows_is_project_not_onboarded(env):
+    # p3 is registered but no executor's allowed_projects names it -- T1 (the
+    # only executor in this fixture) allows only p1/p2.
+    unclaimed = AuthenticatedPrincipal(
+        user_id="carol", email="carol@example.com",
+        allowed_projects=["p3"], scopes=["codexbridge.read", "codexbridge.issues.write"],
+    )
+    async with env.factory() as session:
+        await store.upsert_registry(
+            session, executors=[],
+            projects=[ProjectRegistration(project_id="p3", name="Projeto Tres", path="/srv/p3", max_timeout_seconds=3600)],
+        )
+    epic = await _call(env, unclaimed, "create_epic", {"project": "p3", "title": "Bridge epic"})
+
+    hub = RecordingHub(connected={"T1"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, unclaimed, "publish_epic_to_repo", {"epic_id": epic["epic_id"]}, hub=hub)
+    assert raised.value.status_code == 409
+    assert raised.value.detail.startswith("project_not_onboarded")
+    assert hub.sent == []
+
+
+@pytest.mark.asyncio
+async def test_publish_epic_to_repo_unknown_epic_is_404(env):
+    hub = RecordingHub(connected={"T1"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, ALICE, "publish_epic_to_repo", {"epic_id": "does-not-exist"}, hub=hub)
+    assert raised.value.status_code == 404
+    assert raised.value.detail == "unknown_epic"
+
+
+@pytest.mark.asyncio
+async def test_publish_epic_to_repo_republish_carries_existing_path(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Bridge epic"})
+    async with env.factory() as session:
+        await store.apply_epic_materialization(
+            session,
+            epic_id=epic["epic_id"],
+            epic_path="docs/issues/078-bridge-epic-[ready]",
+            epic_revision=epic["revision"],
+            written_paths={},
+            issue_revisions={},
+        )
+
+    hub = RecordingHub(connected={"T1"})
+    result = await _call(env, ALICE, "publish_epic_to_repo", {"epic_id": epic["epic_id"]}, hub=hub)
+
+    assert result["existing_path"] == "docs/issues/078-bridge-epic-[ready]"
+    _, envelope = hub.sent[0]
+    assert envelope.payload["existing_path"] == "docs/issues/078-bridge-epic-[ready]"
+
+
+@pytest.mark.asyncio
+async def test_publish_epic_to_repo_requires_write_scope(env):
+    epic = await _call(env, ALICE, "create_epic", {"project": "p1", "title": "Bridge epic"})
+    hub = RecordingHub(connected={"T1"})
+    with pytest.raises(HTTPException) as raised:
+        await _call(env, READER, "publish_epic_to_repo", {"epic_id": epic["epic_id"]}, hub=hub)
+    assert raised.value.status_code == 403
+    assert raised.value.detail == "missing_scope:codexbridge.issues.write"
+    assert hub.sent == []

--- a/tests/unit/test_agent_service_materialize.py
+++ b/tests/unit/test_agent_service_materialize.py
@@ -1,0 +1,122 @@
+"""`AgentService._handle_materialize` -- the `ISSUE_MATERIALIZE` handler on
+
+the executor. issue #78, Commit 2c. Mirrors `tests/unit/test_agent_service.py`'s
+own posture for `_handle_dispatch`: a `DummyWebSocket` collecting sent
+envelopes, no real network.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.service import AgentService
+from shared.protocol import AgentEnvelope, AgentMessageType, ProjectRegistration
+
+
+class DummyWebSocket:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(self, payload: str) -> None:
+        self.messages.append(payload)
+
+
+def _envelope(payload: dict) -> AgentEnvelope:
+    return AgentEnvelope(
+        message_id="materialize-1", executor_id="devel3", sent_at=datetime.now(timezone.utc),
+        type=AgentMessageType.ISSUE_MATERIALIZE, payload=payload,
+    )
+
+
+def _payload(**overrides) -> dict:
+    fields = dict(
+        epic_id="epic-1",
+        project_id="codexbridge",
+        slug="bridge-epic-[ready]",
+        files={
+            "README.md": "readme body",
+            "epic.md": "epic body",
+            "issues/issue-a/first-slice-[ready].md": "issue a body",
+        },
+        existing_path=None,
+        epic_revision=3,
+        issue_revisions={"issue-a": 1},
+        delivery=None,
+    )
+    fields.update(overrides)
+    return fields
+
+
+@pytest.mark.asyncio
+async def test_materialize_writes_files_and_reports_success(tmp_path: Path) -> None:
+    """Positive control for the three failure-mode tests below."""
+    service = AgentService(AgentSettings())
+    service.projects = {"codexbridge": ProjectRegistration(project_id="codexbridge", name="CB", path=str(tmp_path))}
+    websocket = DummyWebSocket()
+
+    await service._handle_materialize(websocket, _envelope(_payload()))
+
+    result = AgentEnvelope.model_validate_json(websocket.messages[-1])
+    assert result.type == AgentMessageType.ISSUE_MATERIALIZE_RESULT
+    assert result.payload["ok"] is True
+    assert result.payload["epic_id"] == "epic-1"
+    assert result.payload["epic_path"] == "docs/issues/001-bridge-epic-[ready]"
+    # Echoed back verbatim from the request -- opaque to the executor.
+    assert result.payload["epic_revision"] == 3
+    assert result.payload["issue_revisions"] == {"issue-a": 1}
+
+    written = tmp_path / result.payload["epic_path"]
+    assert (written / "README.md").read_text() == "readme body"
+    assert (written / "epic.md").read_text() == "epic body"
+    issue_key = "issues/issue-a/first-slice-[ready].md"
+    written_issue_path = tmp_path / result.payload["written_paths"][issue_key]
+    assert written_issue_path.read_text() == "issue a body"
+
+
+@pytest.mark.asyncio
+async def test_materialize_for_an_unknown_project_reports_a_typed_error(tmp_path: Path) -> None:
+    service = AgentService(AgentSettings())
+    assert service.settings.auto_project_root is None
+    websocket = DummyWebSocket()
+
+    await service._handle_materialize(websocket, _envelope(_payload(project_id="not-registered")))
+
+    result = AgentEnvelope.model_validate_json(websocket.messages[-1])
+    assert result.payload["ok"] is False
+    assert result.payload["error"] == "unknown_project"
+    assert result.payload["epic_id"] == "epic-1"
+
+
+@pytest.mark.asyncio
+async def test_materialize_with_a_malformed_payload_reports_a_typed_error(tmp_path: Path) -> None:
+    service = AgentService(AgentSettings())
+    service.projects = {"codexbridge": ProjectRegistration(project_id="codexbridge", name="CB", path=str(tmp_path))}
+    websocket = DummyWebSocket()
+
+    # Missing required fields (`files`, `epic_revision`, ...) -- pydantic
+    # validation must fail closed with a typed result, not raise out of the
+    # message loop.
+    await service._handle_materialize(websocket, _envelope({"epic_id": "epic-1"}))
+
+    result = AgentEnvelope.model_validate_json(websocket.messages[-1])
+    assert result.payload["ok"] is False
+    assert result.payload["error"] == "invalid_materialize_request"
+
+
+@pytest.mark.asyncio
+async def test_materialize_republish_with_a_missing_existing_path_reports_a_typed_error(tmp_path: Path) -> None:
+    service = AgentService(AgentSettings())
+    service.projects = {"codexbridge": ProjectRegistration(project_id="codexbridge", name="CB", path=str(tmp_path))}
+    websocket = DummyWebSocket()
+
+    await service._handle_materialize(
+        websocket, _envelope(_payload(existing_path="docs/issues/999-does-not-exist"))
+    )
+
+    result = AgentEnvelope.model_validate_json(websocket.messages[-1])
+    assert result.payload["ok"] is False
+    assert result.payload["error"] == "existing_path_not_found"

--- a/tests/unit/test_issue_materialize.py
+++ b/tests/unit/test_issue_materialize.py
@@ -1,0 +1,246 @@
+"""`materialize_epic` and the shared numbering scanner -- issue #78, Commit 2c.
+
+Against real throwaway directory trees under pytest's `tmp_path`, same
+posture as `tests/unit/test_instructions.py`: this module does real
+filesystem globbing and atomic file creation, so a fake filesystem would test
+the wrong thing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.codex_bridge_agent.instructions import list_used_issue_numbers
+from agent.codex_bridge_agent.issue_materialize import (
+    MaterializeError,
+    _allocate_dir,
+    _allocate_file,
+    materialize_epic,
+)
+from shared.protocol import MaterializeRequest
+
+
+def _write(path: Path, text: str = "x") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _request(**overrides) -> MaterializeRequest:
+    fields = dict(
+        epic_id="epic-1",
+        project_id="p1",
+        slug="issue-materialize-bridge-[ready]",
+        files={
+            "README.md": "readme body",
+            "epic.md": "epic body",
+            "issues/issue-a/first-slice-[ready].md": "issue a body",
+            "issues/issue-b/second-slice-[blocked].md": "issue b body",
+        },
+        existing_path=None,
+        epic_revision=3,
+        issue_revisions={"issue-a": 1, "issue-b": 2},
+        delivery=None,
+    )
+    fields.update(overrides)
+    return MaterializeRequest(**fields)
+
+
+# --------------------------------------------------------------------------
+# `list_used_issue_numbers` -- the three layouts `resolve_issue_text` tolerates.
+# --------------------------------------------------------------------------
+
+
+def test_list_used_issue_numbers_covers_all_three_layouts(tmp_path: Path):
+    # Layout A: nested under some epic's own issues/.
+    _write(tmp_path / "docs/issues/063-chatgpt-entry/issues/065-start-task.md")
+    # Layout B: a whole numbered folder.
+    _write(tmp_path / "docs/issues/001-mobile-api-foundation/README.md")
+    # Layout C: a bare numbered file.
+    _write(tmp_path / "docs/issues/042-standalone-issue.md")
+    # A status-suffixed name (brackets) must not break the scan.
+    _write(tmp_path / "docs/issues/078-bridge-[draft]/README.md")
+
+    # 65 is used too -- it is the nested issue file from Layout A itself,
+    # a real number in the shared pool, not a fixture artifact.
+    assert list_used_issue_numbers(tmp_path) == {63, 65, 1, 42, 78}
+
+    # Positive control: an unrelated, non-numbered entry contributes nothing.
+    _write(tmp_path / "docs/issues/templates/README.md")
+    assert list_used_issue_numbers(tmp_path) == {63, 65, 1, 42, 78}
+
+
+def test_list_used_issue_numbers_empty_when_docs_issues_missing(tmp_path: Path):
+    assert list_used_issue_numbers(tmp_path) == set()
+
+
+# --------------------------------------------------------------------------
+# Fresh publish: numbering, atomic creation, race resolution.
+# --------------------------------------------------------------------------
+
+
+def test_materialize_epic_allocates_the_next_free_number(tmp_path: Path):
+    _write(tmp_path / "docs/issues/077-something-else/README.md")
+
+    outcome = materialize_epic(tmp_path, _request())
+
+    assert outcome.epic_path == "docs/issues/078-issue-materialize-bridge-[ready]"
+    assert (tmp_path / outcome.epic_path / "README.md").read_text() == "readme body"
+    assert (tmp_path / outcome.epic_path / "epic.md").read_text() == "epic body"
+
+    # Both issue files landed under issues/, each with its own allocated
+    # number, continuing the SAME shared pool the epic directory drew from.
+    assert set(outcome.written_paths) == {
+        "README.md",
+        "epic.md",
+        "issues/issue-a/first-slice-[ready].md",
+        "issues/issue-b/second-slice-[blocked].md",
+    }
+    written_a = tmp_path / outcome.written_paths["issues/issue-a/first-slice-[ready].md"]
+    written_b = tmp_path / outcome.written_paths["issues/issue-b/second-slice-[blocked].md"]
+    assert written_a.read_text() == "issue a body"
+    assert written_b.read_text() == "issue b body"
+    assert written_a.name.endswith("-first-slice-[ready].md")
+    assert written_b.name.endswith("-second-slice-[blocked].md")
+    # Every allocated number is unique and none collides with the pre-existing 077.
+    numbers = {int(p.split("/")[-1].split("-")[0]) for p in [outcome.epic_path, str(written_a.relative_to(tmp_path)), str(written_b.relative_to(tmp_path))]}
+    assert 77 not in numbers
+    assert len(numbers) == 3
+
+
+def test_allocate_dir_retries_past_a_real_collision(tmp_path: Path):
+    """Direct test of the atomic-creation retry loop itself -- the exact
+
+    mechanism `materialize_epic` relies on to survive a numbering race (two
+    publications whose OWN scans both missed each other, e.g. because they
+    ran concurrently before either's write landed on disk).
+    `list_used_issue_numbers` cannot catch that case by construction -- only
+    the atomic `mkdir()` here can -- so this is exercised directly against a
+    REAL pre-existing directory, not through a mocked scan.
+    """
+    docs_issues = tmp_path / "docs_issues"
+    docs_issues.mkdir()
+    (docs_issues / "001-slug").mkdir()
+
+    next_cursor, path = _allocate_dir(docs_issues, 1, "slug")
+
+    assert path == docs_issues / "002-slug"
+    assert path.is_dir()
+    assert next_cursor == 3
+    # The colliding directory a concurrent publication already claimed was
+    # left untouched, not overwritten.
+    assert list((docs_issues / "001-slug").iterdir()) == []
+
+
+def test_allocate_file_retries_past_a_real_collision(tmp_path: Path):
+    """Same mechanism, for an issue file -- `os.open(..., O_CREAT|O_EXCL)`
+
+    instead of `mkdir()`, same retry-with-next-number shape.
+    """
+    issues_dir = tmp_path / "issues"
+    issues_dir.mkdir()
+    (issues_dir / "001-foo-[ready].md").write_text("someone else's file", encoding="utf-8")
+
+    next_cursor, path = _allocate_file(issues_dir, 1, "foo-[ready].md")
+
+    assert path == issues_dir / "002-foo-[ready].md"
+    assert path.exists()
+    assert next_cursor == 3
+    assert (issues_dir / "001-foo-[ready].md").read_text() == "someone else's file"
+
+
+def test_materialize_epic_survives_a_numbering_race_end_to_end(tmp_path: Path, monkeypatch):
+    """`materialize_epic` wired end-to-end against a numbering scan that
+
+    UNDER-reports what is really on disk (simulating two publications racing
+    before either's own scan saw the other's write) -- proving the atomic
+    retry in `_allocate_dir` is what actually saves this call, not the scan
+    alone.
+    """
+    docs_issues = tmp_path / "docs" / "issues"
+    docs_issues.mkdir(parents=True)
+    (docs_issues / "001-issue-materialize-bridge-[ready]").mkdir()
+
+    monkeypatch.setattr(
+        "agent.codex_bridge_agent.issue_materialize.list_used_issue_numbers",
+        lambda project_root: set(),  # blind to the directory that already exists
+    )
+
+    outcome = materialize_epic(tmp_path, _request(files={"README.md": "r", "epic.md": "e"}))
+
+    assert outcome.epic_path == "docs/issues/002-issue-materialize-bridge-[ready]"
+    assert list((docs_issues / "001-issue-materialize-bridge-[ready]").iterdir()) == []
+
+
+# --------------------------------------------------------------------------
+# Path traversal.
+# --------------------------------------------------------------------------
+
+
+def test_materialize_epic_refuses_a_traversing_existing_path(tmp_path: Path):
+    request = _request(existing_path="../outside", files={"README.md": "r", "epic.md": "e"})
+    with pytest.raises(MaterializeError) as raised:
+        materialize_epic(tmp_path, request)
+    assert raised.value.code == "existing_path_invalid"
+
+
+def test_materialize_epic_refuses_a_missing_existing_path(tmp_path: Path):
+    request = _request(existing_path="docs/issues/999-does-not-exist", files={"README.md": "r", "epic.md": "e"})
+    with pytest.raises(MaterializeError) as raised:
+        materialize_epic(tmp_path, request)
+    assert raised.value.code == "existing_path_not_found"
+
+
+# --------------------------------------------------------------------------
+# Republish: updates the existing directory instead of creating a new one.
+# --------------------------------------------------------------------------
+
+
+def test_materialize_epic_republish_updates_in_place_and_adds_new_issues(tmp_path: Path):
+    first = materialize_epic(tmp_path, _request(files={
+        "README.md": "readme v1",
+        "epic.md": "epic v1",
+        "issues/issue-a/first-slice-[ready].md": "issue a v1",
+    }))
+    assert first.epic_path == "docs/issues/001-issue-materialize-bridge-[ready]"
+
+    second = materialize_epic(
+        tmp_path,
+        _request(
+            existing_path=first.epic_path,
+            files={
+                "README.md": "readme v2",
+                "epic.md": "epic v2",
+                # Same relative key as before -- must overwrite the SAME
+                # numbered file rather than allocate a second one.
+                "issues/issue-a/first-slice-[ready].md": "issue a v2",
+                # A brand-new issue on the republish -- must allocate a
+                # fresh number rather than collide with the epic dir (001)
+                # or the existing issue file.
+                "issues/issue-b/second-slice-[blocked].md": "issue b v1",
+            },
+        ),
+    )
+
+    # Same directory, not a second one.
+    assert second.epic_path == first.epic_path
+    assert (tmp_path / second.epic_path / "README.md").read_text() == "readme v2"
+    assert (tmp_path / second.epic_path / "epic.md").read_text() == "epic v2"
+
+    # The republished issue kept its original number and file.
+    original_written = tmp_path / first.written_paths["issues/issue-a/first-slice-[ready].md"]
+    republished_written = tmp_path / second.written_paths["issues/issue-a/first-slice-[ready].md"]
+    assert original_written == republished_written
+    assert republished_written.read_text() == "issue a v2"
+
+    # The new issue got a fresh, non-colliding number.
+    new_written = tmp_path / second.written_paths["issues/issue-b/second-slice-[blocked].md"]
+    assert new_written.read_text() == "issue b v1"
+    assert new_written != original_written
+
+    # No second epic directory was created for the same epic.
+    assert sorted(p.name for p in (tmp_path / "docs" / "issues").iterdir()) == [
+        "001-issue-materialize-bridge-[ready]"
+    ]

--- a/tests/unit/test_issue_render.py
+++ b/tests/unit/test_issue_render.py
@@ -1,0 +1,187 @@
+"""`render_epic_markdown` -- issue #78, Commit 2a.
+
+Exact-bytes assertions, not "looks about right": the whole point of this
+function being pure (no I/O, no LLM) is that its output is reproducible and
+checkable, the thing `.docs/napkin-lessons.md`'s "five green tests proved
+only that the code was unreachable" lesson warns a shallower test would miss.
+Each negative/behavioural assertion below sits next to a positive control in
+the same test, per that same lesson.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from gateway.app.models.entities import EpicModel, IssueModel
+from gateway.app.services.issue_render import (
+    epic_directory_slug,
+    issue_relative_key,
+    render_epic_markdown,
+)
+
+
+def _epic(**overrides) -> EpicModel:
+    fields = dict(
+        id="epic-1",
+        project_id="p1",
+        title="Issue materialize bridge",
+        description="Bridges planned epics into versioned files.",
+        status="open",
+        created_by_user_id="alice",
+        created_by_email="alice@example.com",
+        created_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+        revision=3,
+    )
+    fields.update(overrides)
+    return EpicModel(**fields)
+
+
+def _issue(**overrides) -> IssueModel:
+    fields = dict(
+        id="issue-1",
+        project_id="p1",
+        epic_id="epic-1",
+        title="Render pure markdown",
+        description="No I/O, no LLM.",
+        status="open",
+        priority="high",
+        labels_json=json.dumps(["backend"]),
+        dependencies_json=json.dumps([]),
+        blocked_reason=None,
+        created_by_user_id="alice",
+        created_by_email="alice@example.com",
+        created_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+        revision=1,
+    )
+    fields.update(overrides)
+    return IssueModel(**fields)
+
+
+def test_epic_directory_slug_bakes_title_and_status_suffix_together():
+    assert epic_directory_slug(_epic()) == "issue-materialize-bridge-[ready]"
+    assert epic_directory_slug(_epic(status="in_progress")) == "issue-materialize-bridge-[started]"
+    assert epic_directory_slug(_epic(status="done")) == "issue-materialize-bridge-[finished]"
+    assert epic_directory_slug(_epic(status="cancelled")) == "issue-materialize-bridge-[cancelled]"
+    # Positive control alongside the fallback below: a KNOWN status is never
+    # routed through the draft fallback.
+    assert "draft" not in epic_directory_slug(_epic(status="open"))
+    # Negative control: a status this mapping has never seen (schema drift,
+    # or a future value) falls back to `draft` rather than raising or
+    # silently mislabeling.
+    assert epic_directory_slug(_epic(status="totally_unknown")) == "issue-materialize-bridge-[draft]"
+
+
+def test_issue_relative_key_embeds_the_issue_id_as_a_correlation_segment():
+    issue = _issue(id="abc-123", title="Render pure markdown", status="in_review")
+    key = issue_relative_key(issue)
+    assert key == "issues/abc-123/render-pure-markdown-[review].md"
+    # Positive control: a different id changes only the correlation segment.
+    other = issue_relative_key(_issue(id="xyz-789", title="Render pure markdown", status="in_review"))
+    assert other == "issues/xyz-789/render-pure-markdown-[review].md"
+    assert other != key
+
+
+def test_render_epic_markdown_exact_bytes_for_epic_and_two_issues():
+    epic = _epic()
+    issue_a = _issue(
+        id="issue-a", title="First slice", status="open", priority="high",
+        description="Do the first thing.",
+        created_at=datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    issue_b = _issue(
+        id="issue-b", title="Second slice", status="blocked", priority="low",
+        description=None, labels_json=json.dumps([]),
+        dependencies_json=json.dumps(["issue-a"]),
+        blocked_reason="Waiting on first slice.",
+        created_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+    )
+
+    files = render_epic_markdown(epic, [issue_b, issue_a])  # deliberately out of order
+
+    assert set(files) == {
+        "README.md",
+        "epic.md",
+        "issues/issue-a/first-slice-[ready].md",
+        "issues/issue-b/second-slice-[blocked].md",
+    }
+
+    assert files["README.md"] == (
+        "# Epic — Issue materialize bridge\n"
+        "\n"
+        "Bridges planned epics into versioned files.\n"
+        "\n"
+        "## Issues\n"
+        "\n"
+        "| Title | Status | Priority |\n"
+        "| --- | --- | --- |\n"
+        "| First slice | open | high |\n"
+        "| Second slice | blocked | low |\n"
+    )
+
+    assert files["epic.md"] == (
+        "# Issue materialize bridge\n"
+        "\n"
+        "Status: `open` (materialized as `[ready]`)\n"
+        "\n"
+        "Bridges planned epics into versioned files.\n"
+    )
+
+    assert files["issues/issue-a/first-slice-[ready].md"] == (
+        "# First slice\n"
+        "\n"
+        "Status: `open` (materialized as `[ready]`) · Priority: `high`\n"
+        "\n"
+        "Do the first thing.\n"
+        "\n"
+        "## Labels\n"
+        "\n"
+        "- backend\n"
+    )
+
+    assert files["issues/issue-b/second-slice-[blocked].md"] == (
+        "# Second slice\n"
+        "\n"
+        "Status: `blocked` (materialized as `[blocked]`) · Priority: `low`\n"
+        "\n"
+        "## Dependencies\n"
+        "\n"
+        "- issue-a\n"
+        "\n"
+        "## Blocked reason\n"
+        "\n"
+        "Waiting on first slice.\n"
+    )
+
+
+def test_render_epic_markdown_with_no_issues_and_no_description():
+    epic = _epic(description=None)
+    files = render_epic_markdown(epic, [])
+    assert set(files) == {"README.md", "epic.md"}
+    assert files["README.md"] == (
+        "# Epic — Issue materialize bridge\n"
+        "\n"
+        "## Issues\n"
+        "\n"
+        "| Title | Status | Priority |\n"
+        "| --- | --- | --- |\n"
+    )
+    assert files["epic.md"] == (
+        "# Issue materialize bridge\n"
+        "\n"
+        "Status: `open` (materialized as `[ready]`)\n"
+    )
+
+
+def test_render_epic_markdown_is_deterministic_regardless_of_input_order():
+    epic = _epic()
+    issue_a = _issue(id="issue-a", title="A", created_at=datetime(2026, 9, 1, tzinfo=timezone.utc))
+    issue_b = _issue(id="issue-b", title="B", created_at=datetime(2026, 9, 2, tzinfo=timezone.utc))
+
+    forward = render_epic_markdown(epic, [issue_a, issue_b])
+    backward = render_epic_markdown(epic, [issue_b, issue_a])
+    assert forward == backward


### PR DESCRIPTION
Issue #78, stage 3 — stacked on #84, review that first. Two commits: the schema, then the bridge.

## The gap this closes
Two sources of local issue that never spoke to each other: `EpicModel`/`IssueModel` rows in the gateway's database (`local:<id>`, resolved on the gateway), and markdown files under `docs/issues/` in the project (`docs:NNN`, resolved on the **executor**, because the gateway never learns a project's real path). You plan in the chat; the plan stayed in a database no `git log` can see.

Now `publish_epic_to_repo` turns a planned epic and its issues into a real `docs/issues/NNN-<slug>-[<status>]/` folder in the project's own repository — including a project that was never pushed anywhere.

## Two decisions worth reviewing
- **The renderer is a pure function on the gateway** (`gateway/app/services/issue_render.py`), not a coding task sent to an agent. Asking a provider to "write this file" works with zero code and is the wrong tool: non-deterministic (the model reformats, improves, or drops fields — semantic drift between what you approved in chat and what lands in git), it burns a real provider run and a concurrency slot for work with no judgment in it, and it cannot be tested by asserting exact bytes. This one is.
- **The number is allocated on the executor**, not the gateway. The executor already globs `docs/issues/` for reads; it lists the taken `NNN`, picks the next free one, and reports the assigned path back. Same boundary the read side already respects, applied to writes — a gateway-side allocator would invent cross-host collisions. Allocation is `mkdir`/`O_CREAT|O_EXCL` with retry, so two publishes racing cannot land on the same number.

`ensure_within_root` before every write, as `resolve_issue_text` already does. The optional commit reuses `git_delivery.deliver_changes` and `PUSHABLE_BRANCH_PATTERN` — no new authorization concept, never `main`.

The status vocabularies differ (`EPIC_STATUSES`/`ISSUE_STATUSES` vs the seven file suffixes `[draft]…[cancelled]`); the mapping is explicit and documented in the renderer's docstring rather than assumed.

## Validation
`pytest -q`: **818 passed, 7 skipped, 0 failed** (788 + 30 new). `tests/contract/`: 26 passed. Exact-byte assertions on the rendered files; numbering across all three layouts the executor tolerates; the allocation race; path traversal refused; republish updating in place instead of duplicating; no connected executor → typed error, never a silent queue.

## Known limitation, recorded not hidden
`materialized_path`/`materialized_revision` reflect state at publish time. Nothing detects a human hand-editing the markdown afterwards, and a later republish from an unchanged database row would overwrite that edit silently. Closing it was not in scope; it is written into the commit body rather than left to be discovered.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw