### PR TITLE
feat(gh-73): the node scans its roots and proposes candidates (Stage 3, first half)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,22 @@ CODEX_BRIDGE_AGENT_ALLOWED_PROJECTS_FILE=/etc/codex-bridge-agent/projects.json
 # lists by hand -- see AgentSettings.auto_project_root's docstring for the
 # security tradeoff (it relaxes one, not both, of the two allowlist gates).
 # CODEX_BRIDGE_AGENT_AUTO_PROJECT_ROOT=/home/esteban/Sync/Projects
+# WK-20260902-gh73-discovery-report, issue #73 Stage 3. Opt-in, commented out
+# by default: which directory trees THIS node scans for git repositories to
+# PROPOSE as discovery candidates -- NOT the same thing as
+# CODEX_BRIDGE_AGENT_AUTO_PROJECT_ROOT above (that one widens local
+# project_id resolution at dispatch time; this one only produces
+# `discovery.report` messages for an operator to review later). Comma-
+# separated, like every other list-shaped setting in this file. Granting
+# anything automatically from a reported root is a decision made on the
+# GATEWAY's own registry (`ExecutorRegistration.discovery_roots`), never
+# here -- see AgentSettings.discovery_roots's own docstring and
+# docs/control-plane.md.
+# CODEX_BRIDGE_AGENT_DISCOVERY_ROOTS=/home/esteban/Sync/Projects
+# Own cadence, deliberately not tied to the 15s heartbeat -- a real scan (247
+# repositories, in the root that motivated this work) is not something to
+# repeat every 15 seconds.
+CODEX_BRIDGE_AGENT_DISCOVERY_SCAN_INTERVAL_SECONDS=3600
 CODEX_BRIDGE_AGENT_CODEX_BIN=/usr/local/bin/codex
 # WK-20260830-chatgpt-entry-provider-and-delivery, issue #64/#41a.
 CODEX_BRIDGE_AGENT_CLAUDE_BIN=/usr/local/bin/claude

--- a/agent/codex_bridge_agent/config.py
+++ b/agent/codex_bridge_agent/config.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Annotated
 
-from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, Field, field_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from shared.project_discovery import build_project_id_index
 from shared.protocol import ProjectRegistration
@@ -39,6 +40,35 @@ class AgentSettings(BaseSettings):
     # explicit list leaves it unset and keeps using `allowed_projects_file`
     # alone, exactly as before this setting existed.
     auto_project_root: str | None = None
+    # WK-20260902-gh73-discovery-report, issue #73 Stage 3. The directory
+    # trees THIS node scans for git repositories to propose as discovery
+    # candidates -- empty by default, so an operator who never sets it keeps
+    # today's behaviour exactly: no scan loop starts at all
+    # (`AgentService._discovery_loop`).
+    #
+    # NOT `shared.protocol.ExecutorRegistration.discovery_roots`, even though
+    # the names and the `path` strings must line up for the two to cooperate.
+    # That one is the OPERATOR's registry entry (on the gateway) saying what a
+    # tree grants automatically once something is reported under it. This one
+    # is the NODE's own decision about which parts of ITS filesystem it is
+    # willing to walk at all -- only the node can make that call, because only
+    # the node has the filesystem. A discovery report never grants anything by
+    # itself either way (`gateway/app/services/store.py:record_discovery_report`);
+    # this setting only controls what gets PROPOSED, never what gets AUTHORIZED.
+    #
+    # A plain comma-separated string in the environment, like every other
+    # list-shaped setting in this codebase (`Settings.mcp_bearer_tokens`,
+    # `.oauth_allowed_client_ids`, ...) -- pydantic-settings would otherwise
+    # require JSON-encoding a `list[str]` env var, which nothing else here
+    # does. See `_split_comma_separated` below.
+    discovery_roots: Annotated[list[str], NoDecode] = Field(default_factory=list)
+    # Own interval, deliberately not derived from or coupled to
+    # `heartbeat_interval_seconds`: a filesystem walk over a real operator
+    # root (247 repositories, in the root that motivated this work) is not
+    # something to repeat every 15 seconds, and `_discovery_loop` runs as its
+    # own task precisely so a slow scan can never delay a heartbeat or a
+    # dispatch. One scan right after HELLO, then one every this-many seconds.
+    discovery_scan_interval_seconds: int = 3600
     codex_bin: str = "codex"
     # WK-20260830-chatgpt-entry-provider-and-delivery, issue #41a.
     claude_bin: str = "claude"
@@ -72,6 +102,22 @@ class AgentSettings(BaseSettings):
     git_push_timeout_seconds: float = 120
 
     model_config = SettingsConfigDict(env_prefix="CODEX_BRIDGE_AGENT_", env_file=".env")
+
+    @field_validator("discovery_roots", mode="before")
+    @classmethod
+    def _split_comma_separated(cls, value: object) -> object:
+        """Accept `CODEX_BRIDGE_AGENT_DISCOVERY_ROOTS=/a,/b` from the environment.
+
+        pydantic-settings parses a `list[str]` field from the environment as
+        JSON by default, which is not how any other list-shaped setting in
+        this codebase is written (`.env.example` uses plain comma-separated
+        values throughout). Runs only when the raw value is a string --
+        constructing `AgentSettings(discovery_roots=[...])` directly, as the
+        tests do, is untouched.
+        """
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        return value
 
 
 class AgentProjectConfig(BaseModel):

--- a/agent/codex_bridge_agent/service.py
+++ b/agent/codex_bridge_agent/service.py
@@ -13,17 +13,21 @@ import websockets
 
 from agent.codex_bridge_agent.config import AgentSettings, load_agent_projects, resolve_auto_project
 from agent.codex_bridge_agent.git_delivery import deliver_changes
+from agent.codex_bridge_agent.git_tools import run_git
 from agent.codex_bridge_agent.instructions import IssueResolutionError, build_task_instruction, resolve_issue_text
 from agent.codex_bridge_agent.runners.base import EngineNotImplementedError
 from agent.codex_bridge_agent.runners.codex import SANDBOX_READ_ONLY, SANDBOX_WORKSPACE_WRITE
 from agent.codex_bridge_agent.runners.pool import RunnerPool
 from shared.policy import evaluate_task_policy
+from shared.project_discovery import build_project_id_index
 from shared.protocol import (
     EXECUTOR_TOKEN_HEADER,
     AgentEnvelope,
     AgentMessageType,
     Capability,
     DeliveryRequest,
+    DiscoveredCandidate,
+    DiscoveryReport,
     NodeAnnouncement,
     PolicyLevel,
     SubmitTaskRequest,
@@ -42,6 +46,29 @@ logger = logging.getLogger(__name__)
 # package is introduced to get this value: it stays a plain constant local to
 # the agent, exactly as it always was.
 AGENT_VERSION = "0.1.0"
+
+# Issue #73 Stage 3 (`_scan_root` below). Depth cap for the discovery walk,
+# same value `resolve_auto_project` already defaults to -- one number, so a
+# monorepo's submodules are still found (CLAUDE.md's own "monorepo e
+# submodulos" rule) without an unbounded walk on a root that turns out to be
+# far larger or far deeper than an operator expected.
+_DISCOVERY_MAX_DEPTH = 6
+
+# How many repositories `_scan_root` probes with `git` at once. The walk
+# itself runs in a thread executor because it is blocking filesystem I/O; the
+# per-repository `git` calls below are already async subprocesses that do not
+# block the event loop, but launching all of them for a root with hundreds of
+# candidates (247, in the root that motivated this work) at the same instant
+# would still be a burst of process spawns competing with the heartbeat and
+# dispatch loops for scheduling. A modest bound smooths that out without
+# meaningfully slowing an interval measured in the thousands of seconds.
+_DISCOVERY_GIT_CONCURRENCY = 8
+
+# Per-`git` invocation ceiling during a scan. Not the whole-scan budget --
+# `_discovery_loop`'s own interval is that -- just a guard against one
+# corrupted repository (a `.git` that exists but hangs `git` indefinitely)
+# stalling the rest of a root's candidates behind it.
+_DISCOVERY_GIT_TIMEOUT_SECONDS = 10.0
 
 
 BASE_PROMPT = (
@@ -119,6 +146,7 @@ class AgentService:
                 self._envelope(AgentMessageType.HELLO, announcement.model_dump(mode="json")).model_dump_json()
             )
             heartbeat_task = asyncio.create_task(self._heartbeat_loop(websocket))
+            discovery_task = asyncio.create_task(self._discovery_loop(websocket))
             try:
                 async for raw in websocket:
                     envelope = AgentEnvelope.model_validate_json(raw)
@@ -192,11 +220,119 @@ class AgentService:
                         )
             finally:
                 heartbeat_task.cancel()
+                discovery_task.cancel()
 
     async def _heartbeat_loop(self, websocket) -> None:
         while True:
             await websocket.send(self._envelope(AgentMessageType.HEARTBEAT, {}).model_dump_json())
             await asyncio.sleep(self.settings.heartbeat_interval_seconds)
+
+    async def _discovery_loop(self, websocket) -> None:
+        """Issue #73 Stage 3: this node's own periodic filesystem scan.
+
+        Started the same way `_heartbeat_loop` is -- its own task, alongside
+        it -- and deliberately independent of it: `AgentSettings.
+        discovery_scan_interval_seconds` defaults to an hour, not 15 seconds,
+        because a real scan (`build_project_id_index`, walking a real
+        operator root of 247 repositories) is not something to repeat on a
+        heartbeat's cadence, and running it on this loop's own task means a
+        slow scan can never delay a heartbeat or a dispatch either.
+
+        A no-op when `discovery_roots` is empty (the default): no task work,
+        no scan, no message -- exactly today's behaviour for every operator
+        who has not opted in, the same posture `AgentSettings.
+        auto_project_root` already takes.
+
+        One `DISCOVERY_REPORT` envelope PER ROOT, sent as soon as that root's
+        scan finishes rather than batched into one message for every root:
+        see `DiscoveryReport`'s own docstring for why. A scan runs once
+        immediately (this method's own first loop iteration, before the
+        first `sleep`) so a freshly connected node does not wait a full
+        interval to report what it already knows the moment it reconnects.
+        """
+        if not self.settings.discovery_roots:
+            return
+        while True:
+            for root in self.settings.discovery_roots:
+                report = await self._scan_root(root)
+                if report is None:
+                    continue
+                await websocket.send(
+                    self._envelope(AgentMessageType.DISCOVERY_REPORT, report.model_dump(mode="json")).model_dump_json()
+                )
+            await asyncio.sleep(self.settings.discovery_scan_interval_seconds)
+
+    async def _scan_root(self, root: str) -> DiscoveryReport | None:
+        """One root's worth of `DiscoveryReport`, or `None` if the scan itself failed.
+
+        Reuses `shared.project_discovery.build_project_id_index` -- itself
+        built from `walk_for_git_repos` and `suggest_project_id` -- rather
+        than walking the filesystem a second, independent way: the same
+        reasoning that module's own docstring gives for
+        `resolve_auto_project` sharing it applies here, and it is what makes
+        `resource_key` (the absolute path) and `suggested_project_id` agree
+        with what `scripts/discover_projects.py` would show an operator for
+        the same directory.
+
+        The walk itself is blocking filesystem I/O, run in the default
+        executor so it cannot stall the heartbeat or dispatch loops running
+        on the same event loop -- the whole reason this method, and not
+        `_discovery_loop` itself, is the unit that gets awaited per root.
+
+        `root_path` on the returned report is the STRING `root` was passed
+        in as, never the resolved path `build_project_id_index` computes
+        internally -- see `DiscoveryReport.root_path`'s own docstring for why
+        that distinction matters to the operator-side match this feeds.
+        """
+        loop = asyncio.get_running_loop()
+        try:
+            index = await loop.run_in_executor(None, build_project_id_index, Path(root), _DISCOVERY_MAX_DEPTH)
+        except Exception:
+            logger.warning("discovery scan failed for root %r", root, exc_info=True)
+            return None
+
+        semaphore = asyncio.Semaphore(_DISCOVERY_GIT_CONCURRENCY)
+
+        async def _probe(project_id: str, repo_dir: Path) -> DiscoveredCandidate:
+            async with semaphore:
+                remote_url = await self._git_value(repo_dir, "remote", "get-url", "origin")
+                head = await self._git_value(repo_dir, "rev-parse", "HEAD")
+                dirty = await self._git_dirty(repo_dir)
+            return DiscoveredCandidate(
+                resource_key=str(repo_dir),
+                suggested_project_id=project_id,
+                suggested_name=repo_dir.name,
+                remote_url=remote_url,
+                head=head,
+                dirty=dirty,
+            )
+
+        candidates = await asyncio.gather(*(_probe(project_id, path) for project_id, path in index.items()))
+        return DiscoveryReport(root_path=root, candidates=list(candidates), scanned_at=datetime.now(timezone.utc))
+
+    @staticmethod
+    async def _git_value(repo_dir: Path, *args: str) -> str | None:
+        """One `git` field, or `None` on any non-zero exit -- including "no such remote".
+
+        `git remote get-url origin` exits non-zero when a repository simply
+        has no `origin` configured, which is the ordinary case for plenty of
+        legitimate local repositories, not a fault
+        (`DiscoveredCandidate.remote_url`'s own docstring). Reusing the same
+        helper for `rev-parse HEAD` treats a HEAD that cannot be read (an
+        empty repository with no commits yet) the same forgiving way.
+        """
+        code, out, _ = await run_git(repo_dir, *args, timeout_seconds=_DISCOVERY_GIT_TIMEOUT_SECONDS)
+        if code != 0:
+            return None
+        value = out.strip()
+        return value or None
+
+    @staticmethod
+    async def _git_dirty(repo_dir: Path) -> bool | None:
+        code, out, _ = await run_git(repo_dir, "status", "--porcelain", timeout_seconds=_DISCOVERY_GIT_TIMEOUT_SECONDS)
+        if code != 0:
+            return None
+        return bool(out.strip())
 
     async def _handle_dispatch(self, websocket, envelope: AgentEnvelope) -> None:
         task_id = envelope.payload["task_id"]
@@ -373,12 +509,18 @@ class AgentService:
         authorized, I am configured to attempt writes", not "I may write to
         anything".
 
-        `discovery_root_count`: the agent has no local `DiscoveryRoot` list to
-        count (`auto_project_root` is a single optional path, not a list --
-        see `AgentSettings.auto_project_root`'s own docstring), so this
-        reports 1 when that single opt-in root is set and 0 otherwise, rather
-        than inventing a new setting to carry a count `AgentSettings` does not
-        otherwise track.
+        `discovery_root_count`: as of issue #73 Stage 3, `len(self.settings.
+        discovery_roots)` -- the node's own scan-root list
+        (`AgentSettings.discovery_roots`, this method's caller,
+        `_discovery_loop`). Deliberately NOT `auto_project_root`: that path
+        never produces a `DiscoveryReport` or any other message to the
+        gateway -- it only widens which `project_id` values a dispatch may
+        resolve to locally (`AgentSettings.auto_project_root`'s own
+        docstring) -- so counting it here would answer "is this node
+        configured to discover anything at all" with a number the gateway
+        can never observe evidence for. Stage 2 counted it anyway, as a
+        stand-in, because no real list existed yet to count; its own
+        docstring said as much and predicted this replacement.
 
         Never allowed to raise past this method: building the announcement
         must not cost the connection. Any exception here (a runner's `probe`
@@ -400,10 +542,9 @@ class AgentService:
                 engines=await self.runners.probe_all(),
                 capabilities=capabilities,
                 max_concurrent_tasks=self.settings.max_concurrent_tasks,
-                # See this method's own docstring: no local list of discovery
-                # roots exists to count, so the single opt-in
-                # `auto_project_root` collapses to 0 or 1.
-                discovery_root_count=1 if self.settings.auto_project_root else 0,
+                # See this method's own docstring: the node's own scan-root
+                # count, not `auto_project_root` (a different valve entirely).
+                discovery_root_count=len(self.settings.discovery_roots),
             )
         except Exception:
             logger.warning("Failed to build full node announcement; sending minimal fallback", exc_info=True)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -169,7 +169,12 @@ by the contract itself, not by a filter applied late:
   the contents of `users.json` or `registry.json`;
 - **server filesystem paths.** `ProjectModel.path` is the canonical trap: it is
   the project's real path on the executor and it is an internal field. Projects
-  are addressed by `ProjectId` and nothing else;
+  are addressed by `ProjectId` and nothing else. Same category, same rule:
+  `WorkspaceBindingModel.local_path` (issue #73) and
+  `DiscoveredResourceModel.resource_key` (issue #73 Stage 3) — the latter IS
+  the candidate's absolute path on the node, not a project id
+  (`docs/control-plane.md`, "`resource_key` é dado sensível"). Both are
+  operator-surface-only, exactly like `ProjectModel.path`;
 - executor hostnames, internal IPs, ports, or anything that would let a client
   reach an executor without going through the gateway;
 - raw stack traces and raw driver errors. These map to `internal_error` plus a

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-01 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--gh-73-control map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-report`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-report map`
 
 ## Summary
 
-- 132 file(s) · 1246 symbol(s) indexed
-- Languages: config (2), python (128), shell (2)
+- 135 file(s) · 1290 symbol(s) indexed
+- Languages: config (2), python (131), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -132,6 +132,7 @@ tests/
   integration/
     test_agent_ack_handling.py  — "`task.ack` handling in the `/agent/ws` message loop — issue #16 council."
     test_agent_hub.py
+    test_agent_ws_discovery.py  — "`AgentMessageType.DISCOVERY_REPORT` through the real `/agent/ws` receive loop."
     test_agent_ws_handshake.py  — "The `/agent/ws` handshake stops carrying the token in the URL — issue #15."
     test_agent_ws_identity.py  — "An envelope's `executor_id` is a claim; the handshake's is the fact."
     test_api_conventions.py  — "Representative-endpoint compliance for the cross-cutting API rules (issue #12)."
@@ -158,6 +159,7 @@ tests/
     test_agent_announcement.py  — "The `hello` payload's real content -- issue #73 Stage 2."
     test_agent_auth.py  — "Credential resolution for the `/agent/ws` handshake — issue #15."
     test_agent_auto_project.py  — "`agent.codex_bridge_agent.config.resolve_auto_project` -- the opt-in"
+    test_agent_discovery.py  — "`AgentService._scan_root`/`_discovery_loop` -- issue #73 Stage 3."
     test_agent_service.py
     test_apply_migrations.py  — "The migration runner, exercised against real throwaway databases."
     test_capability_vocabulary.py  — "The capability vocabulary issue #73's authorization plane is built on."
@@ -165,6 +167,7 @@ tests/
     test_codex_runner.py  — "CodexRunner's pause/resume/restart/cancel state machine — issue #16 council."
     test_config_settings.py  — "issue #17 council round 1, "the second caller": `cancel_replay_max_age_seconds`"
     test_discover_projects.py  — "`scripts/discover_projects.py` -- read-only repo discovery."
+    test_discovery_store.py  — "`store.record_discovery_report` -- issue #73 Stage 3."
     test_email_templates.py  — "`gateway.app.services.email_templates` -- pure rendering, no I/O."
     test_git_delivery.py  — "`git_delivery.deliver_changes` against real throwaway git repos."
     test_google_calendar.py  — "`gateway.app.services.google_calendar`, without ever touching Google."
@@ -730,6 +733,7 @@ tests/
 - `executor_is_live(executor)` — "Whether an executor should be presented as connected right now."
 - `ensure_node_for_executor(session, executor)` *(async function)* — "The Bridge Node bound to `executor`, creating and binding one if needed."
 - `record_node_announcement(session, executor, announcement)` *(async function)* — "Persist a HELLO's `NodeAnnouncement` onto the node bound to `executor`."
+- `record_discovery_report(session, executor, report)` *(async function)* — "Persist one root's `DiscoveryReport` into `discovered_resources` -- and nothing else."
 - `list_nodes(session)` *(async function)* — "Every Bridge Node, ordered by id, paired with the executor bound to it."
 - `get_node(session, node_id)` *(async function)* — "One Bridge Node and its bound executor, or None if the node does not exist."
 - `next_dispatchable_task(session, executor_id)` *(async function)*
@@ -845,6 +849,8 @@ tests/
 - **`DiscoveryRoot`** *(class)* — "One directory tree a node is configured to scan, and what that grants."
 - **`EngineAvailability`** *(class)* — "Whether one `AgentEngine` can actually run on this node, right now."
 - **`NodeAnnouncement`** *(class)* — "What a node reports about itself when it connects (`hello` payload)."
+- **`DiscoveredCandidate`** *(class)* — "One directory a node's own scan found under one of its `discovery_roots`."
+- **`DiscoveryReport`** *(class)* — "One node's scan of one `discovery_root`, sent as `AgentMessageType.DISCOVERY_REPORT`."
 - `node_health()` — "Derive a node's health from facts, at read time, never from a column."
 - **`ProjectRegistration`** *(class)*
 - **`ExecutorRegistration`** *(class)*
@@ -931,6 +937,22 @@ tests/
 - `test_cancel_replay_still_happens_within_max_age(factory)` *(async function)*
 - `test_control_replay_expires_after_max_age(factory)` *(async function)* — "issue #17 council round 1, "the sweep skeptic": unlike cancel replay,"
 - `test_control_replay_still_happens_within_max_age(factory)` *(async function)*
+
+### `tests/integration/test_agent_ws_discovery.py`
+
+> `AgentMessageType.DISCOVERY_REPORT` through the real `/agent/ws` receive loop.
+
+- **`FakeSocket`** *(class)*
+  - `__init__(self, incoming)` *(method)*
+  - `accept(self)` *(async method)*
+  - `close(self, code)` *(async method)*
+  - `send_json(self, payload)` *(async method)*
+  - `receive_json(self)` *(async method)*
+- `wired(monkeypatch)` *(async function)*
+- `test_a_discovery_report_is_recorded_for_the_authenticated_node(wired)` *(async function)*
+- `test_the_receiving_branch_writes_only_discovered_resources(wired)` *(async function)* — "The structural guarantee, proven through the real handler this time:"
+- `test_a_malformed_discovery_report_is_dropped_not_closed(wired)` *(async function)* — "Same tolerant-parse posture as a malformed HELLO: a broken payload"
+- `test_a_forged_discovery_report_is_dropped_not_recorded_against_the_victim(wired)` *(async function)* — "The claimed-vs-authenticated `executor_id` guard at the top of the"
 
 ### `tests/integration/test_agent_ws_handshake.py`
 
@@ -1577,6 +1599,8 @@ tests/
 
 - `test_hello_envelope_validates_as_node_announcement_with_derived_capabilities(monkeypatch, allow_workspace_write, allow_git_delivery, expected_present, expected_absent)` *(async function)*
 - `test_hello_envelope_carries_os_and_arch_but_never_the_hostname(monkeypatch)` *(async function)* — "Issue #73: node identity must not be inferred from mutable hostname --"
+- `test_discovery_root_count_reflects_the_nodes_own_scan_roots(monkeypatch)` *(async function)* — "Issue #73 Stage 3: `discovery_root_count` counts `AgentSettings."
+- `test_discovery_root_count_is_zero_with_only_auto_project_root_set(monkeypatch)` *(async function)* — "The negative half of the pair above: `auto_project_root` alone never"
 - `test_build_announcement_falls_back_to_minimal_payload_when_probing_raises(monkeypatch)` *(async function)* — "`_build_announcement` must never cost the connection. If anything"
 
 ### `tests/unit/test_agent_auth.py`
@@ -1601,6 +1625,27 @@ tests/
 - `test_a_directory_without_git_is_never_matched(tmp_path)`
 - `test_a_symlinked_directory_outside_root_is_never_followed(tmp_path)` — "`walk_for_git_repos` never follows a symlink -- this proves the"
 - `test_the_resolved_id_matches_what_discover_projects_would_suggest(tmp_path)` — "Consistency property this module's own docstring promises: an id a"
+
+### `tests/unit/test_agent_discovery.py`
+
+> `AgentService._scan_root`/`_discovery_loop` -- issue #73 Stage 3.
+
+- **`DummyWebSocket`** *(class)*
+  - `__init__(self)` *(method)*
+  - `send(self, payload)` *(async method)*
+- `test_discovery_roots_defaults_to_empty()` — "The shipped default: no discovery task work at all (`_discovery_loop`'s"
+- `test_discovery_roots_parses_a_comma_separated_env_var(monkeypatch)` — "Same convention every other list-shaped setting in this codebase uses"
+- `test_discovery_roots_accepts_a_real_list_when_constructed_directly()` — "Tests throughout this file build `AgentSettings(discovery_roots=[...])`"
+- `test_scan_root_finds_real_repos_with_remote_head_and_dirty(tmp_path)` *(async function)*
+- `test_scan_root_reports_no_remote_as_none_not_an_error(tmp_path)` *(async function)* — "`git remote get-url origin` exits non-zero with no `origin` configured"
+- `test_scan_root_marks_a_repo_with_uncommitted_changes_dirty(tmp_path)` *(async function)*
+- `test_scan_root_ignores_a_directory_with_no_git(tmp_path)` *(async function)*
+- `test_scan_root_never_follows_a_symlink_out_of_root(tmp_path)` *(async function)* — "Same guarantee `test_agent_auto_project.py` proves for"
+- `test_scan_root_finds_a_nested_submodule_as_its_own_candidate(tmp_path)` *(async function)* — "CLAUDE.md's own project-scope rule: monorepo submodules are separate"
+- `test_scan_root_returns_none_when_the_walk_itself_fails(tmp_path, monkeypatch)` *(async function)* — "A scan failure (e.g. a permission error surfacing as an exception"
+- `test_discovery_loop_is_a_noop_when_no_roots_are_configured()` *(async function)* — "The shipped default (`discovery_roots=[]`) preserves today's"
+- `test_discovery_loop_sends_one_envelope_per_root(tmp_path)` *(async function)* — "Protects against a single giant payload for every root: a slow or"
+- `test_discovery_loop_skips_a_root_that_fails_but_still_reports_the_others(tmp_path, monkeypatch)` *(async function)* — "A root whose scan raises must not stop the others from being reported."
 
 ### `tests/unit/test_agent_service.py`
 
@@ -1734,6 +1779,23 @@ tests/
 - `test_cli_writes_json_to_the_requested_output_file(tmp_path)`
 - `test_cli_never_writes_anywhere_but_the_requested_output_file(tmp_path)` — "Read-only by contract: the script's own docstring promises this."
 - `test_cli_rejects_a_root_that_is_not_a_directory(tmp_path)`
+
+### `tests/unit/test_discovery_store.py`
+
+> `store.record_discovery_report` -- issue #73 Stage 3.
+
+- `db_session()` *(async function)*
+- `test_a_new_candidate_is_inserted_as_discovered(db_session)` *(async function)*
+- `test_existing_candidate_refreshes_evidence_without_regressing_state(db_session)` *(async function)*
+- `test_a_row_missing_from_the_report_becomes_stale(db_session)` *(async function)*
+- `test_reconciliation_is_scoped_to_the_reports_own_root_path(db_session)` *(async function)* — "A row for a DIFFERENT root on the same node must not go STALE just"
+- `test_denied_row_is_not_touched_even_when_reported_again(db_session)` *(async function)*
+- `test_denied_row_does_not_regress_to_stale_when_absent(db_session)` *(async function)* — "The exact bug named in `docs/control-plane.md`: a refused candidate"
+- `test_stale_row_reappearing_with_no_project_reverts_to_discovered(db_session)` *(async function)*
+- `test_stale_row_reappearing_with_active_authorization_reverts_to_authorized(db_session)` *(async function)*
+- `test_stale_row_reappearing_with_only_a_revoked_authorization_reverts_to_adopted(db_session)` *(async function)* — "The negative half of the pair above: a REVOKED authorization must not"
+- `test_record_discovery_report_never_writes_authorization_or_projects(db_session)` *(async function)* — "The property that makes "the node proposes, the panel adopts" true by"
+- `test_a_large_report_does_not_cost_one_round_trip_per_candidate(db_session)` *(async function)* — "247 candidates -- the real root that motivated this work, rounded up"
 
 ### `tests/unit/test_email_templates.py`
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -194,3 +194,137 @@ O anúncio carrega `discovery_root_count`, um número, não as raízes. A pergun
 de frota é *"este nó está configurado para descobrir alguma coisa?"*, e um
 contador a responde sem publicar o layout de disco da máquina em todo cliente.
 Vale a mesma regra da seção "Caminho absoluto" acima.
+
+Desde a Stage 3 (abaixo), `discovery_root_count` é `len(AgentSettings.
+discovery_roots)` — a lista real de raízes do nó. A Stage 2 o calculava a
+partir de `auto_project_root` (0 ou 1) só porque nenhuma lista de verdade
+existia ainda para contar; o próprio docstring de `_build_announcement`
+previa essa substituição. `auto_project_root` nunca produziu um relatório de
+descoberta nem qualquer outra mensagem ao gateway — é a válvula da camada 7
+(`docs/project-onboarding.md`), que só amplia quais `project_id` um despacho
+resolve localmente. Contá-la aqui teria respondido "descobre algo?" com um
+número para o qual o gateway nunca vê evidência nenhuma.
+
+## Stage 3 — o nó propõe, o painel adota (issue #73)
+
+A Stage 1 criou `discovered_resources` vazia; a Stage 2 fez o nó se anunciar
+sem produzir nenhuma linha nela (`discovery_root_count` era só um número). A
+Stage 3 é o que faz as raízes de descoberta produzirem linhas de verdade —
+sem conceder nada sobre elas. Adotar e decidir candidatos (a rota REST que
+lista `discovered_resources` e move `state`) é a próxima PR; esta entrega
+apenas a proposta.
+
+### Duas listas de raízes, dois donos, nomes parecidos de propósito
+
+A #73 pede exatamente esta distinção, e um nome parecido é o que faz alguém
+tentado a fundir as duas perceber que não deveria:
+
+| lista | onde mora | quem decide | o que ela faz |
+|---|---|---|---|
+| `AgentSettings.discovery_roots` (nó) | no nó, `agent/codex_bridge_agent/config.py` | o operador **daquela máquina** | quais diretórios este nó varre no próprio disco. Vazia por padrão — sem opt-in, nenhum comportamento novo |
+| `ExecutorRegistration.discovery_roots` (operador, `list[DiscoveryRoot]`) | no gateway, `registry.json` | o operador do **registro** | o que cada raiz concede automaticamente (`auto_authorize`), casando por `root_path` — consumido pela próxima PR (adoção), não por esta |
+
+Só o nó pode decidir a primeira — é o filesystem dele. Só o operador do
+registro pode decidir a segunda — é ele quem concede. As duas precisam
+concordar na **string** `path`/`root_path`, porque o casamento na próxima PR é
+por igualdade de string, nunca por resolução: o gateway não enxerga o disco
+do nó (mesma razão pela qual `DiscoveryRoot.path` já não era resolvido desde
+a Stage 1). É por isso que `DiscoveryReport.root_path` (a mensagem, abaixo) é
+exatamente a string configurada no nó, nunca `Path.resolve()`'d.
+
+Uma terceira lista não deveria nunca nascer por acidente aqui — se um dia
+parecer necessária, é sinal de que uma das duas acima está sendo esticada
+para um papel que não é o dela.
+
+`auto_project_root` (a válvula da camada 7, `docs/project-onboarding.md`)
+continua exatamente como está — é uma preocupação diferente: resolve
+`project_id` desconhecido no momento do despacho, nunca produz uma mensagem
+ao gateway, e não tem relação estrutural com nenhuma das duas listas acima
+além da sobreposição de vocabulário ("descoberta").
+
+### `discovery.report`: uma mensagem, não um campo do `hello`
+
+`AgentMessageType.DISCOVERY_REPORT` (`shared/protocol.py`) é deliberadamente
+separada de `NodeAnnouncement`. A Stage 2 já documentava que o `hello` carrega
+só uma contagem (`discovery_root_count`); um relatório de descoberta pode
+carregar centenas de candidatos (247, na raiz real que motivou este
+trabalho), e o `hello` viaja a cada reconexão — misturar os dois faria toda
+reconexão arrastar esse inventário inteiro consigo. Ver `docs/protocol.md`
+para o payload completo.
+
+O nó varre cada raiz num laço próprio (`AgentService._discovery_loop`),
+desacoplado do heartbeat de 15s por desenho: `AgentSettings.
+discovery_scan_interval_seconds` (padrão 3600s) é a única cadência dessa
+varredura. Uma varredura roda logo após o `hello`, depois a cada intervalo. A
+varredura em si (`shared.project_discovery.build_project_id_index`, reusando
+`walk_for_git_repos`/`suggest_project_id` — o mesmo walk de
+`scripts/discover_projects.py` e `resolve_auto_project`, nunca um segundo
+scanner) roda em `run_in_executor`: é I/O de filesystem bloqueante, e não pode
+travar o heartbeat nem o laço de despacho. **Um envelope por raiz**, nunca um
+payload único para todas: uma raiz lenta ou incomumente grande não pode
+atrasar o relatório de nenhuma outra.
+
+### `resource_key` é dado sensível — mesma categoria de `local_path`
+
+Na prática, `resource_key` é o path absoluto do candidato no nó — a única
+forma de identificá-lo antes de existir um `projects.id` para apontar, e por
+isso não é chave estrangeira (mesmo raciocínio que já vale para
+`DiscoveredResourceModel.project_id`, nullable). Cai na mesma categoria de
+dado sensível que `workspace_bindings.local_path` já ocupa nesta página: um
+path absoluto do disco do nó, que só pode aparecer em superfícies de operador
+devidamente autorizadas, nunca em `ProjectStatus`, `Session`, `Mission` ou
+qualquer ferramenta MCP. Essa exceção para `resource_key` está registrada
+aqui e em `docs/api/README.md` ("Fields that must never ship") e
+`docs/threat-model.md` — sem isso, a próxima pessoa a expor
+`discovered_resources` numa rota reintroduz o vazamento que `local_path` já
+evitou uma vez.
+
+Deliberadamente **não** é `suggested_project_id`: `shared.project_discovery.
+suggest_project_id` só garante unicidade dentro da varredura de **uma** raiz
+(seu `taken` é reiniciado a cada chamada); duas raízes varridas de forma
+independente podem sugerir o mesmo id para dois diretórios diferentes. O que
+de fato identifica uma linha em `discovered_resources` — e o que uma nova
+varredura precisa reconhecer como "o mesmo candidato" — é o path, não a
+sugestão.
+
+### Reconciliação de estado: observação nunca é decisão
+
+`store.record_discovery_report` processa um `DiscoveryReport` inteiro (uma
+raiz) como um lote, escaneado por `(node_id, kind, resource_key)` contra o
+que já existe para `(node_id, root_path)`:
+
+- candidato novo → `INSERT`, `state=DISCOVERED`, `first_seen_at=last_seen_at=now`;
+- candidato já existente → atualiza `evidence_json` e `last_seen_at`, e
+  **nunca** muda `state` — uma observação repetida não é uma decisão nova do
+  operador, então um `ADOPTED` ou `AUTHORIZED` não pode regredir só porque o
+  nó reconectou e relatou de novo;
+- linha daquele `(node_id, root_path)` ausente do relatório atual, com
+  `state != DENIED` → `STALE` — visto antes, não visto agora;
+- `DENIED` nunca é tocado por observação, em nenhuma direção: nem regride
+  para a fila de adoção por reaparecer (a falha que esta seção nomeou na
+  Stage 1: "candidato recusado volta à fila de adoção a cada reconexão"), nem
+  tem sua evidência atualizada — uma linha negada simplesmente para de se
+  mover quando o operador decide;
+- uma linha `STALE` que reaparece **não** volta a `DISCOVERED` por padrão: se
+  já havia binding/autorização ativos antes de ficar `STALE`, ela volta para
+  `ADOPTED`/`AUTHORIZED`; só cai em `DISCOVERED` quando não havia decisão
+  nenhuma sobre ela. Hoje, como nada nesta PR ainda escreve
+  `discovered_resources.project_id` (isso é da PR de adoção), todo caso
+  prático cai em `DISCOVERED` — a lógica para os outros dois já existe porque
+  a linha sobre a qual ela vai operar já existe hoje.
+
+O upsert é em lote: um único `select` carrega tudo que já existe para aquele
+`(node_id, root_path)`, o laço só muda objetos ORM em memória, e há um único
+`commit` — um relatório de 247 candidatos custa uma consulta e um commit, não
+247 de cada.
+
+### O que esta PR deliberadamente não faz
+
+Nenhuma rota REST lê ou decide `discovered_resources` — listar candidatos e
+adotá-los é a PR seguinte. Por isso `API_CONTRACT_VERSION` não muda aqui. E o
+branch que recebe `discovery.report` no gateway chama **só**
+`store.record_discovery_report`, que escreve **só** em
+`discovered_resources` — nunca em `project_authorizations`, `projects` nem
+`workspace_bindings`. Isso é o que torna "o nó propõe, o painel adota"
+verdade por construção: o caminho que recebe uma descoberta não tem, no
+código, nenhum jeito de chegar a uma tabela de autorização.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -95,6 +95,7 @@ Mensagens (`AgentMessageType` em `shared/protocol.py`):
 * `task.restart`
 * `task.cancelled`
 * `error`
+* `discovery.report`
 
 Não existe mensagem `task.progress`. O progresso é inferido pelo fluxo de
 `task.log`, cada uma com `offset` incremental.
@@ -130,6 +131,83 @@ a configuração da máquina permitiria, nunca uma concessão sobre projeto — 
 ...}`. O gateway lê essa forma como `agent_version` e um payload que não valide
 gera `WARNING` e **não derruba a conexão** — um gateway que desliga o agente da
 release anterior transforma deploy em interrupção.
+
+### Payload de `discovery.report`: `DiscoveryReport`
+
+Issue #73 Stage 3. Um nó com `AgentSettings.discovery_roots` configurado (por
+padrão, vazio — nenhum comportamento novo sem opt-in) varre cada raiz num laço
+próprio (`AgentService._discovery_loop`, intervalo
+`discovery_scan_interval_seconds`, padrão 3600s), **desacoplado do
+heartbeat de 15s**: uma varredura real (247 repositórios, na raiz que motivou
+este trabalho) não é algo para repetir a cada 15 segundos, nem algo que possa
+atrasar um heartbeat ou um despacho.
+
+**Uma mensagem por raiz, nunca um payload único para todas as raízes** — uma
+raiz lenta ou incomumente grande não pode atrasar o relatório de nenhuma
+outra:
+
+```json
+{
+  "root_path": "/home/esteban/Sync/Projects",
+  "candidates": [
+    {
+      "resource_key": "/home/esteban/Sync/Projects/AI/CodexBridge",
+      "suggested_project_id": "codexbridge",
+      "suggested_name": "CodexBridge",
+      "remote_url": "git@github.com:example/codexbridge.git",
+      "head": "a1b2c3d",
+      "dirty": false
+    }
+  ],
+  "scanned_at": "2026-09-02T18:00:00Z"
+}
+```
+
+Deliberadamente **separada** de `NodeAnnouncement`/`hello`, não um campo a
+mais nele: o `hello` é pequeno e viaja a cada reconexão; um relatório de
+descoberta pode carregar centenas de candidatos, e misturar os dois faria
+toda reconexão arrastar esse inventário inteiro junto — ver o próprio
+docstring de `DiscoveryReport` em `shared/protocol.py`.
+
+`resource_key` é o path absoluto do candidato no nó — dado sensível, na mesma
+categoria de `workspace_bindings.local_path`
+(`docs/control-plane.md`, `docs/api/README.md` "Fields that must never
+ship"). Deliberadamente **não** é `suggested_project_id`:
+`suggest_project_id` só garante unicidade dentro da varredura de uma raiz, e
+duas raízes varridas de forma independente podem sugerir o mesmo id para
+dois diretórios diferentes — o que de fato identifica uma linha em
+`discovered_resources` é o path.
+
+`remote_url` vem de `git remote get-url origin`; ausência de `origin`
+configurado não é erro, vira `None`.
+
+`root_path` é exatamente a string configurada em
+`AgentSettings.discovery_roots` no nó, nunca resolvida/expandida — ela
+precisa casar, caractere a caractere, com o `DiscoveryRoot.path` que o
+operador configura no lado do gateway (`ExecutorRegistration.
+discovery_roots`, consumido pela PR de adoção que segue este trabalho), que
+por sua vez também nunca é resolvido (`DiscoveryRoot.path`'s próprio
+docstring): o gateway não enxerga o disco do nó.
+
+**Recepção no gateway:** o laço de `/agent/ws` (`gateway/app/main.py`) chama
+**apenas** `store.record_discovery_report(session, executor, report)`, que
+escreve **apenas** em `discovered_resources` — nunca em
+`project_authorizations`, `projects` ou `workspace_bindings`. Isso é o que
+torna "o nó propõe, o painel adota" verdade **por construção**: o caminho que
+recebe uma descoberta não tem, no código, nenhum jeito de conceder
+autorização. As regras de reconciliação de estado (candidato novo, candidato
+já visto, ausência, `DENIED`, `STALE` que reaparece) estão em
+`docs/control-plane.md`.
+
+Mesma postura tolerante do `hello`: um payload que não valida como
+`DiscoveryReport` gera `WARNING` e é descartado — a conexão **nunca** é
+derrubada por um relatório malformado, e o guard de identidade
+(`envelope.executor_id` reivindicado vs. autenticado no handshake, "Identidade:
+o handshake manda, o envelope não" acima) já cobre este tipo de mensagem
+também, por estar antes de qualquer branch, não dentro de um.
+
+**Nenhuma rota REST lê `discovered_resources` ainda** — listar e decidir
+candidatos é a próxima PR.
 
 
 Campos comuns:

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -66,6 +66,58 @@ real sob esta raiz" (`shared/project_discovery.py`, `resolve_auto_project`).
   ponta a ponta" — só remove o segundo cadastro (o do executor), não o
   primeiro (o do gateway).
 
+### Descoberta de projetos pelo nó (WK-20260902, issue #73 Stage 3)
+
+Distinta da válvula anterior: `AgentSettings.discovery_roots` não amplia o que
+um despacho pode resolver (`auto_project_root` continua sendo isso, inalterado
+por este trabalho). Ela faz o nó **relatar** o que vê sob raízes configuradas
+por ele mesmo — para um humano decidir depois, numa PR seguinte, que ainda
+não existe.
+
+* controle: opt-in explícito e vazio por padrão
+  (`AgentSettings.discovery_roots`) — nenhum comportamento novo sem
+  configuração
+* controle: a varredura reusa `shared.project_discovery.walk_for_git_repos`,
+  herdando as mesmas duas garantias já testadas para
+  `resolve_auto_project`: nunca segue symlink, nunca sobe diretório
+* controle: só lê — nenhum comando de varredura escreve no repositório
+  candidato (`git remote get-url origin`, `git rev-parse HEAD`,
+  `git status --porcelain`, todos read-only)
+* controle: **nenhuma escrita de autorização é alcançável por este caminho**.
+  `store.record_discovery_report` só tem acesso de escrita a
+  `discovered_resources`; não importa, não consulta para escrita, e não
+  atribui a `ProjectAuthorizationModel`, `ProjectModel` nem
+  `WorkspaceBindingModel` — propriedade estrutural, testada diretamente
+  (`tests/unit/test_discovery_store.py::
+  test_record_discovery_report_never_writes_authorization_or_projects`,
+  `tests/integration/test_agent_ws_discovery.py::
+  test_the_receiving_branch_writes_only_discovered_resources`). Um nó
+  comprometido que relata candidatos fabricados só polui a fila de adoção —
+  não tem, por construção, nenhum caminho para conceder capacidade a nada
+* controle: `resource_key` (o path absoluto do candidato) nunca sai por
+  nenhuma rota REST hoje — não há rota nesta PR — e quando a rota de adoção
+  existir, cai na mesma regra de `local_path`
+  (`docs/api/README.md`, "Fields that must never ship")
+* controle: o mesmo guard de identidade do `hello`/`heartbeat`
+  (`envelope.executor_id` reivindicado vs. autenticado no handshake) já cobre
+  `discovery.report` por estar antes de qualquer branch no laço de
+  recepção — um nó não pode relatar descobertas **como** outro nó
+* controle: um `DiscoveryReport` malformado é descartado com `WARNING`, nunca
+  derruba a conexão — mesma postura já adotada para um `hello` inválido
+* risco aceito, sem mitigação nova nesta PR: nenhum teto explícito no número
+  de candidatos por relatório (`DiscoveryReport.candidates` não tem
+  `max_length`). Na prática limitado pelo filesystem real do nó e por
+  `max_size=2_000_000` bytes na conexão WebSocket que o próprio nó abre
+  (`agent/codex_bridge_agent/service.py:_run_once`); o gateway não impõe um
+  limite equivalente do seu lado hoje — o mesmo estado, não pior, que já vale
+  para `task.log` e os demais tipos de mensagem deste canal. O pior caso
+  continua sendo ruído em `discovered_resources`, nunca escalada de
+  privilégio, pela mesma garantia estrutural do controle acima
+* recomendação operacional: um nó cujo `discovery_roots` aponta para uma
+  árvore que o operador não controla totalmente relata o que existir nela —
+  a mitigação é a mesma de sempre: escolher a raiz com cuidado, não confiar
+  cegamente no que ela aponta
+
 ### Execução de comandos arbitrários
 
 * controle: nenhuma ferramenta MCP genérica de shell

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -48,7 +48,14 @@ from gateway.app.services import metrics, store
 from gateway.app.services.audit import record_event
 from gateway.app.services.agent_hub import AgentHub
 from gateway.app.services.notify import notify_task_finished
-from shared.protocol import EXECUTOR_TOKEN_HEADER, AgentEnvelope, AgentMessageType, NodeAnnouncement, TaskState
+from shared.protocol import (
+    EXECUTOR_TOKEN_HEADER,
+    AgentEnvelope,
+    AgentMessageType,
+    DiscoveryReport,
+    NodeAnnouncement,
+    TaskState,
+)
 from shared.security import sanitize_log_line, secure_compare
 
 
@@ -840,6 +847,35 @@ async def agent_ws(
                         hello_executor = await session.get(store.ExecutorModel, executor_id)
                         if hello_executor is not None:
                             await store.record_node_announcement(session, hello_executor, announcement)
+                elif envelope.type == AgentMessageType.DISCOVERY_REPORT:
+                    # Issue #73 Stage 3. This branch calls exactly ONE store
+                    # function, and that function writes to exactly ONE
+                    # table (`discovered_resources`). That is not a style
+                    # choice -- it is what makes "the node proposes, the
+                    # panel adopts" true by construction rather than by
+                    # convention: there is no code path from a connected
+                    # node's own message to `project_authorizations`,
+                    # `projects`, or `workspace_bindings`. Adoption is a
+                    # separate, operator-scoped surface (a later PR), never
+                    # a side effect of a node reporting what it saw.
+                    #
+                    # Same tolerant-parse posture as HELLO above: a
+                    # malformed report is logged and dropped, never a reason
+                    # to close the socket -- a bug in one node's discovery
+                    # scan must not look like a dropped connection to the
+                    # operator, and must not stop that node's tasks, logs or
+                    # heartbeats, which all share this same loop.
+                    try:
+                        report = DiscoveryReport.model_validate(envelope.payload)
+                    except ValidationError:
+                        logging.getLogger(__name__).warning(
+                            "executor %s sent a DISCOVERY_REPORT payload that failed validation; ignoring it",
+                            sanitize_log_line(envelope.executor_id),
+                        )
+                    else:
+                        discovery_executor = await session.get(store.ExecutorModel, executor_id)
+                        if discovery_executor is not None:
+                            await store.record_discovery_report(session, discovery_executor, report)
                 elif envelope.type == AgentMessageType.HEARTBEAT:
                     await store.mark_executor_connected(session, envelope.executor_id, True)
                 elif envelope.type == AgentMessageType.TASK_ACK:

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -13,6 +13,7 @@ from gateway.app.models.entities import (
     ConversationMessageModel,
     ConversationModel,
     ConversationReadStateModel,
+    DiscoveredResourceModel,
     EpicModel,
     ExecutorModel,
     IssueModel,
@@ -21,6 +22,7 @@ from gateway.app.models.entities import (
     OAuthAccessTokenModel,
     OAuthAuthorizationCodeModel,
     OAuthRefreshTokenModel,
+    ProjectAuthorizationModel,
     ProjectModel,
     TaskLogModel,
     TaskModel,
@@ -46,6 +48,8 @@ from shared.protocol import (
     ApprovalDecision,
     DEFAULT_CANCEL_REPLAY_MAX_AGE_SECONDS,
     DEFAULT_CONTROL_REPLAY_MAX_AGE_SECONDS,
+    DiscoveredState,
+    DiscoveryReport,
     ExecutorRegistration,
     NodeAnnouncement,
     PolicyLevel,
@@ -582,6 +586,161 @@ async def record_node_announcement(
     await session.commit()
     await session.refresh(node)
     return node
+
+
+async def record_discovery_report(
+    session: AsyncSession,
+    executor: ExecutorModel,
+    report: DiscoveryReport,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Persist one root's `DiscoveryReport` into `discovered_resources` -- and nothing else.
+
+    Issue #73 Stage 3. This is what makes "the node proposes, the panel
+    adopts" true by CONSTRUCTION rather than by convention: this function
+    never imports, queries for write, or assigns to
+    `ProjectAuthorizationModel`, `ProjectModel`, or `WorkspaceBindingModel`.
+    A node reporting a directory can therefore never, through this code path,
+    grant itself -- or anything else -- capability over it. See
+    `tests/unit/test_discovery_store.py::
+    test_record_discovery_report_never_writes_authorization_or_projects` for
+    the property this preserves, not just the intent.
+
+    Reconciliation, scoped to `(node.id, "project", report.root_path)` --
+    everything this node has ever reported for THIS root, never another root
+    or another node's rows:
+
+    * a `resource_key` not seen before is INSERTed with
+      `state=DISCOVERED`, `first_seen_at=last_seen_at=now`;
+    * a `resource_key` already on file has its `evidence_json` and
+      `last_seen_at` refreshed, and its `state` is left exactly as it is --
+      a repeated observation is not a new operator decision, so an `ADOPTED`
+      or `AUTHORIZED` row must not regress to `DISCOVERED` just because the
+      node reconnected and reported the same directory again
+      (`docs/control-plane.md`);
+    * a row for THIS root that is NOT in the current report, and whose state
+      is not `DENIED`, becomes `STALE` -- last observed, not currently seen;
+    * `DENIED` is a standing operator decision and is never written to by
+      observation, in either direction: a denied candidate does not regress
+      to the adoption queue on reconnect (`docs/control-plane.md`: "candidato
+      recusado volta à fila de adoção a cada reconexão" is exactly the bug
+      this refusal prevents), and it does not have its evidence refreshed
+      either -- the row simply stops moving once an operator has decided;
+    * a `STALE` row that reappears in a report does not default back to
+      `DISCOVERED` if the operator's earlier decision on it is still on
+      file -- see `_revive_stale_discovery_row`.
+
+    Batched, not one round trip per candidate: ONE `select` loads every
+    existing row for this `(node_id, root_path)` up front, the loop below
+    only mutates ORM objects in memory (`session.add`/attribute assignment,
+    neither of which issues SQL by itself), and there is exactly ONE
+    `commit`. A report of 247 candidates -- the real root that motivated this
+    work -- costs one query and one commit, not 247 of either.
+    """
+    node = await ensure_node_for_executor(session, executor)
+    now = now or datetime.now(timezone.utc)
+
+    existing = list(
+        (
+            await session.execute(
+                select(DiscoveredResourceModel).where(
+                    DiscoveredResourceModel.node_id == node.id,
+                    DiscoveredResourceModel.kind == "project",
+                    DiscoveredResourceModel.root_path == report.root_path,
+                )
+            )
+        ).scalars()
+    )
+    by_key = {row.resource_key: row for row in existing}
+    reported_keys: set[str] = set()
+
+    for candidate in report.candidates:
+        reported_keys.add(candidate.resource_key)
+        row = by_key.get(candidate.resource_key)
+        if row is not None and row.state == DiscoveredState.DENIED.value:
+            # A denial is the operator's decision, not a fact the node can
+            # overwrite by continuing to see the directory. Skipped entirely
+            # -- not even evidence/last_seen_at move -- so a denied row stops
+            # changing the moment it is denied.
+            continue
+
+        evidence = json.dumps(
+            {
+                "suggested_project_id": candidate.suggested_project_id,
+                "suggested_name": candidate.suggested_name,
+                "remote_url": candidate.remote_url,
+                "head": candidate.head,
+                "dirty": candidate.dirty,
+            },
+            ensure_ascii=True,
+        )
+
+        if row is None:
+            session.add(
+                DiscoveredResourceModel(
+                    id=str(uuid4()),
+                    node_id=node.id,
+                    kind="project",
+                    resource_key=candidate.resource_key,
+                    evidence_json=evidence,
+                    state=DiscoveredState.DISCOVERED.value,
+                    root_path=report.root_path,
+                    first_seen_at=now,
+                    last_seen_at=now,
+                )
+            )
+            continue
+
+        row.evidence_json = evidence
+        row.last_seen_at = now
+        if row.state == DiscoveredState.STALE.value:
+            await _revive_stale_discovery_row(session, row)
+        # Any other state (DISCOVERED/ADOPTED/AUTHORIZED) stays exactly as it
+        # is -- see this function's own docstring.
+
+    for row in existing:
+        if row.resource_key in reported_keys:
+            continue
+        if row.state == DiscoveredState.DENIED.value:
+            continue
+        row.state = DiscoveredState.STALE.value
+
+    await session.commit()
+
+
+async def _revive_stale_discovery_row(session: AsyncSession, row: DiscoveredResourceModel) -> None:
+    """What a `STALE` row becomes when the node reports it again.
+
+    Not unconditionally `DISCOVERED`: if the operator had already adopted or
+    authorized this resource before the node stopped reporting it, that
+    decision must survive the gap, not be forgotten because the row briefly
+    went `STALE`. `row.project_id` is set by the adoption work that follows
+    this PR, never by anything in this file -- so this function's first
+    branch (`DISCOVERED`) is the only one reachable from code that exists
+    today. The rest is written now because the row it operates on already
+    exists today, and a row this function would get wrong later is a bug
+    nobody would think to test until it reappeared.
+    """
+    if row.project_id is None:
+        row.state = DiscoveredState.DISCOVERED.value
+        return
+    authorization = (
+        (
+            await session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == row.node_id,
+                    ProjectAuthorizationModel.project_id == row.project_id,
+                    ProjectAuthorizationModel.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    row.state = (
+        DiscoveredState.AUTHORIZED.value if authorization is not None else DiscoveredState.ADOPTED.value
+    )
 
 
 async def list_nodes(session: AsyncSession) -> list[tuple[NodeModel, ExecutorModel | None]]:

--- a/shared/protocol.py
+++ b/shared/protocol.py
@@ -215,6 +215,13 @@ class AgentMessageType(str, Enum):
     TASK_RESTART = "task.restart"
     TASK_CANCELLED = "task.cancelled"
     ERROR = "error"
+    # Issue #73 Stage 3. Deliberately its own message, never folded into
+    # `HELLO`'s `NodeAnnouncement`: the announcement is small and travels once
+    # per connection, while a discovery scan can carry hundreds of candidates
+    # from a real operator root (247, in the root that motivated this work) --
+    # mixing the two would make every reconnect drag that whole inventory
+    # along with it. See `DiscoveryReport`'s own docstring.
+    DISCOVERY_REPORT = "discovery.report"
 
 
 class ApprovalDecision(str, Enum):
@@ -395,6 +402,69 @@ class NodeAnnouncement(BaseModel):
         return value
 
 
+class DiscoveredCandidate(BaseModel):
+    """One directory a node's own scan found under one of its `discovery_roots`.
+
+    Issue #73 Stage 3. `resource_key` is the candidate's absolute path on the
+    node -- the same sensitive-data category `docs/control-plane.md` already
+    names for `WorkspaceBindingModel.local_path`
+    (`docs/api/README.md`, "Fields that must never ship"), and it is
+    deliberately NOT `suggested_project_id`: `shared.project_discovery.
+    suggest_project_id` only guarantees uniqueness *within one root's own
+    scan* (its `taken` set is seeded fresh per call), so two different roots,
+    scanned independently, can legitimately suggest the same id for two
+    different directories. What actually keys a row in `discovered_resources`
+    -- and what a re-scan must recognise as "the same candidate" -- is the
+    path, not the suggestion.
+
+    `remote_url` comes from `git remote get-url origin`
+    (`agent/codex_bridge_agent/git_tools.py:run_git`) and is `None` when the
+    repository simply has no `origin` configured -- not an error, and not
+    evidence of anything wrong with the candidate.
+    """
+
+    resource_key: str = Field(min_length=1, max_length=2048)
+    suggested_project_id: str = Field(min_length=1, max_length=128)
+    suggested_name: str = Field(min_length=1, max_length=255)
+    remote_url: str | None = Field(default=None, max_length=2048)
+    head: str | None = Field(default=None, max_length=255)
+    dirty: bool | None = None
+
+
+class DiscoveryReport(BaseModel):
+    """One node's scan of one `discovery_root`, sent as `AgentMessageType.DISCOVERY_REPORT`.
+
+    Issue #73 Stage 3. One report per root rather than one giant payload for
+    every root a node scans: a slow or unusually large root (hundreds of
+    candidates) must not delay the report for every other root, and the
+    gateway reconciles `discovered_resources` per `(node_id, root_path)`
+    anyway (`gateway/app/services/store.py:record_discovery_report`), so a
+    per-root envelope is also the natural unit of that reconciliation.
+
+    Kept out of `NodeAnnouncement`/`hello` on purpose -- see
+    `AgentMessageType.DISCOVERY_REPORT`'s own comment: the announcement is
+    small and travels on every reconnect, a discovery report is neither.
+
+    `root_path` is the exact string from the node's own
+    `AgentSettings.discovery_roots` entry -- never resolved or expanded here
+    -- because the gateway-side `DiscoveryRoot.path` it must eventually match
+    (for `auto_authorize`, in the adoption work that follows this one) is
+    itself compared as a string, never canonicalized (`DiscoveryRoot`'s own
+    docstring: the gateway cannot see the node's disk). A node and its
+    operator-configured `DiscoveryRoot` must agree on that string for the
+    match to work; this report does not, and cannot, correct a mismatch.
+
+    Receiving this NEVER grants anything: `store.record_discovery_report`
+    writes only to `discovered_resources`. See that function's own docstring
+    for why that is structural, not a convention some future change could
+    quietly break.
+    """
+
+    root_path: str = Field(min_length=1, max_length=2048)
+    candidates: list[DiscoveredCandidate] = Field(default_factory=list)
+    scanned_at: datetime
+
+
 def node_health(
     *,
     live: bool,
@@ -450,6 +520,19 @@ class ExecutorRegistration(BaseModel):
     # Deliberately on the executor's registration rather than a global
     # setting: #73 requires the model to support a fleet, and two nodes of the
     # same fleet legitimately hold different trees at different paths.
+    #
+    # NOT the same list as `agent.codex_bridge_agent.config.AgentSettings.
+    # discovery_roots` (Stage 3), even though the two share a name and a
+    # `path` string that must agree for either to be useful. This one is the
+    # OPERATOR'S registry entry: it lives on the gateway, and says what each
+    # tree grants automatically once a node reports something under it
+    # (`auto_authorize`) -- the node never gets to decide that for itself.
+    # `AgentSettings.discovery_roots` is the NODE'S own, unrelated setting:
+    # which directories it is willing to walk its own filesystem for at all.
+    # Only the node can decide that one -- it is the node's disk. Say it here
+    # so a third, in-between list never gets invented by accident: see
+    # `AgentSettings.discovery_roots`'s own docstring, and
+    # `docs/control-plane.md`.
     discovery_roots: list[DiscoveryRoot] = Field(default_factory=list)
 
 

--- a/tests/integration/test_agent_ws_discovery.py
+++ b/tests/integration/test_agent_ws_discovery.py
@@ -1,0 +1,208 @@
+"""`AgentMessageType.DISCOVERY_REPORT` through the real `/agent/ws` receive loop.
+
+Issue #73 Stage 3. Same idiom `tests/integration/test_agent_ws_identity.py`
+uses and explains at length: `agent_ws` is awaited directly with a fake
+socket, never through `TestClient.websocket_connect` (which runs the app in
+its own thread/event loop and deadlocks against one in-memory aiosqlite
+engine shared with the test's own loop).
+
+`tests/unit/test_discovery_store.py` already proves `store.
+record_discovery_report`'s reconciliation rules in isolation. What these
+tests prove instead is the WIRING: that the one branch in `gateway/app/
+main.py` for this message type calls that function and nothing else, that a
+malformed report cannot drop the connection, and that the same
+claimed-vs-authenticated `executor_id` guard every other message type gets
+for free also covers this one.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from starlette.websockets import WebSocketDisconnect
+
+from gateway.app.db.base import Base
+from gateway.app.models.entities import DiscoveredResourceModel, ProjectAuthorizationModel, ProjectModel
+from gateway.app.services import store
+from shared.protocol import AgentMessageType, ExecutorRegistration
+
+
+VICTIM = "victim-node"
+ATTACKER = "attacker-node"
+
+
+class FakeSocket:
+    def __init__(self, incoming: list[dict]) -> None:
+        self._incoming = list(incoming)
+        self.sent: list[dict] = []
+        self.accepted = False
+        self.close_code: int | None = None
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def close(self, code: int = 1000) -> None:
+        self.close_code = code
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+    async def receive_json(self) -> dict:
+        if not self._incoming:
+            raise WebSocketDisconnect(1000)
+        return self._incoming.pop(0)
+
+
+@pytest.fixture
+async def wired(monkeypatch) -> AsyncIterator[async_sessionmaker]:
+    from gateway.app import main
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(main, "SessionLocal", factory)
+    # See `test_agent_ws_identity.py`'s own fixture for why this second patch
+    # is required: `AgentHub` was built at import time holding the
+    # production session factory.
+    monkeypatch.setattr(main.hub, "session_factory", factory)
+
+    async with factory() as session:
+        await store.upsert_registry(
+            session,
+            [
+                ExecutorRegistration(
+                    executor_id=name,
+                    display_name=name,
+                    machine_token=f"token-{name}",
+                    allowed_projects=[],
+                )
+                for name in (VICTIM, ATTACKER)
+            ],
+            [],
+        )
+
+    yield factory
+    await engine.dispose()
+
+
+def _envelope(executor_id: str, message_type: AgentMessageType, payload: dict) -> dict:
+    return {
+        "message_id": str(uuid4()),
+        "executor_id": executor_id,
+        "sent_at": datetime.now(timezone.utc).isoformat(),
+        "type": message_type.value,
+        "payload": payload,
+    }
+
+
+def _discovery_report_payload(root_path: str = "/root", candidates: list[dict] | None = None) -> dict:
+    return {
+        "root_path": root_path,
+        "candidates": candidates
+        if candidates is not None
+        else [
+            {
+                "resource_key": "/root/hub",
+                "suggested_project_id": "hub",
+                "suggested_name": "hub",
+                "remote_url": None,
+                "head": "abc123",
+                "dirty": False,
+            }
+        ],
+        "scanned_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def _speak(as_executor: str, *envelopes: dict) -> FakeSocket:
+    from gateway.app import main
+
+    socket = FakeSocket(list(envelopes))
+    await main.agent_ws(socket, executor_id=as_executor, x_executor_token=f"token-{as_executor}")
+    assert socket.accepted, "the handshake was refused; the test proves nothing"
+    return socket
+
+
+async def _discovered_rows(factory: async_sessionmaker, node_id: str) -> list[DiscoveredResourceModel]:
+    async with factory() as session:
+        result = await session.execute(select(DiscoveredResourceModel).where(DiscoveredResourceModel.node_id == node_id))
+        return list(result.scalars())
+
+
+async def test_a_discovery_report_is_recorded_for_the_authenticated_node(wired) -> None:
+    await _speak(
+        VICTIM,
+        _envelope(VICTIM, AgentMessageType.HELLO, {"agent_version": "1.0.0"}),
+        _envelope(VICTIM, AgentMessageType.DISCOVERY_REPORT, _discovery_report_payload()),
+    )
+
+    rows = await _discovered_rows(wired, VICTIM)
+    assert len(rows) == 1
+    assert rows[0].resource_key == "/root/hub"
+    assert rows[0].root_path == "/root"
+
+
+async def test_the_receiving_branch_writes_only_discovered_resources(wired) -> None:
+    """The structural guarantee, proven through the real handler this time:
+
+    the branch in `main.py` calls exactly one store function, and even a
+    report full of brand-new candidates cannot put a row in
+    `project_authorizations` or `projects`.
+    """
+    async with wired() as session:
+        projects_before = (await session.execute(select(ProjectModel))).scalars().all()
+        authorizations_before = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+
+    await _speak(
+        VICTIM,
+        _envelope(VICTIM, AgentMessageType.HELLO, {"agent_version": "1.0.0"}),
+        _envelope(VICTIM, AgentMessageType.DISCOVERY_REPORT, _discovery_report_payload()),
+    )
+
+    async with wired() as session:
+        projects_after = (await session.execute(select(ProjectModel))).scalars().all()
+        authorizations_after = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+
+    assert len(projects_after) == len(projects_before)
+    assert len(authorizations_after) == len(authorizations_before)
+
+
+async def test_a_malformed_discovery_report_is_dropped_not_closed(wired) -> None:
+    """Same tolerant-parse posture as a malformed HELLO: a broken payload
+
+    from a buggy node must not read as a dropped connection, and must not
+    stop that node's other messages from being processed.
+    """
+    socket = await _speak(
+        VICTIM,
+        _envelope(VICTIM, AgentMessageType.HELLO, {"agent_version": "1.0.0"}),
+        _envelope(VICTIM, AgentMessageType.DISCOVERY_REPORT, {"candidates": "not-even-a-list"}),
+        _envelope(VICTIM, AgentMessageType.HEARTBEAT, {}),
+    )
+
+    assert socket.close_code is None
+    rows = await _discovered_rows(wired, VICTIM)
+    assert rows == []
+
+
+async def test_a_forged_discovery_report_is_dropped_not_recorded_against_the_victim(wired) -> None:
+    """The claimed-vs-authenticated `executor_id` guard at the top of the
+
+    receive loop covers every message type by construction (issue #73
+    Stage 2's own fix); this proves it also covers the type this PR adds,
+    rather than assuming it "just because it's before the branch".
+    """
+    await _speak(
+        ATTACKER,
+        _envelope(VICTIM, AgentMessageType.DISCOVERY_REPORT, _discovery_report_payload(root_path="/attacker-claims")),
+    )
+
+    assert await _discovered_rows(wired, VICTIM) == []
+    assert await _discovered_rows(wired, ATTACKER) == []

--- a/tests/unit/test_agent_announcement.py
+++ b/tests/unit/test_agent_announcement.py
@@ -146,6 +146,50 @@ async def test_hello_envelope_carries_os_and_arch_but_never_the_hostname(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_discovery_root_count_reflects_the_nodes_own_scan_roots(monkeypatch) -> None:
+    """Issue #73 Stage 3: `discovery_root_count` counts `AgentSettings.
+
+    discovery_roots` (the node's own scan-root list), never `auto_project_root`
+    -- a positive/negative pair in one test, since `auto_project_root` alone
+    used to be Stage 2's only source for this number and must no longer move
+    it at all.
+    """
+    service = AgentService(
+        AgentSettings(
+            discovery_roots=["/srv/projects/a", "/srv/projects/b"],
+            auto_project_root="/srv/projects",
+        )
+    )
+
+    async def fake_probe_all() -> list:
+        return []
+
+    monkeypatch.setattr(service.runners, "probe_all", fake_probe_all)
+
+    announcement = await service._build_announcement()
+    assert announcement.discovery_root_count == 2
+
+
+@pytest.mark.asyncio
+async def test_discovery_root_count_is_zero_with_only_auto_project_root_set(monkeypatch) -> None:
+    """The negative half of the pair above: `auto_project_root` alone never
+
+    produces a `DiscoveryReport` (`AgentSettings.auto_project_root`'s own
+    docstring -- it only widens local `project_id` resolution), so it must
+    not move this count either.
+    """
+    service = AgentService(AgentSettings(auto_project_root="/srv/projects"))
+
+    async def fake_probe_all() -> list:
+        return []
+
+    monkeypatch.setattr(service.runners, "probe_all", fake_probe_all)
+
+    announcement = await service._build_announcement()
+    assert announcement.discovery_root_count == 0
+
+
+@pytest.mark.asyncio
 async def test_build_announcement_falls_back_to_minimal_payload_when_probing_raises(monkeypatch) -> None:
     """`_build_announcement` must never cost the connection. If anything
 

--- a/tests/unit/test_agent_discovery.py
+++ b/tests/unit/test_agent_discovery.py
@@ -1,0 +1,324 @@
+"""`AgentService._scan_root`/`_discovery_loop` -- issue #73 Stage 3.
+
+The node-side half of discovery: turning `AgentSettings.discovery_roots`
+into `DiscoveredCandidate` rows, one `DiscoveryReport` envelope per root.
+Every repo here is a REAL, throwaway `git init` under pytest's own
+`tmp_path` (the same posture `tests/unit/test_git_delivery.py` and
+`tests/unit/test_agent_auto_project.py` already take) -- never a real
+project.
+
+Reuses `shared.project_discovery.walk_for_git_repos`/`suggest_project_id`
+under the hood (via `build_project_id_index`), so the walking guarantees
+already proven in `tests/unit/test_agent_auto_project.py` (never follows a
+symlink, ignores a directory with no `.git`) are exercised again here
+end-to-end through `_scan_root`, not re-proven from scratch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.codex_bridge_agent.config import AgentSettings
+from agent.codex_bridge_agent.service import AgentService
+from shared.protocol import AgentMessageType, DiscoveryReport
+
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "codexbridge-test",
+    "GIT_AUTHOR_EMAIL": "test@example.invalid",
+    "GIT_COMMITTER_NAME": "codexbridge-test",
+    "GIT_COMMITTER_EMAIL": "test@example.invalid",
+}
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(args, cwd=cwd, check=True, capture_output=True, text=True, env={**os.environ, **GIT_ENV})
+
+
+def _init_repo(root: Path, *, remote: str | None = None) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init", "-q", "-b", "development"], root)
+    (root / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], root)
+    _run(["git", "commit", "-q", "-m", "initial commit"], root)
+    if remote:
+        _run(["git", "remote", "add", "origin", remote], root)
+
+
+class DummyWebSocket:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    async def send(self, payload: str) -> None:
+        self.messages.append(payload)
+
+
+async def _wait_until(predicate, *, timeout: float = 5.0) -> None:
+    async def _poll() -> None:
+        while not predicate():
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(_poll(), timeout=timeout)
+
+
+# --------------------------------------------------------------------------
+# AgentSettings.discovery_roots
+# --------------------------------------------------------------------------
+
+
+def test_discovery_roots_defaults_to_empty() -> None:
+    """The shipped default: no discovery task work at all (`_discovery_loop`'s
+
+    own no-op check) unless an operator opts in.
+    """
+    assert AgentSettings(_env_file=None).discovery_roots == []
+
+
+def test_discovery_roots_parses_a_comma_separated_env_var(monkeypatch) -> None:
+    """Same convention every other list-shaped setting in this codebase uses
+
+    (`Settings.mcp_bearer_tokens`, `.oauth_allowed_client_ids`) -- plain
+    comma-separated values in `.env`, not JSON.
+    """
+    monkeypatch.setenv("CODEX_BRIDGE_AGENT_DISCOVERY_ROOTS", "/srv/projects/a, /srv/projects/b ,/srv/projects/c")
+    settings = AgentSettings(_env_file=None)
+    assert settings.discovery_roots == ["/srv/projects/a", "/srv/projects/b", "/srv/projects/c"]
+
+
+def test_discovery_roots_accepts_a_real_list_when_constructed_directly() -> None:
+    """Tests throughout this file build `AgentSettings(discovery_roots=[...])`
+
+    directly -- the comma-split validator must be a no-op for an actual
+    `list[str]`, not just for a string.
+    """
+    settings = AgentSettings(discovery_roots=["/a", "/b"], _env_file=None)
+    assert settings.discovery_roots == ["/a", "/b"]
+
+
+# --------------------------------------------------------------------------
+# _scan_root
+# --------------------------------------------------------------------------
+
+
+async def test_scan_root_finds_real_repos_with_remote_head_and_dirty(tmp_path: Path) -> None:
+    repo = tmp_path / "hub"
+    _init_repo(repo, remote="git@example.invalid:org/hub.git")
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(tmp_path))
+
+    assert report is not None
+    assert report.root_path == str(tmp_path)
+    assert len(report.candidates) == 1
+    candidate = report.candidates[0]
+    assert candidate.resource_key == str(repo.resolve())
+    assert candidate.suggested_project_id == "hub"
+    assert candidate.suggested_name == "hub"
+    assert candidate.remote_url == "git@example.invalid:org/hub.git"
+    assert candidate.head is not None
+    assert candidate.dirty is False
+
+
+async def test_scan_root_reports_no_remote_as_none_not_an_error(tmp_path: Path) -> None:
+    """`git remote get-url origin` exits non-zero with no `origin` configured
+
+    -- `DiscoveredCandidate.remote_url`'s own contract: that is not evidence
+    of anything wrong with the candidate.
+    """
+    repo = tmp_path / "no-remote"
+    _init_repo(repo)
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(tmp_path))
+
+    assert report is not None
+    assert len(report.candidates) == 1
+    assert report.candidates[0].remote_url is None
+
+
+async def test_scan_root_marks_a_repo_with_uncommitted_changes_dirty(tmp_path: Path) -> None:
+    repo = tmp_path / "dirty-repo"
+    _init_repo(repo)
+    (repo / "README.md").write_text("changed\n", encoding="utf-8")
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(tmp_path))
+
+    assert report is not None
+    assert report.candidates[0].dirty is True
+
+
+async def test_scan_root_ignores_a_directory_with_no_git(tmp_path: Path) -> None:
+    (tmp_path / "not-a-repo").mkdir()
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(tmp_path))
+
+    assert report is not None
+    assert report.candidates == []
+
+
+async def test_scan_root_never_follows_a_symlink_out_of_root(tmp_path: Path) -> None:
+    """Same guarantee `test_agent_auto_project.py` proves for
+
+    `resolve_auto_project` -- exercised here through `_scan_root` because it
+    is inherited from `walk_for_git_repos`, not reopened by a second walk.
+    """
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    _init_repo(outside)
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "escape-hatch").symlink_to(outside, target_is_directory=True)
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(root))
+
+    assert report is not None
+    assert report.candidates == []
+
+
+async def test_scan_root_finds_a_nested_submodule_as_its_own_candidate(tmp_path: Path) -> None:
+    """CLAUDE.md's own project-scope rule: monorepo submodules are separate
+
+    candidates, not swallowed by the parent repo -- same reasoning
+    `walk_for_git_repos`'s own docstring gives.
+    """
+    _init_repo(tmp_path / "monorepo")
+    _init_repo(tmp_path / "monorepo" / "packages" / "web")
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(tmp_path))
+
+    assert report is not None
+    assert {c.suggested_name for c in report.candidates} == {"monorepo", "web"}
+
+
+async def test_scan_root_returns_none_when_the_walk_itself_fails(tmp_path: Path, monkeypatch) -> None:
+    """A scan failure (e.g. a permission error surfacing as an exception
+
+    despite `walk_for_git_repos`'s own best-effort handling) must not raise
+    out of `_scan_root` -- `_discovery_loop` depends on `None` meaning "skip
+    this root", not on catching an exception itself.
+    """
+    from agent.codex_bridge_agent import service as service_module
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service_module, "build_project_id_index", _boom)
+
+    service = AgentService(AgentSettings())
+    report = await service._scan_root(str(tmp_path))
+    assert report is None
+
+
+# --------------------------------------------------------------------------
+# _discovery_loop
+# --------------------------------------------------------------------------
+
+
+async def test_discovery_loop_is_a_noop_when_no_roots_are_configured() -> None:
+    """The shipped default (`discovery_roots=[]`) preserves today's
+
+    behaviour exactly: no task work, no scan, no message.
+    """
+    service = AgentService(AgentSettings())
+    socket = DummyWebSocket()
+
+    # Returns on its own -- no task/cancel dance needed, unlike the other
+    # tests below, precisely because this is the no-op path.
+    await asyncio.wait_for(service._discovery_loop(socket), timeout=2.0)
+    assert socket.messages == []
+
+
+async def test_discovery_loop_sends_one_envelope_per_root(tmp_path: Path) -> None:
+    """Protects against a single giant payload for every root: a slow or
+
+    huge root must not delay the report for any other root
+    (`DiscoveryReport`'s own docstring).
+    """
+    root_a = tmp_path / "root-a"
+    root_b = tmp_path / "root-b"
+    _init_repo(root_a / "repo-a")
+    _init_repo(root_b / "repo-b")
+
+    service = AgentService(
+        AgentSettings(discovery_roots=[str(root_a), str(root_b)], discovery_scan_interval_seconds=3600)
+    )
+    socket = DummyWebSocket()
+    task = asyncio.create_task(service._discovery_loop(socket))
+    try:
+        await _wait_until(lambda: len(socket.messages) >= 2)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert len(socket.messages) == 2
+    reports = []
+    for raw in socket.messages:
+        from shared.protocol import AgentEnvelope
+
+        envelope = AgentEnvelope.model_validate_json(raw)
+        assert envelope.type == AgentMessageType.DISCOVERY_REPORT
+        reports.append(DiscoveryReport.model_validate(envelope.payload))
+
+    reported_roots = {report.root_path for report in reports}
+    assert reported_roots == {str(root_a), str(root_b)}
+    for report in reports:
+        assert len(report.candidates) == 1
+
+
+async def test_discovery_loop_skips_a_root_that_fails_but_still_reports_the_others(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A root whose scan raises must not stop the others from being reported.
+
+    `build_project_id_index` itself never raises on an ordinary missing or
+    unreadable directory (`walk_for_git_repos` swallows `OSError` and
+    reports zero candidates instead) -- so the failure this test proves
+    `_scan_root` survives has to be forced, the same way
+    `test_scan_root_returns_none_when_the_walk_itself_fails` forces it.
+    """
+    from agent.codex_bridge_agent import service as service_module
+    from shared.project_discovery import build_project_id_index as real_build_project_id_index
+
+    good_root = tmp_path / "good"
+    _init_repo(good_root / "repo")
+    bad_root = tmp_path / "bad"
+
+    def _flaky(root_path: Path, max_depth: int):
+        if Path(root_path) == bad_root:
+            raise RuntimeError("boom")
+        return real_build_project_id_index(root_path, max_depth)
+
+    monkeypatch.setattr(service_module, "build_project_id_index", _flaky)
+
+    service = AgentService(
+        AgentSettings(discovery_roots=[str(bad_root), str(good_root)], discovery_scan_interval_seconds=3600)
+    )
+    socket = DummyWebSocket()
+    task = asyncio.create_task(service._discovery_loop(socket))
+    try:
+        await _wait_until(lambda: len(socket.messages) >= 1)
+        # Give the (already-failed) bad root a moment too, to prove it never
+        # sends a second envelope rather than just winning a race.
+        await asyncio.sleep(0.05)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert len(socket.messages) == 1
+    from shared.protocol import AgentEnvelope
+
+    envelope = AgentEnvelope.model_validate_json(socket.messages[0])
+    report = DiscoveryReport.model_validate(envelope.payload)
+    assert report.root_path == str(good_root)

--- a/tests/unit/test_discovery_store.py
+++ b/tests/unit/test_discovery_store.py
@@ -1,0 +1,464 @@
+"""`store.record_discovery_report` -- issue #73 Stage 3.
+
+The gateway-side half of discovery: reconciling one node's per-root
+`DiscoveryReport` into `discovered_resources`. Same in-memory-sqlite idiom
+`tests/unit/test_node_store.py` uses for `record_node_announcement` -- a real
+(in-memory) async engine, no FastAPI app.
+
+Every negative rule below (never regress ADOPTED/AUTHORIZED, never touch
+DENIED, never resurrect STALE without cause) is paired with a positive
+control in the same test: `docs/napkin-lessons.md`'s 2026-09-01 entry is
+explicit that five green tests once proved only that the code they exercised
+was unreachable, not that it behaved -- a purely negative assertion cannot
+tell "correctly refused" apart from "never ran".
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.db.base import Base
+from gateway.app.models.entities import (
+    DiscoveredResourceModel,
+    ExecutorModel,
+    ProjectAuthorizationModel,
+    ProjectModel,
+)
+from gateway.app.services import store
+from shared.protocol import DiscoveredCandidate, DiscoveredState, DiscoveryReport, ExecutorRegistration
+
+
+@pytest.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _executor(session: AsyncSession, executor_id: str = "E1") -> ExecutorModel:
+    await store.upsert_registry(
+        session,
+        executors=[
+            ExecutorRegistration(
+                executor_id=executor_id,
+                display_name=executor_id,
+                machine_token="t",
+                allowed_projects=[],
+            )
+        ],
+        projects=[],
+    )
+    return await session.get(ExecutorModel, executor_id)
+
+
+def _candidate(resource_key: str, **overrides) -> DiscoveredCandidate:
+    fields = {
+        "resource_key": resource_key,
+        "suggested_project_id": resource_key.rsplit("/", 1)[-1],
+        "suggested_name": resource_key.rsplit("/", 1)[-1],
+        "remote_url": None,
+        "head": "abc123",
+        "dirty": False,
+    }
+    fields.update(overrides)
+    return DiscoveredCandidate(**fields)
+
+
+def _report(root_path: str, candidates: list[DiscoveredCandidate], *, scanned_at: datetime | None = None) -> DiscoveryReport:
+    return DiscoveryReport(root_path=root_path, candidates=candidates, scanned_at=scanned_at or datetime.now(timezone.utc))
+
+
+async def _row(session: AsyncSession, node_id: str, resource_key: str) -> DiscoveredResourceModel | None:
+    result = await session.execute(
+        select(DiscoveredResourceModel).where(
+            DiscoveredResourceModel.node_id == node_id,
+            DiscoveredResourceModel.resource_key == resource_key,
+        )
+    )
+    return result.scalars().first()
+
+
+async def _seed_row(
+    session: AsyncSession,
+    *,
+    node_id: str,
+    resource_key: str,
+    root_path: str,
+    state: str,
+    project_id: str | None = None,
+    evidence: dict | None = None,
+    first_seen_at: datetime | None = None,
+    last_seen_at: datetime | None = None,
+) -> DiscoveredResourceModel:
+    now = datetime.now(timezone.utc)
+    row = DiscoveredResourceModel(
+        id=f"row-{resource_key}",
+        node_id=node_id,
+        kind="project",
+        resource_key=resource_key,
+        project_id=project_id,
+        evidence_json=json.dumps(evidence or {"suggested_project_id": "x"}),
+        state=state,
+        root_path=root_path,
+        first_seen_at=first_seen_at or now,
+        last_seen_at=last_seen_at or now,
+    )
+    session.add(row)
+    await session.commit()
+    return row
+
+
+# --------------------------------------------------------------------------
+# Rule 1: a new candidate is INSERTed as DISCOVERED
+# --------------------------------------------------------------------------
+
+
+async def test_a_new_candidate_is_inserted_as_discovered(db_session) -> None:
+    executor = await _executor(db_session)
+    now = datetime.now(timezone.utc)
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+
+    await store.record_discovery_report(db_session, executor, report, now=now)
+
+    row = await _row(db_session, "E1", "/root/hub")
+    assert row is not None
+    assert row.state == DiscoveredState.DISCOVERED.value
+    seen = row.first_seen_at if row.first_seen_at.tzinfo else row.first_seen_at.replace(tzinfo=timezone.utc)
+    assert seen == now
+    assert row.first_seen_at == row.last_seen_at
+    evidence = json.loads(row.evidence_json)
+    assert evidence["suggested_project_id"] == "hub"
+
+
+# --------------------------------------------------------------------------
+# Rule 2: an existing candidate refreshes evidence/last_seen_at, never state
+# --------------------------------------------------------------------------
+
+
+async def test_existing_candidate_refreshes_evidence_without_regressing_state(db_session) -> None:
+    executor = await _executor(db_session)
+    old_seen = datetime.now(timezone.utc) - timedelta(hours=1)
+    await _seed_row(
+        db_session,
+        node_id="E1",
+        resource_key="/root/hub",
+        root_path="/root",
+        state=DiscoveredState.ADOPTED.value,
+        evidence={"suggested_project_id": "hub", "head": "old-sha"},
+        last_seen_at=old_seen,
+    )
+
+    now = datetime.now(timezone.utc)
+    report = _report(
+        "/root",
+        [
+            _candidate("/root/hub", suggested_project_id="hub", suggested_name="hub", head="new-sha"),
+            # Positive control: a genuinely new candidate in the SAME report
+            # still gets inserted -- proves the loop is not a global no-op.
+            _candidate("/root/new-repo", suggested_project_id="new-repo", suggested_name="new-repo"),
+        ],
+    )
+    await store.record_discovery_report(db_session, executor, report, now=now)
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    assert hub.state == DiscoveredState.ADOPTED.value  # never regressed
+    assert json.loads(hub.evidence_json)["head"] == "new-sha"
+    seen = hub.last_seen_at if hub.last_seen_at.tzinfo else hub.last_seen_at.replace(tzinfo=timezone.utc)
+    assert seen == now
+
+    new_repo = await _row(db_session, "E1", "/root/new-repo")
+    assert new_repo is not None
+    assert new_repo.state == DiscoveredState.DISCOVERED.value
+
+
+# --------------------------------------------------------------------------
+# Rule 3: a row absent from the current report (and not DENIED) goes STALE
+# --------------------------------------------------------------------------
+
+
+async def test_a_row_missing_from_the_report_becomes_stale(db_session) -> None:
+    executor = await _executor(db_session)
+    await _seed_row(
+        db_session, node_id="E1", resource_key="/root/gone", root_path="/root", state=DiscoveredState.DISCOVERED.value
+    )
+    await _seed_row(
+        db_session, node_id="E1", resource_key="/root/still-here", root_path="/root", state=DiscoveredState.DISCOVERED.value
+    )
+
+    report = _report("/root", [_candidate("/root/still-here", suggested_project_id="still-here", suggested_name="s")])
+    await store.record_discovery_report(db_session, executor, report)
+
+    gone = await _row(db_session, "E1", "/root/gone")
+    assert gone.state == DiscoveredState.STALE.value
+
+    # Positive control: presence prevents staling.
+    still_here = await _row(db_session, "E1", "/root/still-here")
+    assert still_here.state == DiscoveredState.DISCOVERED.value
+
+
+async def test_reconciliation_is_scoped_to_the_reports_own_root_path(db_session) -> None:
+    """A row for a DIFFERENT root on the same node must not go STALE just
+
+    because this report is about a different root entirely.
+    """
+    executor = await _executor(db_session)
+    await _seed_row(
+        db_session,
+        node_id="E1",
+        resource_key="/other-root/untouched",
+        root_path="/other-root",
+        state=DiscoveredState.DISCOVERED.value,
+    )
+
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+    await store.record_discovery_report(db_session, executor, report)
+
+    untouched = await _row(db_session, "E1", "/other-root/untouched")
+    assert untouched.state == DiscoveredState.DISCOVERED.value
+
+
+# --------------------------------------------------------------------------
+# Rule 4: DENIED is never touched by observation, in either direction
+# --------------------------------------------------------------------------
+
+
+async def test_denied_row_is_not_touched_even_when_reported_again(db_session) -> None:
+    old_evidence = {"suggested_project_id": "hub", "head": "old-sha"}
+    old_seen = datetime.now(timezone.utc) - timedelta(days=1)
+    await _seed_row(
+        db_session,
+        node_id="E1",
+        resource_key="/root/hub",
+        root_path="/root",
+        state=DiscoveredState.DENIED.value,
+        evidence=old_evidence,
+        last_seen_at=old_seen,
+    )
+    executor = await _executor(db_session)
+
+    report = _report(
+        "/root",
+        [
+            _candidate("/root/hub", suggested_project_id="hub", suggested_name="hub", head="new-sha"),
+            # Positive control: a non-denied candidate in the same report DOES update.
+            _candidate("/root/other", suggested_project_id="other", suggested_name="other"),
+        ],
+    )
+    await store.record_discovery_report(db_session, executor, report)
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    assert hub.state == DiscoveredState.DENIED.value
+    assert json.loads(hub.evidence_json) == old_evidence  # untouched, not just "state unchanged"
+    seen = hub.last_seen_at if hub.last_seen_at.tzinfo else hub.last_seen_at.replace(tzinfo=timezone.utc)
+    assert abs(seen - old_seen) < timedelta(seconds=1)  # untouched -- not refreshed to "now"
+
+    other = await _row(db_session, "E1", "/root/other")
+    assert other is not None
+    assert other.state == DiscoveredState.DISCOVERED.value
+
+
+async def test_denied_row_does_not_regress_to_stale_when_absent(db_session) -> None:
+    """The exact bug named in `docs/control-plane.md`: a refused candidate
+
+    must not return to the adoption queue -- here, by going STALE and later
+    reappearing as DISCOVERED -- on a reconnect that no longer reports it.
+    """
+    await _seed_row(
+        db_session, node_id="E1", resource_key="/root/hub", root_path="/root", state=DiscoveredState.DENIED.value
+    )
+    executor = await _executor(db_session)
+
+    report = _report("/root", [])  # hub no longer reported at all
+    await store.record_discovery_report(db_session, executor, report)
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    assert hub.state == DiscoveredState.DENIED.value
+
+
+# --------------------------------------------------------------------------
+# Rule 5: a STALE row that reappears restores the prior decision, not DISCOVERED
+# --------------------------------------------------------------------------
+
+
+async def test_stale_row_reappearing_with_no_project_reverts_to_discovered(db_session) -> None:
+    await _seed_row(
+        db_session, node_id="E1", resource_key="/root/hub", root_path="/root", state=DiscoveredState.STALE.value
+    )
+    executor = await _executor(db_session)
+
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+    await store.record_discovery_report(db_session, executor, report)
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    assert hub.state == DiscoveredState.DISCOVERED.value
+
+
+async def test_stale_row_reappearing_with_active_authorization_reverts_to_authorized(db_session) -> None:
+    await _seed_row(
+        db_session,
+        node_id="E1",
+        resource_key="/root/hub",
+        root_path="/root",
+        state=DiscoveredState.STALE.value,
+        project_id="p1",
+    )
+    db_session.add(
+        ProjectAuthorizationModel(
+            id="auth-1",
+            node_id="E1",
+            project_id="p1",
+            capabilities_json="[\"read\"]",
+            granted_by="operator:esteban",
+            granted_at=datetime.now(timezone.utc),
+            revoked_at=None,
+        )
+    )
+    await db_session.commit()
+    executor = await _executor(db_session)
+
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+    await store.record_discovery_report(db_session, executor, report)
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    assert hub.state == DiscoveredState.AUTHORIZED.value
+
+
+async def test_stale_row_reappearing_with_only_a_revoked_authorization_reverts_to_adopted(db_session) -> None:
+    """The negative half of the pair above: a REVOKED authorization must not
+
+    count -- the row goes back to ADOPTED (the binding decision survives),
+    not AUTHORIZED (which the operator specifically took away).
+    """
+    await _seed_row(
+        db_session,
+        node_id="E1",
+        resource_key="/root/hub",
+        root_path="/root",
+        state=DiscoveredState.STALE.value,
+        project_id="p1",
+    )
+    db_session.add(
+        ProjectAuthorizationModel(
+            id="auth-1",
+            node_id="E1",
+            project_id="p1",
+            capabilities_json="[\"read\"]",
+            granted_by="operator:esteban",
+            granted_at=datetime.now(timezone.utc) - timedelta(days=2),
+            revoked_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+    )
+    await db_session.commit()
+    executor = await _executor(db_session)
+
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+    await store.record_discovery_report(db_session, executor, report)
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    assert hub.state == DiscoveredState.ADOPTED.value
+
+
+# --------------------------------------------------------------------------
+# Structural property: discovery never touches authorization or projects
+# --------------------------------------------------------------------------
+
+
+async def test_record_discovery_report_never_writes_authorization_or_projects(db_session) -> None:
+    """The property that makes "the node proposes, the panel adopts" true by
+
+    construction: this function has no code path to either table at all.
+    """
+    executor = await _executor(db_session)
+    db_session.add(ProjectModel(id="p1", name="Existing Project", path="/srv/p1", enabled=True))
+    db_session.add(
+        ProjectAuthorizationModel(
+            id="auth-1",
+            node_id="E1",
+            project_id="p1",
+            capabilities_json="[\"read\"]",
+            granted_by="operator:esteban",
+            granted_at=datetime.now(timezone.utc),
+        )
+    )
+    await db_session.commit()
+
+    projects_before = (await db_session.execute(select(ProjectModel))).scalars().all()
+    authorizations_before = (await db_session.execute(select(ProjectAuthorizationModel))).scalars().all()
+    projects_before_dump = [(p.id, p.name, p.path, p.enabled) for p in projects_before]
+    authorizations_before_dump = [
+        (a.id, a.node_id, a.project_id, a.capabilities_json, a.revoked_at) for a in authorizations_before
+    ]
+
+    report = _report(
+        "/root",
+        [_candidate(f"/root/repo-{i}", suggested_project_id=f"repo-{i}", suggested_name=f"repo-{i}") for i in range(20)],
+    )
+    await store.record_discovery_report(db_session, executor, report)
+
+    projects_after = (await db_session.execute(select(ProjectModel))).scalars().all()
+    authorizations_after = (await db_session.execute(select(ProjectAuthorizationModel))).scalars().all()
+    projects_after_dump = [(p.id, p.name, p.path, p.enabled) for p in projects_after]
+    authorizations_after_dump = [
+        (a.id, a.node_id, a.project_id, a.capabilities_json, a.revoked_at) for a in authorizations_after
+    ]
+
+    assert projects_after_dump == projects_before_dump
+    assert authorizations_after_dump == authorizations_before_dump
+
+
+# --------------------------------------------------------------------------
+# Batch behaviour: many candidates, not one round trip each
+# --------------------------------------------------------------------------
+
+
+async def test_a_large_report_does_not_cost_one_round_trip_per_candidate(db_session) -> None:
+    """247 candidates -- the real root that motivated this work, rounded up
+
+    to 250 -- must not cost 250 `SELECT`s or 250 commits. `record_discovery_
+    report`'s own docstring promises exactly one of each; this asserts it.
+    """
+    executor = await _executor(db_session)
+    report = _report(
+        "/root",
+        [_candidate(f"/root/repo-{i}", suggested_project_id=f"repo-{i}", suggested_name=f"repo-{i}") for i in range(250)],
+    )
+
+    execute_calls = 0
+    commit_calls = 0
+    original_execute = AsyncSession.execute
+    original_commit = AsyncSession.commit
+
+    async def counting_execute(self, *args, **kwargs):
+        nonlocal execute_calls
+        execute_calls += 1
+        return await original_execute(self, *args, **kwargs)
+
+    async def counting_commit(self, *args, **kwargs):
+        nonlocal commit_calls
+        commit_calls += 1
+        return await original_commit(self, *args, **kwargs)
+
+    AsyncSession.execute = counting_execute
+    AsyncSession.commit = counting_commit
+    try:
+        await store.record_discovery_report(db_session, executor, report)
+    finally:
+        AsyncSession.execute = original_execute
+        AsyncSession.commit = original_commit
+
+    # One SELECT to load existing rows for this (node, root); one COMMIT to
+    # persist all 250 inserts together. Nowhere near 250 of either.
+    assert execute_calls <= 2, f"expected O(1) session.execute calls, got {execute_calls}"
+    assert commit_calls == 1
+
+    rows = (await db_session.execute(select(DiscoveredResourceModel))).scalars().all()
+    assert len(rows) == 250


### PR DESCRIPTION
Issue #73, Stage 3 — stacked on **#75**, review that first. Stage 1 created `discovered_resources` and left it empty with no code touching it; Stage 2 left the node reporting a `discovery_root_count` and nothing else. This is what makes the roots produce rows.

## The design decision that was missing
Two things with almost the same name, doing different jobs — stated out loud in code and docs so a third place never appears:
- **On the node** (`AgentSettings.discovery_roots`, new): *which directories this node scans*. Only the node can decide that; it is its filesystem. Empty by default, so today's behaviour is preserved.
- **On the operator** (`ExecutorRegistration.discovery_roots`, which has existed in `registry.json` since Stage 1 and nothing read): *what each root grants automatically*, matched by `root_path`. Consumed by the adoption PR, not this one.

`auto_project_root` is left alone: it is the layer-7 valve that resolves an unknown `project_id` at dispatch time — a different concern, noted rather than merged.

## What changes
- `_discovery_loop` beside the existing `_heartbeat_loop`, reusing `shared.project_discovery`'s walk (the same one `discover_projects.py` and `resolve_auto_project` use — not a second scanner) and `git_tools.run_git` for the remote probe. The walk runs in `run_in_executor`: it is blocking filesystem I/O and a real operator root holds **247 repositories**, which cannot be allowed to stall the heartbeat or the dispatch loop. Its own interval (3600s), never coupled to the 15s heartbeat.
- **One envelope per root**, so a root with hundreds of candidates cannot delay the others.
- `DISCOVERY_REPORT` as its own message, deliberately not folded into `NodeAnnouncement`: Stage 2 documented why `hello` carries only a count, and mixing them would make a small, once-per-connection message carry hundreds of paths on every reconnect.
- The gateway branch calls **only** `store.record_discovery_report`, which writes **only** `discovered_resources`. That is what makes "the node proposes, the panel adopts" true by construction rather than by convention — the code path that receives a discovery has no way to grant authorization. A test asserts it writes to neither `projects` nor `project_authorizations`.
- Reconciliation implements all five state rules: new → `DISCOVERED`; seen again → evidence refreshed, state never regressed; absent from a fresh report → `STALE`; `DENIED` never touched by observation; a `STALE` row that reappears returns to what it was. Batched — one `SELECT`, in-memory mutation, one commit — not 247 round trips.

## `resource_key` is sensitive data, and now says so
In practice it is the candidate's absolute path on the node — the only stable way to identify it before a `projects.id` exists, which is also why it is not a foreign key. That puts it in the same category as `workspace_bindings.local_path`, whose exception `docs/control-plane.md` already names. That exception did not exist anywhere for `resource_key`; this PR writes it into `docs/control-plane.md`, `docs/api/README.md` ("fields that must never ship") and `docs/threat-model.md`.

## Defect found, flagged not patched
`discovered_resources.resource_key` is `varchar(255)` in migration `0009`, written when the column was still imagined as a short suggested id. This PR settles it as an absolute path. SQLite's type affinity does not enforce the width — and `aiomysql` is a dependency, so MySQL is a supported target where it **would**. Widening it naively is not the fix either: the column sits in a composite unique index, and MySQL's index key limit is what 255 was probably protecting. This needs a deliberate follow-up (a hashed key of fixed width, with the path in `evidence_json`, is the likely shape) rather than a fragile single-dialect `ALTER`.

## Validation
`pytest -q`: **829 passed, 7 skipped, 0 failed** (baseline on this branch was 799). `tests/contract/`: 26 passed. No REST route, so `API_CONTRACT_VERSION` is untouched.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw