### PR TITLE
feat(gh-73): discovery adoption — the panel decides, project_authorizations answers only to a human

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -171,10 +171,21 @@ by the contract itself, not by a filter applied late:
   the project's real path on the executor and it is an internal field. Projects
   are addressed by `ProjectId` and nothing else. Same category, same rule:
   `WorkspaceBindingModel.local_path` (issue #73) and
-  `DiscoveredResourceModel.resource_key` (issue #73 Stage 3) — the latter IS
-  the candidate's absolute path on the node, not a project id
-  (`docs/control-plane.md`, "`resource_key` é dado sensível"). Both are
-  operator-surface-only, exactly like `ProjectModel.path`;
+  `DiscoveredResourceModel.resource_path` (issue #73 Stage 3 adoption half,
+  `migrations/0013_discovery_resource_key_hash.sql`) — the latter IS the
+  candidate's absolute path on the node, not a project id
+  (`docs/control-plane.md`, "resource_key é dado sensível"). Both are
+  operator-surface-only, exactly like `ProjectModel.path` — and both have
+  exactly one exception, both narrow and both administrative-scoped:
+  `WorkspaceBindingModel.local_path` has none yet (no endpoint returns it in
+  this build); `DiscoveredResourceModel.resourcePath` is returned by
+  `GET /api/v1/nodes/{nodeId}/discovered-resources` and the `adopt`/`deny`
+  responses ONLY — see "Discovered resources" above for why. Since 0013,
+  `DiscoveredResourceModel.resource_key` itself is no longer the sensitive
+  field: it is `hash_resource_key(path)`, a fixed-width lookup key with no
+  reversible relationship to the path it was computed from, and it is not
+  part of this contract's response shape at all (present in the database,
+  absent from every DTO);
 - executor hostnames, internal IPs, ports, or anything that would let a client
   reach an executor without going through the gateway;
 - raw stack traces and raw driver errors. These map to `internal_error` plus a
@@ -997,6 +1008,106 @@ different-fingerprint call is answered `409`, never silently replayed. This
 is issue #10's "message creation is idempotent for offline retries"
 acceptance criterion, and the mechanism that also prevents the duplicate
 messages the issue's own test coverage requirement names.
+
+---
+
+## Discovered resources (issue #73 Stage 3, WK-20260902-gh73-discovery-adoption)
+
+`GET /api/v1/nodes/{nodeId}/discovered-resources`,
+`POST /api/v1/discovered-resources/{resourceId}/adopt` and
+`POST .../{resourceId}/deny`. The panel's half of "the node proposes, the
+panel adopts" (`docs/control-plane.md`): the report half (Stage 3's other PR)
+writes only `discovered_resources`; this half is the only REST surface that
+may turn a row there into a `ProjectModel`, a `WorkspaceBindingModel`, a
+`ScmAssociationModel`, or a `project_authorizations` grant.
+
+### Administrative, not project-scoped — reason, not just form
+
+A discovered candidate is not scoped to any project the caller already sees;
+often none exists yet, which is the whole point of the adoption decision. Both
+actions (`nodes.discoveries.read`, `nodes.discoveries.decide`) therefore
+follow `nodes.read`'s precedent: `codexbridge.admin`, fleet-wide, never
+`visible_projects`-scoped. Deciding is a separate action from reading for the
+same reason `decisions.read`/`decisions.decide` are separate: seeing the queue
+and deciding it are capabilities an operator may grant independently.
+
+### Why `resourcePath`/`rootPath` are allowed on the wire here
+
+"No response exposes a server filesystem path" (this document's own
+conventions, and "Fields that must never ship" below) has exactly one standing
+exception, pre-registered by the report PR before this one existed
+(`docs/control-plane.md`, "resource_key é dado sensível... quando a rota de
+adoção existir, cai na mesma regra de local_path"): this endpoint, and only
+this endpoint, because an operator deciding whether to adopt a candidate
+cannot decide from an opaque id — they need to see which directory it is. The
+exception is narrow on purpose: gated by the same administrative scope as
+every other node-fleet field, and not extended to any other DTO on this
+contract. `ProjectStatus`, `Session`, `Mission` and every MCP tool still never
+carry it.
+
+### Why `resourcePath` exists at all, distinct from `resourceKey`
+
+`discovered_resources.resource_key` was written, from Stage 3's report PR
+through `migrations/0013_discovery_resource_key_hash.sql`, as the candidate's
+raw absolute path — up to 2048 characters — into a column declared
+`varchar(255)`. SQLite never enforced that width (type affinity, not a
+constraint); MySQL, a declared target via `aiomysql`, does, so a long enough
+path was an unhit insert failure. `resource_key` is now
+`shared.security.hash_resource_key(path)` — a fixed-width lookup key, never
+part of this contract's response — and `resourcePath`, a new, unindexed
+column, carries the actual path instead. See `hash_resource_key`'s own
+docstring and that migration's comment for why widening the original column
+was rejected in favor of hashing.
+
+### `adopt`: exactly one of `projectId`/`newProject`, and two grant origins that can coexist
+
+`grantCapabilities` in the request body is the operator's explicit grant,
+recorded `grantedBy: "operator:<userId>"`. Separately, when the candidate's
+`rootPath` string-matches a `DiscoveryRoot` on the node's own registration
+that carries `autoAuthorize`, that grant is applied too, recorded
+`grantedBy: "root-config:<path>"`. Both can apply in the same call — the
+underlying `project_authorizations` table allows exactly one row per
+`(nodeId, projectId)` (`0009_control_plane.sql`), so the two origins merge
+into one row rather than racing that constraint, and `grantedBy` becomes a
+`;`-joined set naming every origin that contributed. Neither `autoAuthorize`
+nor a node's own configuration can ever reach `modify`/`deliver` —
+`shared.protocol.AUTO_AUTHORIZABLE_CAPABILITIES` caps it to `read`/`test`,
+enforced when `DiscoveryRoot` is parsed, before any node connects. Only an
+explicit `grantCapabilities` naming a human operator can grant those two.
+
+### A node cannot reach `adopt`/`deny` — structurally, not by convention
+
+Both routes require `nodes.discoveries.decide` (`codexbridge.admin`), which
+`gateway/app/api/auth.py:current_principal` grants only to a caller presenting
+an OAuth access token. The executor WebSocket
+(`gateway/app/main.py:agent_ws`) authenticates with a `machine_token`, checked
+independently in `main.py` and never turned into an `AuthenticatedPrincipal` —
+there is no code path from a connected node's credential to either endpoint.
+Issue #73: "a node cannot grant itself project authorization merely by
+reporting a discovery" — this is the one door into `project_authorizations`
+this build has, and only a human can open it
+(`tests/integration/test_discovery_routes.py::
+test_a_principal_without_the_administrative_scope_cannot_adopt`,
+`tests/unit/test_discovery_store.py::
+test_a_matching_auto_authorize_root_grants_nothing_from_a_report_alone`).
+
+### `adopt`/`deny` require a decidable state, and that is what prevents duplication
+
+Only `discovered`/`stale` may be adopted or denied; a candidate already
+`adopted`/`authorized`/`denied` answers `409 conflict`. This is not a
+defensive check layered on top of the write — it IS what keeps a repeated
+`adopt` from creating a second `WorkspaceBindingModel` or
+`ScmAssociationModel` for the same candidate: the second call never reaches
+the write at all.
+
+### No `revision`, no `ETag`, no `If-Match`
+
+`DiscoveredResourceModel` carries no revision column — same posture
+`Conversations` above documents for its own GET-only shapes, extended here to
+a row two POST endpoints do mutate: `adopt`/`deny` are one-shot state
+transitions guarded by the decidable-state check above, not a general-purpose
+update a concurrent writer could race meaningfully. `Idempotency-Key` is what
+protects a retry instead, the same shape `POST /api/v1/issues` established.
 
 ---
 

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.9.0
+  version: 1.12.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -550,6 +550,181 @@ paths:
         '401': {$ref: '#/components/responses/Unauthenticated'}
         '403': {$ref: '#/components/responses/PermissionDenied'}
         '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/nodes/{nodeId}/discovered-resources:
+    get:
+      operationId: listDiscoveredResources
+      tags: [discovery]
+      summary: Candidates one Bridge Node has discovered
+      description: |
+        Issue #73 Stage 3 (adoption half). What the node's own discovery
+        scan has SEEN under its configured roots, not what it may run —
+        "discovery is not authorization" (#73). Administrative and
+        fleet-wide, same posture as `GET /api/v1/nodes`: a candidate is not
+        scoped to any project the caller already sees, often because none
+        exists yet.
+
+        Cursor-paginated, unlike `GET /api/v1/nodes` — a single real operator
+        root has reported 247 candidates in one scan, which is exactly the
+        scale `GET /api/v1/nodes` does not have to handle.
+
+        `resourcePath` and `rootPath` are absolute filesystem paths on the
+        node. This is the one endpoint on this contract that returns them —
+        a pre-registered, narrow exception to "no response exposes a server
+        filesystem path" (see `docs/api/README.md`, "Fields that must never
+        ship"), gated by the same administrative scope as every other field
+        here.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/NodeId'
+        - name: state
+          in: query
+          required: false
+          description: Restrict to one `DiscoveredResource.state`.
+          schema:
+            $ref: '#/components/schemas/DiscoveredState'
+        - $ref: '#/components/parameters/Cursor'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of discovered candidates.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items, page]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DiscoveredResource'
+                  page:
+                    $ref: '#/components/schemas/PageInfo'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/discovered-resources/{resourceId}/adopt:
+    post:
+      operationId: adoptDiscoveredResource
+      tags: [discovery]
+      summary: Bind a discovered candidate to a project
+      description: |
+        Issue #73 Stage 3 (adoption half). Creates or reuses a `ProjectModel`,
+        binds it to the candidate's node (`local_path` = the candidate's own
+        path), records an SCM association when the candidate's evidence
+        carried a `remote_url`, and moves `state` to `adopted` or
+        `authorized`.
+
+        Exactly one of `projectId` or `newProject` is required. When the
+        candidate's `rootPath` matches a `DiscoveryRoot` the node's own
+        registration marks `autoAuthorize`, or when `grantCapabilities` is
+        given, the resulting authorization is granted in the same call — both
+        may apply at once. Neither path can ever grant `modify` or `deliver`
+        through `autoAuthorize` (`shared.protocol.AUTO_AUTHORIZABLE_
+        CAPABILITIES`); only an explicit `grantCapabilities` naming an
+        operator can.
+
+        Only a `discovered`/`stale` candidate may be adopted — one already
+        `adopted`/`authorized`/`denied` answers `409`, which is also what
+        keeps a repeated adopt from duplicating the project/binding/
+        association it already produced.
+
+        With `Idempotency-Key`, a retry returns the first response and
+        adopts nothing twice; the replay carries `Idempotent-Replay: true`.
+
+        A node cannot reach this endpoint: it requires an authenticated
+        human/operator principal with `codexbridge.admin`, a class of
+        credential the executor's `machine_token` cannot satisfy (issue #73:
+        "a node cannot grant itself project authorization merely by
+        reporting a discovery").
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: resourceId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdoptDiscoveredResourceRequest'
+      responses:
+        '200':
+          description: The discovered resource after adoption.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveredResource'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/discovered-resources/{resourceId}/deny:
+    post:
+      operationId: denyDiscoveredResource
+      tags: [discovery]
+      summary: Refuse a discovered candidate
+      description: |
+        Moves `state` to `denied`. Distinct from an "ignore" — the contract
+        (and `shared.protocol.DiscoveredState`) names no sixth state; "ignore"
+        is a client-side filter over `discovered`/`stale`, not a server
+        decision. Once `denied`, the candidate is never touched by another
+        discovery report from its node — reappearing does not return it to
+        the adoption queue.
+
+        Only a `discovered`/`stale` candidate may be denied; one already
+        decided answers `409`.
+
+        With `Idempotency-Key`, a retry returns the first response and denies
+        nothing twice; the replay carries `Idempotent-Replay: true`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: resourceId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/Id'
+        - $ref: '#/components/parameters/IdempotencyKey'
+      responses:
+        '200':
+          description: The discovered resource after denial.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DiscoveredResource'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {$ref: '#/components/responses/Conflict'}
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
 
@@ -3160,6 +3335,106 @@ components:
             `true` when `capabilitiesObservedAt` is `null`, or older than the
             gateway's inventory freshness window. A client should render stale
             inventory as visibly stale rather than as current fact.
+
+    DiscoveredState:
+      type: string
+      enum: [discovered, adopted, authorized, denied, stale]
+      description: |
+        Lifecycle of one candidate a node has reported (issue #73). `discovered`
+        — reported, nothing decided; this is NOT permission to run it
+        ("discovery is not authorization"). `adopted` — bound to a project, no
+        capability granted yet. `authorized` — at least one capability is
+        granted. `denied` — refused; does not return to the queue on
+        reconnect. `stale` — last seen in an earlier scan, absent from the
+        current one; the row and its prior decision survive.
+
+    DiscoveredResource:
+      type: object
+      description: |
+        One candidate a Bridge Node's own discovery scan found. `resourcePath`
+        and `rootPath` are absolute paths on the node's filesystem — see
+        `docs/api/README.md`, "Fields that must never ship", for why this is
+        the one shape on this contract allowed to carry them.
+      required: [id, nodeId, kind, state, firstSeenAt, lastSeenAt]
+      properties:
+        id:
+          $ref: '#/components/schemas/Id'
+        nodeId:
+          $ref: '#/components/schemas/NodeId'
+        kind:
+          type: string
+          description: Always `project` in this build; the schema leaves room for other machine-local resource kinds issue #73 anticipates.
+        state:
+          $ref: '#/components/schemas/DiscoveredState'
+        projectId:
+          type: [string, 'null']
+          description: Set once this candidate is adopted; `null` before that.
+        resourcePath:
+          type: [string, 'null']
+          maxLength: 2048
+          description: The candidate's absolute path on the node. Sensitive — see the schema description above.
+        rootPath:
+          type: [string, 'null']
+          maxLength: 2048
+          description: The `discoveryRoots` entry this candidate was found under, exactly as the node's own configuration names it.
+        suggestedProjectId:
+          type: [string, 'null']
+          maxLength: 128
+        suggestedName:
+          type: [string, 'null']
+          maxLength: 255
+        remoteUrl:
+          type: [string, 'null']
+          maxLength: 2048
+          description: '`git remote get-url origin`, or `null` when the repository has no `origin`.'
+        head:
+          type: [string, 'null']
+        dirty:
+          type: [boolean, 'null']
+        firstSeenAt:
+          $ref: '#/components/schemas/Timestamp'
+        lastSeenAt:
+          $ref: '#/components/schemas/Timestamp'
+        decidedBy:
+          type: [string, 'null']
+          description: '`operator:<userId>`, set by `adopt`/`deny`. `null` before any decision.'
+        decidedAt:
+          type: [string, 'null']
+          format: date-time
+
+    NewProjectSpec:
+      type: object
+      required: [projectId, name]
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        name:
+          type: string
+          minLength: 1
+          maxLength: 255
+
+    AdoptDiscoveredResourceRequest:
+      type: object
+      description: |
+        Exactly one of `projectId` or `newProject` is required — neither or
+        both is `validation_failed`.
+      properties:
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+          description: Reuse an existing project. Mutually exclusive with `newProject`.
+        newProject:
+          $ref: '#/components/schemas/NewProjectSpec'
+          description: Create a project for this candidate. Mutually exclusive with `projectId`.
+        grantCapabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Capability'
+          description: |
+            Capabilities the operator explicitly grants on adoption, recorded
+            with `grantedBy: "operator:<userId>"`. May include `modify`/
+            `deliver` — unlike a discovery root's `autoAuthorize`, which never
+            can. May coexist with a matching root's own grant in the same
+            call; both merge into one authorization row.
 
     Session:
       type: object

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-report`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-report map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-adoption`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-adoption map`
 
 ## Summary
 
-- 135 file(s) · 1290 symbol(s) indexed
-- Languages: config (2), python (131), shell (2)
+- 138 file(s) · 1335 symbol(s) indexed
+- Languages: config (2), python (134), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -70,6 +70,7 @@ gateway/
         auth.py  — "Sign-in, renewal, revocation, and what the actor may actually do."
         conversations.py  — "Conversations and contextual messaging — issue #10."
         decisions.py  — "Operational decisions: sensitive tasks held for a human to resolve — issue #6."
+        discovery.py  — "Discovered resources: the panel's half of "the node proposes, the panel adopts"."
         epics.py  — "Epics — issue #8."
         issues.py  — "Issues — issue #8."
         missions.py  — "Missions: the mission-control view of the same run Sessions exposes — issue #7."
@@ -103,6 +104,7 @@ gateway/
       agent_hub.py
       audit.py
       conversation_types.py  — "Closed vocabulary for conversation context references, and their error."
+      discovery_types.py  — "Closed vocabulary for adopting a `discovered_resources` row, and its error."
       email_templates.py  — "Branded HTML for every CodexBridge transactional email."
       google_calendar.py  — "A Google Calendar client for reminders, built to be tested without ever"
       issue_types.py  — "Closed vocabularies for epics and issues, and the error they fail with."
@@ -141,6 +143,7 @@ tests/
     test_codex_runner_real_process.py  — "CodexRunner against a REAL `codex` subprocess — not the fake used everywhere else."
     test_conversations.py  — "Conversations and contextual messaging — issue #10."
     test_decisions.py  — "Operational decisions — issue #6."
+    test_discovery_routes.py  — "Discovered-resource adoption routes — issue #73 Stage 3 adoption half."
     test_dispatch_payload_engine_and_delivery.py  — "`AgentHub.dispatch_next` forwards engine/issue_ref/delivery to the executor."
     test_epics_issues.py  — "Epics and issues — issue #8."
     test_mcp_reminders.py  — "The `create_reminder`/`cancel_reminder` MCP tools, at the `handle_mcp_call` layer."
@@ -427,6 +430,16 @@ tests/
 - `reject_decision(decision_id, body, response, if_match, idempotency_key, principal, session)` *(async function)*
 - `request_decision_revision(decision_id, body, response, if_match, idempotency_key, principal, session)` *(async function)*
 
+### `gateway/app/api/routes/discovery.py`
+
+> Discovered resources: the panel's half of "the node proposes, the panel adopts".
+
+- **`NewProjectSpec`** *(class)*
+- **`AdoptDiscoveredResourceRequest`** *(class)*
+- `list_discovered_resources(node_id, response, state, cursor, limit, principal, session)` *(async function)* — "One node's discovered candidates, cursor-paginated, newest-id last."
+- `adopt_discovered_resource(resource_id, payload, response, idempotency_key, principal, session)` *(async function)* — "Bind a discovered candidate to a project (existing or new)."
+- `deny_discovered_resource(resource_id, response, idempotency_key, principal, session)` *(async function)* — "Refuse a discovered candidate. "Ignore" is a UI filter over `DISCOVERED`/"
+
 ### `gateway/app/api/routes/epics.py`
 
 > Epics — issue #8.
@@ -673,6 +686,13 @@ tests/
 - **`ConversationPlanningError`** *(class)* — "A create input that fails validation inside the store itself."
   - `__init__(self, field, code, message)` *(method)*
 
+### `gateway/app/services/discovery_types.py`
+
+> Closed vocabulary for adopting a `discovered_resources` row, and its error.
+
+- **`DiscoveryAdoptionError`** *(class)* — "An adopt/deny input that fails validation inside the store itself."
+  - `__init__(self, field, code, message)` *(method)*
+
 ### `gateway/app/services/email_templates.py`
 
 > Branded HTML for every CodexBridge transactional email.
@@ -734,6 +754,10 @@ tests/
 - `ensure_node_for_executor(session, executor)` *(async function)* — "The Bridge Node bound to `executor`, creating and binding one if needed."
 - `record_node_announcement(session, executor, announcement)` *(async function)* — "Persist a HELLO's `NodeAnnouncement` onto the node bound to `executor`."
 - `record_discovery_report(session, executor, report)` *(async function)* — "Persist one root's `DiscoveryReport` into `discovered_resources` -- and nothing else."
+- `list_discovered_resources_page(session, node_id)` *(async function)* — "One node's discovered candidates, ordered by id, over-fetched by one."
+- `get_discovered_resource(session, resource_id)` *(async function)*
+- `adopt_discovered_resource(session, resource_id)` *(async function)* — "Adopt one discovered candidate: bind it to a project and, when either"
+- `deny_discovered_resource(session, resource_id)` *(async function)* — "Refuse one discovered candidate. See `DECIDABLE_DISCOVERY_STATES` --"
 - `list_nodes(session)` *(async function)* — "Every Bridge Node, ordered by id, paired with the executor bound to it."
 - `get_node(session, node_id)` *(async function)* — "One Bridge Node and its bound executor, or None if the node does not exist."
 - `next_dispatchable_task(session, executor_id)` *(async function)*
@@ -864,6 +888,7 @@ tests/
 
 - `secure_compare(left, right)`
 - `hash_token(token)`
+- `hash_resource_key(value)` — "A fixed-width (64 hex chars), indexable stand-in for an unbounded string."
 - `sanitize_log_line(line)`
 - `ensure_within_root(root, target)`
 - `filtered_environment(allowed_keys)`
@@ -1200,6 +1225,41 @@ tests/
 - `test_request_revision_requires_a_non_empty_reason(api)` *(async function)*
 - `test_request_revision_is_a_distinct_outcome_from_reject(api)` *(async function)*
 - `test_request_revision_on_a_resolved_decision_is_a_conflict(api)` *(async function)*
+
+### `tests/integration/test_discovery_routes.py`
+
+> Discovered-resource adoption routes — issue #73 Stage 3 adoption half.
+
+- `users_file(tmp_path)`
+- `api(users_file, monkeypatch)` *(async function)*
+- `auth(token)`
+- `seed_resource(factory)` *(async function)*
+- `test_list_requires_a_token(api)` *(async function)*
+- `test_list_without_the_admin_scope_is_forbidden(api)` *(async function)*
+- `test_list_with_the_admin_scope_is_allowed(api)` *(async function)* — "Positive control for the previous two: the scope alone is sufficient."
+- `test_a_principal_without_the_administrative_scope_cannot_adopt(api)` *(async function)*
+- `test_a_principal_with_the_administrative_scope_can_adopt(api)` *(async function)* — "Positive control for the previous test."
+- `test_a_token_with_no_scopes_cannot_deny(api)` *(async function)*
+- `test_an_unknown_node_id_is_not_found(api)` *(async function)*
+- `test_an_invalid_state_filter_is_rejected(api)` *(async function)*
+- `test_the_state_filter_narrows_the_list(api)` *(async function)*
+- `test_a_resource_from_a_different_node_is_not_listed(api)` *(async function)*
+- `test_pagination_covers_more_candidates_than_one_page(api)` *(async function)* — "The real-world case this PR names: 247 candidates from one root."
+- `test_the_dto_carries_the_sensitive_path_fields(api)` *(async function)* — "This IS the pre-registered exception (`docs/control-plane.md`,"
+- `test_adopting_with_a_new_project_creates_project_binding_and_moves_state(api)` *(async function)*
+- `test_adopting_without_a_remote_url_creates_no_scm_association(api)` *(async function)* — "Positive control for the previous test's association assertion."
+- `test_adopting_into_an_existing_project_reuses_it(api)` *(async function)*
+- `test_adopting_twice_does_not_duplicate_the_binding(api)` *(async function)*
+- `test_adopt_requires_exactly_one_of_project_id_or_new_project(api)` *(async function)*
+- `test_adopting_an_unknown_resource_is_not_found(api)` *(async function)*
+- `test_a_matching_auto_authorize_root_grants_read_on_adoption(api)` *(async function)* — "`E1`'s registration grants `read` for exactly `/root` (see the `api` fixture)."
+- `test_a_non_matching_root_grants_nothing(api)` *(async function)* — "Positive control: a candidate under a root E1 never registered grants nothing automatically."
+- `test_operator_grant_capabilities_can_include_modify_and_deliver(api)` *(async function)*
+- `test_root_config_and_operator_grants_coexist_in_one_call(api)` *(async function)* — "Both origins apply in the same adopt call -- `/root` auto-grants `read`,"
+- `test_auto_authorize_can_never_grant_modify_or_deliver(api)` *(async function)* — "A malicious/misconfigured root cannot smuggle `modify`/`deliver` in --"
+- `test_denying_moves_state_and_records_the_actor(api)` *(async function)*
+- `test_denying_twice_is_a_conflict(api)` *(async function)*
+- `test_a_denied_resource_is_not_touched_by_a_later_report(api)` *(async function)* — "The rule `docs/control-plane.md` names survives this PR: DENIED is"
 
 ### `tests/integration/test_dispatch_payload_engine_and_delivery.py`
 
@@ -1795,6 +1855,9 @@ tests/
 - `test_stale_row_reappearing_with_active_authorization_reverts_to_authorized(db_session)` *(async function)*
 - `test_stale_row_reappearing_with_only_a_revoked_authorization_reverts_to_adopted(db_session)` *(async function)* — "The negative half of the pair above: a REVOKED authorization must not"
 - `test_record_discovery_report_never_writes_authorization_or_projects(db_session)` *(async function)* — "The property that makes "the node proposes, the panel adopts" true by"
+- `test_a_matching_auto_authorize_root_grants_nothing_from_a_report_alone(db_session)` *(async function)* — "The invariant this PR must not break: a node cannot authorize itself."
+- `test_resource_key_is_a_fixed_width_hash_and_resource_path_carries_the_real_path(db_session)` *(async function)* — "The defect this PR fixes: a MySQL `varchar(255)` cannot hold every"
+- `test_a_pre_migration_row_self_heals_its_resource_key_on_next_report(db_session)` *(async function)* — "A row written before 0013 has `resource_key` = the raw path (the"
 - `test_a_large_report_does_not_cost_one_round_trip_per_candidate(db_session)` *(async function)* — "247 candidates -- the real root that motivated this work, rounded up"
 
 ### `tests/unit/test_email_templates.py`

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -279,6 +279,32 @@ aqui e em `docs/api/README.md` ("Fields that must never ship") e
 `discovered_resources` numa rota reintroduz o vazamento que `local_path` já
 evitou uma vez.
 
+**Atualização (WK-20260902-gh73-discovery-adoption, `migrations/
+0013_discovery_resource_key_hash.sql`).** O parágrafo acima descreve a coluna
+como a PR de relatório a deixou — e é exatamente aí que mora um defeito que
+essa PR encontrou e não teve escopo para consertar: `resource_key` é
+`varchar(255)`, dimensionado quando a coluna ainda era pensada como um id
+curto sugerido, mas passou a receber o path inteiro (até 2048 caracteres,
+`DiscoveredCandidate.resource_key`). O SQLite nunca impôs essa largura (é
+afinidade de tipo, não restrição), mas `aiomysql` é dependência declarada — e
+lá a mesma escrita é `Data too long for column`.
+
+Alargar a coluna não seria o conserto: ela ancora o índice único composto
+`(node_id, kind, resource_key)`, e o limite de chave de índice do MySQL
+(3072 bytes, ~767 caracteres em `utf8mb4`) é quase certamente o que os 255
+originais protegiam — alargar para 2048 trocaria uma falha silenciosa por
+outra no mesmo alvo. A forma escolhida: `resource_key` vira
+`shared.security.hash_resource_key(path)` — sha256 hex, sempre 64
+caracteres, folgado tanto na coluna quanto no limite de índice do MySQL — e
+o path de verdade passa a viver em `resource_path`, coluna nova, sem índice,
+na mesma largura de 2048 que o protocolo já permitia. `resource_path`, não
+`resource_key`, é agora o dado sensível desta seção; `resource_key` é só
+uma chave de busca interna, sem relação reversível com o path, e não sai em
+DTO nenhum. Ver o comentário da própria migração para o porquê de o backfill
+de linhas existentes copiar o path para `resource_path` sem tentar
+recalcular o hash em SQL portável — e `store.record_discovery_report`'s
+docstring para como uma linha pré-0013 se autorrepara na próxima observação.
+
 Deliberadamente **não** é `suggested_project_id`: `shared.project_discovery.
 suggest_project_id` só garante unicidade dentro da varredura de **uma** raiz
 (seu `taken` é reiniciado a cada chamada); duas raízes varridas de forma
@@ -328,3 +354,79 @@ branch que recebe `discovery.report` no gateway chama **só**
 `workspace_bindings`. Isso é o que torna "o nó propõe, o painel adota"
 verdade por construção: o caminho que recebe uma descoberta não tem, no
 código, nenhum jeito de chegar a uma tabela de autorização.
+
+## Stage 3 — a metade de adoção (issue #73, WK-20260902-gh73-discovery-adoption)
+
+A seção anterior descreveu a PR que fez o nó propor. Esta é a PR seguinte que
+ela previa: `GET /api/v1/nodes/{nodeId}/discovered-resources`,
+`POST /api/v1/discovered-resources/{resourceId}/adopt` e
+`POST .../{resourceId}/deny` — o único caminho, em todo o código, de uma
+linha de `discovered_resources` para `projects`, `workspace_bindings`,
+`scm_associations` ou `project_authorizations`.
+
+### O invariante não muda de lado — só ganha uma porta
+
+`store.record_discovery_report` continua escrevendo só em
+`discovered_resources`, inalterado nesta PR além do ajuste de
+`resource_key`/`resource_path` (seção acima). `store.
+adopt_discovered_resource` e `store.deny_discovered_resource` são as únicas
+funções novas com acesso de escrita às outras quatro tabelas, e as duas só
+são alcançáveis por `gateway/app/api/routes/discovery.py`, atrás de
+`permissions.NODES_DISCOVERIES_DECIDE` — uma ação administrativa que exige
+`AuthenticatedPrincipal`, e `current_principal` só produz um a partir de um
+token OAuth. O `machine_token` do executor autentica exclusivamente o
+WebSocket (`gateway/app/main.py:agent_ws`) e nunca vira um principal REST —
+não há, por construção, nenhuma sequência de chamadas que leve da conexão de
+um nó até `adopt`/`deny`. É isso que mantém "um nó não se autoriza sozinho"
+verdadeiro depois desta PR existir, não apenas antes dela: o teste que prova
+isso é `tests/unit/test_discovery_store.py::
+test_a_matching_auto_authorize_root_grants_nothing_from_a_report_alone`, que
+roda com uma raiz `auto_authorize` de verdade configurada e mostra que
+`record_discovery_report` sozinho não a usa — só `adopt_discovered_resource`
+usa, e só um humano chega lá.
+
+### `adopt`: cria ou reusa projeto, e a concessão automática tem teto
+
+Corpo `{projectId?, newProject?: {projectId, name}, grantCapabilities?}` —
+exatamente um de `projectId`/`newProject`. Cria (ou reusa)
+`ProjectModel`, cria/atualiza `WorkspaceBindingModel` com `local_path` =
+`resource_path` do candidato, cria `ScmAssociationModel` com
+`confidence="observed"` quando a evidência do candidato carrega
+`remote_url`, e move `discovered_resources.state` para `adopted` ou
+`authorized`.
+
+A concessão automática (a partir de `ExecutorRegistration.discovery_roots` —
+a lista do operador do registro, não a do nó; ver a seção "Duas listas de
+raízes" acima) entra em jogo quando `root_path` da linha casa, por igualdade
+de string, uma entrada com `auto_authorize`: essa concessão é
+gravada com `granted_by="root-config:<path>"`. Um `grantCapabilities`
+explícito no corpo é gravado com `granted_by="operator:<user_id>"`. As duas
+podem valer na mesma chamada de adoção — `project_authorizations_node_
+project_idx` permite só uma linha não revogada por `(node_id, project_id)`,
+então as duas origens se fundem numa linha só (`capabilities_json` vira a
+união, `granted_by` vira um conjunto `;`-separado de origens) em vez de
+competir pelo índice único. `AUTO_AUTHORIZABLE_CAPABILITIES` continua
+limitando `auto_authorize` a `read`/`test`, validado no parse de
+`DiscoveryRoot` — antes de qualquer nó conectar, muito antes de qualquer
+adoção. `modify`/`deliver` só chegam a uma linha de autorização por
+`grantCapabilities`, nomeando um operador.
+
+### `deny`: um sexto estado não nasce por acidente
+
+Move `state` para `denied`, grava `decided_by`/`decided_at`. "Ignorar" fica
+sendo filtro de UI sobre `discovered`/`stale` — `shared.protocol.
+DiscoveredState` continua com cinco valores, e nenhuma rota desta PR grava um
+sexto. A regra que a Stage 1 nomeou e a PR de relatório implementou —
+`DENIED` nunca regride por observação — continua valendo depois desta PR:
+`adopt`/`deny` só agem sobre uma linha em `discovered`/`stale`
+(`DECIDABLE_DISCOVERY_STATES`), e uma linha já `denied` responde `409` em vez
+de ser tocada de novo.
+
+### Por que `409`, não sobrescrita silenciosa
+
+`adopt`/`deny` só decidem uma linha `discovered`/`stale`. Uma linha já
+`adopted`/`authorized`/`denied` é uma decisão já tomada — decidi-la de novo
+responde `409 conflict`. Isso não é um defensive check em cima da escrita: é
+o que impede uma segunda chamada de `adopt` de duplicar o
+`WorkspaceBindingModel`/`ScmAssociationModel` que a primeira já produziu —
+a segunda chamada nunca chega à escrita.

--- a/docs/issues/073-codexbridge-control/RESUME.md
+++ b/docs/issues/073-codexbridge-control/RESUME.md
@@ -1,81 +1,103 @@
-# RESUME — WK-20260901-gh73-fleet-visibility (epic #73)
+# RESUME — WK-20260902-gh73-discovery-adoption (epic #73)
 
-- work_id: WK-20260901-gh73-fleet-visibility
-- data: 2026-09-01
-- Stage 1: **PR #74 merged** into `development` as `80e5d2f`.
-- Stage 2: branch `feature/gh-73/fleet-visibility` (commit `2ed550f`), worktree
-  `../CodexBridge--gh-73-control`. Pushed; **PR #75** open. NOT merged.
+- work_id: WK-20260902-gh73-discovery-adoption
+- data: 2026-09-02
+- Stage 1 (domain/contracts): **PR #74 merged** into `development` as `80e5d2f`.
+- Stage 2 (fleet visibility): merged onto this lineage (`2ed550f`).
+- Stage 3, report half (node proposes): merged onto this lineage (`a57a8d9`,
+  branch `feature/gh-73/discovery-report`).
+- Stage 3, adoption half (panel decides): **this session**, branch
+  `feature/gh-73/discovery-adoption`, worktree
+  `../CodexBridge--WK-20260902-gh73-discovery-adoption`. Committed locally,
+  **not pushed, no PR opened** (out of this session's scope — commit and stop).
 
 ## Next Step (DO THIS FIRST)
 
-Start Stage 3 (project discovery and adoption: scan the configured roots,
-correlate candidates, write `discovered_resources`, and the adopt/ignore
-decision) on a branch cut from `feature/gh-73/fleet-visibility`. Stage 2 left
-the node reporting only a `discovery_root_count`; Stage 3 is what makes the
-roots produce rows.
+Open the PR for `feature/gh-73/discovery-adoption` against
+`feature/gh-73/discovery-report` (or wherever the operator wants it based),
+get it reviewed, then start Stage 4 of the epic (whatever "fleet enable/disable
+and node lifecycle actions" or the next unstarted stage is — check the epic's
+own issue body, not this file, for the authoritative stage list).
 
 ## Current state
 
-- Stage 2 (fleet visibility) delivered on `feature/gh-73/fleet-visibility`:
-  `NodeAnnouncement` on the `hello` message, `Runner.probe()` +
-  `RunnerPool.probe_all()`, `store.record_node_announcement`, and
-  `GET /api/v1/nodes` + `/{id}` with health derived by
-  `shared.protocol.node_health`. No migration — Stage 1's columns sufficed.
-- A **security fix** rode along: the websocket receive loop trusted
-  `AgentEnvelope.executor_id` (client-written) instead of the id authenticated
-  at the handshake, so a node could announce itself as another node or forge
-  another node's liveness. Guard now sits once, before the dispatch.
-- Stage 1 (domain and contracts) merged as `80e5d2f`: migration
-  `0009_control_plane.sql`, entities, `schema_guard` entries, and the
-  `Capability` vocabulary in `shared/protocol.py`, documented in
-  `docs/control-plane.md`.
-- Capability is **derived** from `TaskMode` (`CAPABILITY_MODES`), so
-  `allowed_modes` stays the single enforcement point. `DiscoveryRoot`
-  `auto_authorize` refuses `modify`/`deliver` at parse time.
-- Stages 2–7 of the epic: not started.
+- `GET /api/v1/nodes/{nodeId}/discovered-resources` (cursor-paginated,
+  `?state=` filter), `POST /api/v1/discovered-resources/{id}/adopt`,
+  `POST .../{id}/deny` — `gateway/app/api/routes/discovery.py`.
+- `store.adopt_discovered_resource`/`deny_discovered_resource` are the ONLY
+  functions with write access to `projects`/`workspace_bindings`/
+  `scm_associations`/`project_authorizations` starting from a
+  `discovered_resources` row. Both require `permissions.
+  NODES_DISCOVERIES_DECIDE` (`codexbridge.admin`), reachable only by an
+  OAuth-authenticated principal — never by a node's `machine_token`.
+- Auto-grant: a candidate whose `root_path` matches a `DiscoveryRoot` with
+  `auto_authorize` on the node's own `ExecutorRegistration` grants
+  automatically (`granted_by="root-config:<path>"`), capped to `read`/`test`
+  at parse time. An explicit `grantCapabilities` in the adopt body grants
+  with `granted_by="operator:<user_id>"` and may include `modify`/`deliver`.
+  Both can apply in the same call — merged into one `project_authorizations`
+  row (`;`-joined `granted_by`), since the table allows only one non-revoked
+  row per `(node_id, project_id)`.
+- **Defect fixed, found by the previous PR and left for this one**:
+  `discovered_resources.resource_key` was `varchar(255)` but held a path up
+  to 2048 chars — silent on SQLite, a hard failure on MySQL (`aiomysql` is a
+  declared dependency). `migrations/0013_discovery_resource_key_hash.sql`:
+  `resource_key` becomes `hash_resource_key(path)` (sha256 hex, 64 chars);
+  the real path moves to a new, unindexed `resource_path` column. A
+  pre-migration row self-heals its `resource_key` the next time its node
+  reports the same path (matched by `resource_path`, not `resource_key`).
+- Contract bumped **1.9.0 → 1.12.0** (`probes.API_CONTRACT_VERSION` and
+  `docs/api/codex-bridge.openapi.yaml`'s `info.version`) — skipping
+  1.10.0/1.11.0/1.13.0, claimed by other branches of this same orchestration
+  not yet merged onto this one.
+- `resourcePath`/`rootPath` are returned ONLY by the three routes above — the
+  one pre-registered exception to "no response exposes a server filesystem
+  path" (`docs/control-plane.md`, `docs/api/README.md`, `docs/threat-model.md`
+  all updated to say so explicitly).
 
-## Changed files (13583f8)
+## Changed files
 
-`migrations/0009_control_plane.sql`, `gateway/app/models/entities.py`,
-`gateway/app/db/schema_guard.py`, `shared/protocol.py`,
-`docs/control-plane.md`, `docs/codemap.md`, `docs/required-reading.md`,
-`tests/unit/test_apply_migrations.py`, `tests/unit/test_capability_vocabulary.py`.
+`migrations/0013_discovery_resource_key_hash.sql` (new),
+`gateway/app/api/routes/discovery.py` (new),
+`gateway/app/services/discovery_types.py` (new),
+`tests/integration/test_discovery_routes.py` (new),
+`gateway/app/models/entities.py`, `gateway/app/services/store.py`,
+`gateway/app/api/permissions.py`, `gateway/app/api/routes/probes.py`,
+`gateway/app/db/schema_guard.py`, `gateway/app/main.py`, `shared/security.py`,
+`docs/api/README.md`, `docs/api/codex-bridge.openapi.yaml`,
+`docs/control-plane.md`, `docs/threat-model.md`, `docs/codemap.md`,
+`tests/unit/test_discovery_store.py`, `tests/integration/test_agent_ws_discovery.py`,
+`tests/integration/test_auth.py`.
 
 ## Checks
 
-- `pytest -q` → **799 passed, 7 skipped** (Stage 2; branch baseline 757/7).
-- The two identity-exploit tests were verified failing against the pre-fix
-  source (vulnerable lines restored by file copy, not `git stash`).
-- Stage 1: 757 passed, 7 skipped (baseline was 746/7).
-- `0009` applied against SQLite **and** a real PostgreSQL 16 (throwaway
-  container, removed afterwards; no other project's Postgres touched).
-- Three mutations proved the tests bite: widening `Capability.READ` to include
-  `edit`; widening `AUTO_AUTHORIZABLE_CAPABILITIES` to include `modify`;
-  reversing the migration's statement order.
-- Codemap regeneration command is `governancekit --root . map`.
-
-## Decisions carried forward
-
-1. `projects.path` was **kept**, against the plan: dropping it in the same
-   migration that creates the replacement destroys the only copy of the path
-   for any project absent from today's `registry.json`; the backfill depends
-   on `executors.metadata_json` and is not expressible in portable SQL. The
-   reason is written into the migration file.
-2. `alter table executors` runs first in `0009` — SQLite does not roll back
-   DDL, so hitting a wrong database leaves the schema intact, not half-built.
-3. The migration grants nothing: `project_authorizations` is born empty, even
-   for projects the node already ran.
+- `.venv/bin/python -m pytest -q` → **858 passed, 7 skipped, 0 failed**
+  (branch baseline before this PR: 829/7).
+- `tests/contract/` → all green (26 passed), including the OpenAPI route/
+  version-parity gates and the codemap freshness gate (regenerated with
+  `governancekit --root . map`).
+- `tests/unit/test_apply_migrations.py` → all green; `0013` applies cleanly
+  to a `0009`-shaped legacy SQLite database and self-heals a pre-0013 row on
+  next report (dedicated tests in `tests/unit/test_discovery_store.py`).
+- The local dev `codex_bridge.db` (gitignored) needed `scripts/
+  apply_migrations.py --mark-applied` for 0001–0009 (it was bootstrapped by
+  `create_all`, never tracked in the ledger) and a real run of `0013` before
+  `test_probes.py`'s real-app tests (which hit that file directly) went
+  green — noted here in case another agent's session hits the same
+  `SchemaOutOfDate` against the same file.
 
 ## NOT validated
 
-No deploy. `0009` never applied to any real gateway database. No real agent has
-connected to a real gateway with the Stage 2 build. `inventoryObservedAt` is
-exposed but reserved for Stage 3 and stays `null`. `GET /api/v1/nodes` is
-unpaginated. Contract is at 1.9.0 and collides by design with PRs #61/#62.
+No deploy, no real MySQL run of `0013` (only SQLite — same caveat `0009`'s own
+RESUME already carried; a throwaway Postgres/MySQL verification is worth doing
+before this ships to a MySQL-backed environment). No real node has adopted a
+real discovered resource end-to-end through a live gateway. `POST .../adopt`
+and `.../deny` carry no `revision`/`ETag` — reconsider if a future stage needs
+optimistic concurrency on `discovered_resources` beyond the decidable-state
+check already enforced.
 
 ## Watch for
 
-Stage 2 was implemented by two subagents sharing ONE worktree; one ran `git
-stash` and transiently reverted the other's uncommitted work. Give each agent
-its own worktree, or forbid repository-wide git commands in the prompt — see
-`docs/napkin-lessons.md`, 2026-09-01.
+Two subagents sharing one worktree caused a `git stash` incident on 2026-09-01
+(`docs/napkin-lessons.md`). This session ran in its own dedicated worktree
+with no sibling agent inside it — no repeat.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1330,3 +1330,35 @@ repositório inteiro e não têm como respeitar uma divisão de escopo que exist
 no prompt. Ou se dá um worktree por agente, ou se proíbe explicitamente esses
 comandos no prompt e se verifica mutação copiando o arquivo (`cp` e restaura),
 que foi como a prova acabou sendo feita aqui.
+
+## 2026-09-02 — uma coluna dimensionada para um propósito, reaproveitada para outro, sem revisitar a largura
+
+`discovered_resources.resource_key` nasceu em `0009_control_plane.sql` como
+`varchar(255)`, pensada como um id curto sugerido. A PR seguinte (Stage 3,
+relatório) reaproveitou a mesma coluna para guardar o path absoluto do
+candidato — até 2048 caracteres, o próprio limite que o protocolo já
+declarava em `DiscoveredCandidate.resource_key`. Ninguém voltou a olhar a
+largura da coluna quando o significado do campo mudou. O SQLite não acusou
+nada: é afinidade de tipo, não restrição, então qualquer string cabe. O
+projeto declara `aiomysql` como dependência — MySQL é alvo suportado — e lá
+a mesma escrita seria `Data too long for column`, sem que nenhum teste local
+(rodado só contra SQLite) jamais visse isso.
+
+Lição: quando o *significado* de uma coluna muda — de "id curto sugerido"
+para "path de filesystem" — a largura declarada é parte do contrato que
+mudou junto, não um detalhe que sobrevive por acidente. Perguntar "isso
+ainda cabe no que declarei?" é parte de mudar o significado, não um passo
+opcional depois. E testar só contra o motor mais permissivo (aqui, SQLite)
+esconde exatamente esse tipo de defeito: a suíte fica verde enquanto o
+contrato declarado (múltiplos motores de banco suportados) já está quebrado
+para um deles. Quem generaliza o uso de uma coluna existente deve verificar
+a largura contra TODOS os motores declarados como alvo, não só contra o que
+os testes locais usam.
+
+O conserto (`migrations/0013_discovery_resource_key_hash.sql`) não alargou a
+coluna — alargar teria estourado o limite de chave do índice único composto
+que essa mesma coluna ancora, trocando uma falha silenciosa por outra no
+mesmo alvo. A saída foi separar "chave de busca" (hash de largura fixa) de
+"dado real" (path, em coluna nova, sem índice) — quando um valor precisa
+simultaneamente indexar barato E carregar um dado de tamanho não controlado,
+essas são duas responsabilidades, não uma.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -94,10 +94,15 @@ não existe.
   test_the_receiving_branch_writes_only_discovered_resources`). Um nó
   comprometido que relata candidatos fabricados só polui a fila de adoção —
   não tem, por construção, nenhum caminho para conceder capacidade a nada
-* controle: `resource_key` (o path absoluto do candidato) nunca sai por
-  nenhuma rota REST hoje — não há rota nesta PR — e quando a rota de adoção
-  existir, cai na mesma regra de `local_path`
-  (`docs/api/README.md`, "Fields that must never ship")
+* controle: o path absoluto do candidato (`DiscoveredResourceModel.
+  resource_path` desde `migrations/0013_discovery_resource_key_hash.sql`;
+  antes disso vivia em `resource_key`) só sai por uma rota REST: `GET
+  /api/v1/nodes/{nodeId}/discovered-resources` e as respostas de
+  `adopt`/`deny` — a mesma regra de `local_path`
+  (`docs/api/README.md`, "Fields that must never ship"), gated pelo mesmo
+  escopo administrativo de `nodes.read`. `resource_key` propriamente dito
+  deixou de ser o dado sensível: é `hash_resource_key(path)`, sem relação
+  reversível com o path, e não aparece em DTO nenhum
 * controle: o mesmo guard de identidade do `hello`/`heartbeat`
   (`envelope.executor_id` reivindicado vs. autenticado no handshake) já cobre
   `discovery.report` por estar antes de qualquer branch no laço de
@@ -117,6 +122,56 @@ não existe.
   árvore que o operador não controla totalmente relata o que existir nela —
   a mitigação é a mesma de sempre: escolher a raiz com cuidado, não confiar
   cegamente no que ela aponta
+
+### Adoção de descobertas pelo painel (WK-20260902-gh73-discovery-adoption, issue #73 Stage 3, metade de adoção)
+
+A metade que fecha o ciclo aberto pela seção anterior: `discovered_resources`
+passa a poder virar `ProjectModel`, `WorkspaceBindingModel`,
+`ScmAssociationModel` e `project_authorizations` — só por este caminho, nunca
+pelo caminho do nó.
+
+* controle: **um nó não alcança `project_authorizations` por construção,
+  mesmo com as rotas de adoção existindo.** `store.adopt_discovered_resource`
+  e `store.deny_discovered_resource` são as ÚNICAS funções que escrevem
+  nessas quatro tabelas a partir de uma linha de `discovered_resources`, e
+  ambas exigem `permissions.NODES_DISCOVERIES_DECIDE`
+  (`codexbridge.admin`). `gateway/app/api/auth.py:current_principal` — o
+  único jeito de uma requisição REST virar um `AuthenticatedPrincipal` —
+  resolve exclusivamente um token OAuth (`store.get_oauth_access_token`); o
+  `machine_token` do executor autentica só o WebSocket
+  (`gateway/app/main.py:agent_ws`), checado ali mesmo, e nunca produz um
+  `AuthenticatedPrincipal`. Não existe caminho de código da credencial de um
+  nó conectado até `adopt`/`deny` (testado diretamente:
+  `tests/integration/test_discovery_routes.py::
+  test_a_principal_without_the_administrative_scope_cannot_adopt`,
+  `tests/unit/test_discovery_store.py::
+  test_a_matching_auto_authorize_root_grants_nothing_from_a_report_alone` —
+  este último com uma raiz `auto_authorize` de verdade configurada, provando
+  que a configuração por si só não basta sem a decisão humana)
+* controle: `AUTO_AUTHORIZABLE_CAPABILITIES` (`read`/`test`) é validado no
+  parse de `DiscoveryRoot`, antes de qualquer nó conectar — `modify`/
+  `deliver` nunca são obteníveis por `auto_authorize`, só por
+  `grantCapabilities` explícito no corpo da requisição, atribuído a
+  `operator:<user_id>`
+* controle: `adopt`/`deny` só agem sobre um candidato em estado
+  `discovered`/`stale` — um já decidido responde `409`, o que também é o que
+  impede uma segunda chamada de duplicar `WorkspaceBindingModel`/
+  `ScmAssociationModel`
+* controle: a regra "DENIED nunca é tocado por observação" (seção anterior)
+  continua valendo depois de decidido — nada nesta PR toca
+  `record_discovery_report`'s tratamento de `DENIED`, e há teste direto
+  (`tests/integration/test_discovery_routes.py::
+  test_a_denied_resource_is_not_touched_by_a_later_report`)
+* controle: `ProjectAuthorizationModel` permite só uma linha não revogada por
+  `(node_id, project_id)` — uma concessão de raiz e uma concessão explícita
+  do operador na mesma chamada de adoção são mescladas na mesma linha
+  (`granted_by` vira um conjunto `;`-separado de origens), nunca duas linhas
+  competindo pelo índice único
+* risco aceito: `resourcePath`/`rootPath` (paths absolutos) saem por
+  `GET /api/v1/nodes/{nodeId}/discovered-resources` e pelas respostas de
+  `adopt`/`deny` — exceção deliberada e estreita à regra "nenhuma resposta
+  expõe path de filesystem", gated pelo mesmo escopo administrativo de
+  `nodes.read`. Ver `docs/api/README.md`, "Fields that must never ship"
 
 ### Execução de comandos arbitrários
 

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -201,6 +201,36 @@ NODES_READ = Action(
     summary="List Bridge Nodes and read one, across the whole fleet.",
 )
 
+# Issue #73 Stage 3 adoption half (WK-20260902-gh73-discovery-adoption).
+# Same reasoning as `NODES_READ`: a discovered candidate belongs to a node,
+# not to a project the caller may or may not see, so this follows the
+# administrative/fleet-wide precedent rather than `visible_projects` scoping.
+NODES_DISCOVERIES_READ = Action(
+    name="nodes.discoveries.read",
+    category=ADMINISTRATIVE,
+    scope=ADMIN_SCOPE,
+    summary="List the candidates one Bridge Node has discovered.",
+)
+
+# Deciding a candidate (`adopt`/`deny`) can create a project, a workspace
+# binding, an SCM association and -- when a discovery root or the request
+# grants capability -- a `project_authorizations` row. Separate action from
+# `NODES_DISCOVERIES_READ` for the same reason `DECISIONS_READ`/
+# `DECISIONS_DECIDE` are separate: seeing the queue and deciding it are
+# different capabilities an operator may grant independently. Administrative,
+# not operational, for the same reason `NODES_READ` is: a discovered
+# candidate is not scoped to any project the caller already sees -- often
+# there is no project yet -- so this reaches beyond `visible_projects` by
+# definition, which is the axis this classification tracks
+# (`DECISIONS_DECIDE` stays operational because the task it resolves IS
+# already inside the actor's own projects).
+NODES_DISCOVERIES_DECIDE = Action(
+    name="nodes.discoveries.decide",
+    category=ADMINISTRATIVE,
+    scope=ADMIN_SCOPE,
+    summary="Adopt or deny a discovered candidate.",
+)
+
 EPICS_READ = Action(
     name="epics.read",
     category=READ,
@@ -293,6 +323,8 @@ CATALOGUE: tuple[Action, ...] = (
     DECISIONS_DECIDE,
     MISSIONS_READ_ALL_PROJECTS,
     NODES_READ,
+    NODES_DISCOVERIES_READ,
+    NODES_DISCOVERIES_DECIDE,
 )
 
 

--- a/gateway/app/api/routes/discovery.py
+++ b/gateway/app/api/routes/discovery.py
@@ -1,0 +1,324 @@
+"""Discovered resources: the panel's half of "the node proposes, the panel adopts".
+
+WK-20260902-gh73-discovery-adoption, issue #73 Stage 3 (adoption half). The
+report half (`docs/control-plane.md`, "Stage 3 -- o nó propõe, o painel
+adota") shipped `discovered_resources` and the branch in `gateway/app/main.py`
+that fills it, writing nothing else -- by construction, not convention. This
+module is the other half: the only REST surface that may turn one of those
+rows into a `ProjectModel`, a `WorkspaceBindingModel`, a `ScmAssociationModel`,
+or a `ProjectAuthorizationModel`, and it does so through
+`gateway/app/services/store.py:adopt_discovered_resource`/
+`deny_discovered_resource` exclusively -- see those functions' own docstrings
+for the full invariant.
+
+## Why this is administrative, not project-scoped
+
+A discovered candidate is not scoped to any project the caller already sees --
+often there is no project yet, that is the whole point of the adoption
+decision. `NODES_DISCOVERIES_READ`/`NODES_DISCOVERIES_DECIDE` therefore follow
+`routes/nodes.py`'s precedent (`NODES_READ`): fleet-wide, administrative,
+`codexbridge.admin`, never `visible_projects`-scoped.
+
+## `resourcePath`/`rootPath` are the one exception on this contract
+
+`docs/api/README.md` ("Fields that must never ship") forbids a server
+filesystem path in any response, with one standing, pre-registered exception:
+`docs/control-plane.md` names it explicitly ("resource_key é dado sensível...
+quando a rota de adoção existir, cai na mesma regra de local_path") for
+exactly this endpoint. `resourcePath` (the candidate's absolute path,
+`migrations/0013_discovery_resource_key_hash.sql`) and `rootPath` (the
+discovery root it came from) are returned here and ONLY here, guarded by the
+same administrative scope as `NODES_READ`. The internal `resource_key` hash
+itself is not part of this DTO at all -- it is a lookup key for
+`record_discovery_report`, not information an operator decides anything from.
+
+## Pagination
+
+`GET .../discovered-resources` is cursor-paginated, unlike `GET /api/v1/nodes`
+(unpaginated because the fleet is small and operator-curated). That reasoning
+does not extend here: a single real operator root has reported 247 candidates
+in one scan (`docs/control-plane.md`), so this follows `routes/projects.py`'s
+cursor idiom instead.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, Header, Query, Response
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.app.api import idempotency, pagination, permissions, timestamps
+from gateway.app.api.auth import require_action
+from gateway.app.api.errors import CONFLICT, NOT_FOUND, VALIDATION_FAILED, ApiError
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.session import get_session
+from gateway.app.services import store
+from gateway.app.services.discovery_types import DiscoveryAdoptionError
+from shared.protocol import Capability, DiscoveredState
+
+
+router = APIRouter(prefix="/api/v1")
+
+DISCOVERED_RESOURCES_ENDPOINT = "/api/v1/discovered-resources"
+
+_STATE_VALUES = {state.value for state in DiscoveredState}
+
+
+def _iso(value) -> str | None:
+    return timestamps.utc_z(value)
+
+
+def _node_not_found() -> ApiError:
+    return ApiError(status_code=404, code=NOT_FOUND, message="No such node.")
+
+
+def _resource_not_found() -> ApiError:
+    return ApiError(status_code=404, code=NOT_FOUND, message="No such discovered resource.")
+
+
+def _invalid_state() -> ApiError:
+    return ApiError(
+        status_code=400,
+        code=VALIDATION_FAILED,
+        message=f"state must be one of {sorted(_STATE_VALUES)}.",
+        details=[{"field": "?state", "code": "invalid_enum", "message": "Unknown discovery state."}],
+    )
+
+
+def _not_decidable(resource_id: str, state: str) -> ApiError:
+    return ApiError(
+        status_code=409,
+        code=CONFLICT,
+        message=f"Discovered resource {resource_id!r} is {state!r} and cannot be decided again.",
+    )
+
+
+def _adoption_error(exc: DiscoveryAdoptionError) -> ApiError:
+    return ApiError(
+        status_code=400,
+        code=VALIDATION_FAILED,
+        message=exc.message,
+        details=[{"field": exc.field, "code": exc.code, "message": exc.message}],
+    )
+
+
+def _discovered_resource_dto(row) -> dict:
+    evidence = json.loads(row.evidence_json or "{}")
+    return {
+        "id": row.id,
+        "nodeId": row.node_id,
+        "kind": row.kind,
+        "state": row.state,
+        "projectId": row.project_id,
+        # Sensitive filesystem data -- see this module's own docstring for
+        # why this endpoint, and only this endpoint, may return them.
+        "resourcePath": row.resource_path,
+        "rootPath": row.root_path,
+        "suggestedProjectId": evidence.get("suggested_project_id"),
+        "suggestedName": evidence.get("suggested_name"),
+        "remoteUrl": evidence.get("remote_url"),
+        "head": evidence.get("head"),
+        "dirty": evidence.get("dirty"),
+        "firstSeenAt": _iso(row.first_seen_at),
+        "lastSeenAt": _iso(row.last_seen_at),
+        "decidedBy": row.decided_by,
+        "decidedAt": _iso(row.decided_at),
+    }
+
+
+class NewProjectSpec(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    project_id: str = Field(alias="projectId", min_length=1, max_length=128)
+    name: str = Field(min_length=1, max_length=255)
+
+
+class AdoptDiscoveredResourceRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    project_id: str | None = Field(default=None, alias="projectId", min_length=1, max_length=128)
+    new_project: NewProjectSpec | None = Field(default=None, alias="newProject")
+    grant_capabilities: list[Capability] = Field(default_factory=list, alias="grantCapabilities")
+
+
+@router.get("/nodes/{node_id}/discovered-resources", tags=["discovery"])
+async def list_discovered_resources(
+    node_id: str,
+    response: Response,
+    state: str | None = Query(default=None),
+    cursor: str | None = Query(default=None),
+    limit: int | None = Query(default=None),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_DISCOVERIES_READ)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """One node's discovered candidates, cursor-paginated, newest-id last.
+
+    404 for an unknown node id, the same "do not confirm what the caller
+    cannot see" posture `routes/nodes.py` already documents -- there is no
+    project scope to hide it behind here either, the id simply is not
+    present.
+    """
+    if await store.get_node(session, node_id) is None:
+        raise _node_not_found()
+    if state is not None and state not in _STATE_VALUES:
+        raise _invalid_state()
+
+    size = pagination.parse_limit(limit)
+    scope = pagination.scope_digest(
+        f"{DISCOVERED_RESOURCES_ENDPOINT}:{node_id}", {"state": state}
+    )
+    after_id = None
+    if cursor:
+        after_id = pagination.decode_cursor(scope, cursor, expect={"id": str})["id"]
+
+    rows = await store.list_discovered_resources_page(
+        session, node_id, state=state, after=after_id, limit=size
+    )
+    page, info = pagination.paginate(rows, limit=size, scope=scope, position_of=lambda row: {"id": row.id})
+    return {"items": [_discovered_resource_dto(row) for row in page], "page": info}
+
+
+@router.post("/discovered-resources/{resource_id}/adopt", tags=["discovery"])
+async def adopt_discovered_resource(
+    resource_id: str,
+    payload: AdoptDiscoveredResourceRequest,
+    response: Response,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_DISCOVERIES_DECIDE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Bind a discovered candidate to a project (existing or new).
+
+    `project_id` XOR `new_project` -- exactly one, enforced again inside
+    `store.adopt_discovered_resource` because the guard belongs on the
+    operation, not the caller. When the candidate's `rootPath` matches a
+    `DiscoveryRoot` with `auto_authorize` on this node's registration, or when
+    `grantCapabilities` is given, the resulting `project_authorizations` row
+    is granted here -- never by the node itself (see the module docstring).
+    """
+    endpoint = f"{DISCOVERED_RESOURCES_ENDPOINT}/{{resourceId}}/adopt"
+    fingerprint = idempotency.fingerprint(
+        f"adopt:{resource_id}:{payload.project_id}:"
+        f"{payload.new_project.project_id if payload.new_project else ''}:"
+        f"{sorted(c.value for c in payload.grant_capabilities)}".encode()
+    )
+    claim = None
+    if idempotency_key:
+        outcome = await idempotency.reserve(
+            session,
+            key=idempotency_key,
+            endpoint=endpoint,
+            actor_id=principal.user_id,
+            request_fingerprint=fingerprint,
+        )
+        if isinstance(outcome, idempotency.ReplayedResponse):
+            response.status_code = outcome.status_code
+            response.headers["Idempotent-Replay"] = "true"
+            return outcome.body
+        claim = outcome
+
+    try:
+        row = await store.adopt_discovered_resource(
+            session,
+            resource_id,
+            project_id=payload.project_id,
+            new_project_id=payload.new_project.project_id if payload.new_project else None,
+            new_project_name=payload.new_project.name if payload.new_project else None,
+            grant_capabilities=payload.grant_capabilities,
+            actor_user_id=principal.user_id,
+        )
+    except DiscoveryAdoptionError as exc:
+        if claim is not None:
+            await idempotency.release(session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim)
+        raise _adoption_error(exc) from exc
+    except ValueError as exc:
+        if claim is not None:
+            await idempotency.release(session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim)
+        if str(exc) == "discovered_resource_not_found":
+            raise _resource_not_found() from exc
+        if str(exc) == "discovered_resource_not_decidable":
+            # The row exists; re-fetch only to report its current state.
+            existing = await store.get_discovered_resource(session, resource_id)
+            raise _not_decidable(resource_id, existing.state if existing else "unknown") from exc
+        raise
+    except Exception:
+        if claim is not None:
+            await idempotency.release(session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim)
+        raise
+
+    body = _discovered_resource_dto(row)
+    if claim is not None:
+        await idempotency.complete(
+            session,
+            key=idempotency_key,
+            endpoint=endpoint,
+            actor_id=principal.user_id,
+            status_code=200,
+            body=body,
+            claim=claim,
+            request_fingerprint=fingerprint,
+        )
+    return body
+
+
+@router.post("/discovered-resources/{resource_id}/deny", tags=["discovery"])
+async def deny_discovered_resource(
+    resource_id: str,
+    response: Response,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_DISCOVERIES_DECIDE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Refuse a discovered candidate. "Ignore" is a UI filter over `DISCOVERED`/
+
+    `STALE`, not a sixth state -- `shared.protocol.DiscoveredState` names
+    exactly five, and this endpoint only ever writes `DENIED`.
+    """
+    endpoint = f"{DISCOVERED_RESOURCES_ENDPOINT}/{{resourceId}}/deny"
+    fingerprint = idempotency.fingerprint(f"deny:{resource_id}".encode())
+    claim = None
+    if idempotency_key:
+        outcome = await idempotency.reserve(
+            session,
+            key=idempotency_key,
+            endpoint=endpoint,
+            actor_id=principal.user_id,
+            request_fingerprint=fingerprint,
+        )
+        if isinstance(outcome, idempotency.ReplayedResponse):
+            response.status_code = outcome.status_code
+            response.headers["Idempotent-Replay"] = "true"
+            return outcome.body
+        claim = outcome
+
+    try:
+        row = await store.deny_discovered_resource(session, resource_id, actor_user_id=principal.user_id)
+    except ValueError as exc:
+        if claim is not None:
+            await idempotency.release(session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim)
+        if str(exc) == "discovered_resource_not_found":
+            raise _resource_not_found() from exc
+        if str(exc) == "discovered_resource_not_decidable":
+            existing = await store.get_discovered_resource(session, resource_id)
+            raise _not_decidable(resource_id, existing.state if existing else "unknown") from exc
+        raise
+    except Exception:
+        if claim is not None:
+            await idempotency.release(session, key=idempotency_key, endpoint=endpoint, actor_id=principal.user_id, claim=claim)
+        raise
+
+    body = _discovered_resource_dto(row)
+    if claim is not None:
+        await idempotency.complete(
+            session,
+            key=idempotency_key,
+            endpoint=endpoint,
+            actor_id=principal.user_id,
+            status_code=200,
+            body=body,
+            claim=claim,
+            request_fingerprint=fingerprint,
+        )
+    return body

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -67,7 +67,18 @@ version_router = APIRouter()
 # an optional `reason` field on its request body, recorded on the mission's
 # timeline. Additive only (new optional field; an existing client sending no
 # body is unaffected), so another minor bump.
-API_CONTRACT_VERSION = "1.9.0"
+#
+# 1.9.0 -> 1.12.0 (WK-20260902-gh73-discovery-adoption, issue #73 Stage 3
+# adoption half): `GET /api/v1/nodes/{nodeId}/discovered-resources`,
+# `POST /api/v1/discovered-resources/{resourceId}/adopt` and
+# `POST /api/v1/discovered-resources/{resourceId}/deny`. Additive only (three
+# new endpoints, new schemas), so a minor bump per docs/api/README.md's "What
+# is not breaking" -- jumping straight to 1.12.0 rather than 1.10.0 because
+# 1.10.0, 1.11.0 and 1.13.0 are claimed by other branches of this same
+# orchestration (issue #73's other Stage 3/4 tracks) not yet merged onto this
+# one; only one bump survives the eventual merge, same reasoning the 1.4.0
+# comment above already gives for four branches sharing one line.
+API_CONTRACT_VERSION = "1.12.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a

--- a/gateway/app/db/schema_guard.py
+++ b/gateway/app/db/schema_guard.py
@@ -77,6 +77,14 @@ REQUIRED_COLUMNS: dict[str, dict[str, str]] = {
     "executors": {
         "node_id": "0009_control_plane.sql",
     },
+    # Without this, `record_discovery_report` and the adoption routes both
+    # select a column the ORM model declares (`DiscoveredResourceModel.
+    # resource_path`) that a pre-0013 database does not have -- a 500 on the
+    # first discovery report or adoption call, not a startup failure that
+    # names the fix.
+    "discovered_resources": {
+        "resource_path": "0013_discovery_resource_key_hash.sql",
+    },
 }
 
 

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -15,6 +15,7 @@ from gateway.app.api.rate_limit import RateLimitDependency, client_key
 from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import decisions, missions, nodes as nodes_routes, probes, projects, sessions
 from gateway.app.api.routes import conversations as conversations_routes
+from gateway.app.api.routes import discovery as discovery_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
 from gateway.app.api.setup import install_api_conventions
@@ -150,6 +151,11 @@ app.include_router(conversations_routes.router, dependencies=[Depends(RateLimitD
 # the fleet-wide `permissions.NODES_READ` action rather than the
 # project-scoped `visible_projects` pattern the routers above use.
 app.include_router(nodes_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# Discovered-resource adoption (issue #73, Stage 3 adoption half). Same
+# limiter, same administrative/fleet-wide posture as nodes.router above --
+# guarded by `NODES_DISCOVERIES_READ`/`NODES_DISCOVERIES_DECIDE`.
+app.include_router(discovery_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 
 
 def oauth_www_authenticate_header() -> str:

--- a/gateway/app/models/entities.py
+++ b/gateway/app/models/entities.py
@@ -157,6 +157,26 @@ class DiscoveredResourceModel(Base):
     deliberately NOT a foreign key: a candidate exists precisely before there
     is a `projects` row to point at. `kind` leaves room for the
     processes/services #73 anticipates without a schema change.
+
+    `resource_key`/`resource_path` split (WK-20260902-gh73-discovery-adoption,
+    `migrations/0013_discovery_resource_key_hash.sql`). Issue #73 Stage 3
+    wrote the candidate's absolute path straight into `resource_key`, a
+    `varchar(255)` that also anchors the composite unique index `(node_id,
+    kind, resource_key)`. SQLite never enforced that width; MySQL -- a
+    declared target via `aiomysql` -- does, so a path near the protocol's own
+    2048-character limit was one `codex exec` scan away from an insert
+    failure nobody had hit yet. See `shared.security.hash_resource_key`'s
+    docstring for why widening the column was rejected in favor of hashing.
+
+    `resource_key` is now `hash_resource_key(path)` -- 64 hex characters,
+    comfortably inside both the column and the MySQL index-key limit that
+    likely sized the original 255. `resource_path` carries the real path, at
+    the same 2048-character width `DiscoveredCandidate.resource_key` already
+    allows, unindexed. It joins `root_path` in the same sensitive-data
+    category `docs/control-plane.md` documents for `WorkspaceBindingModel.
+    local_path`: operator-surface-only, never `ProjectStatus`/`Session`/
+    `Mission`/any MCP tool (`docs/api/README.md`, "Fields that must never
+    ship").
     """
 
     __tablename__ = "discovered_resources"
@@ -169,6 +189,7 @@ class DiscoveredResourceModel(Base):
     evidence_json: Mapped[str] = mapped_column(Text, default="{}")
     state: Mapped[str] = mapped_column(String(32), default="discovered")
     root_path: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    resource_path: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     first_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     decided_by: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/gateway/app/services/discovery_types.py
+++ b/gateway/app/services/discovery_types.py
@@ -1,0 +1,42 @@
+"""Closed vocabulary for adopting a `discovered_resources` row, and its error.
+
+WK-20260902-gh73-discovery-adoption, issue #73 Stage 3 (adoption half). Kept
+out of `shared/protocol.py` on purpose, same reasoning `issue_types.py` and
+`conversation_types.py` already give: this is a gateway-only, operator-facing
+concept -- the node never sees an adoption decision, only its eventual effect
+(a `project_authorizations` row it did not write) -- so it does not share a
+module with the executor wire protocol.
+"""
+
+from __future__ import annotations
+
+from shared.protocol import DiscoveredState
+
+
+# The only states `adopt_discovered_resource`/`deny_discovered_resource` may
+# act on. `ADOPTED`/`AUTHORIZED`/`DENIED` are all standing operator decisions;
+# re-deciding one is a conflict, not a silent overwrite -- the same posture
+# `routes/decisions.py:DECIDABLE` already takes toward a resolved decision.
+# `STALE` is included deliberately: a candidate the node stopped reporting is
+# still something an operator may choose to adopt or deny from history, and
+# `docs/control-plane.md` already treats a `STALE` row's earlier decision (if
+# any) as worth preserving -- an *undecided* `STALE` row deserves the same
+# adoption path a `DISCOVERED` one gets, not a dead end.
+DECIDABLE_DISCOVERY_STATES = frozenset({DiscoveredState.DISCOVERED.value, DiscoveredState.STALE.value})
+
+
+class DiscoveryAdoptionError(ValueError):
+    """An adopt/deny input that fails validation inside the store itself.
+
+    Same shape as `issue_types.IssuePlanningError` and
+    `conversation_types.ConversationPlanningError`: the guard belongs inside
+    the operation, not the route, so a future second caller (there is none
+    today, but `link_issue_to_epic`'s own history is the reason this is
+    written now rather than assumed) does not get to skip it by construction.
+    """
+
+    def __init__(self, field: str, code: str, message: str) -> None:
+        super().__init__(message)
+        self.field = field
+        self.code = code
+        self.message = message

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -24,8 +24,10 @@ from gateway.app.models.entities import (
     OAuthRefreshTokenModel,
     ProjectAuthorizationModel,
     ProjectModel,
+    ScmAssociationModel,
     TaskLogModel,
     TaskModel,
+    WorkspaceBindingModel,
 )
 from gateway.app.services.audit import record_event
 from gateway.app.services.conversation_types import (
@@ -33,6 +35,10 @@ from gateway.app.services.conversation_types import (
     MAX_ATTACHMENTS_PER_MESSAGE,
     MAX_MESSAGE_BODY_LENGTH,
     ConversationPlanningError,
+)
+from gateway.app.services.discovery_types import (
+    DECIDABLE_DISCOVERY_STATES,
+    DiscoveryAdoptionError,
 )
 from gateway.app.services.issue_types import (
     DEFAULT_EPIC_STATUS,
@@ -46,10 +52,13 @@ from gateway.app.services.issue_types import (
 from shared.policy import evaluate_task_policy
 from shared.protocol import (
     ApprovalDecision,
+    BindingState,
+    Capability,
     DEFAULT_CANCEL_REPLAY_MAX_AGE_SECONDS,
     DEFAULT_CONTROL_REPLAY_MAX_AGE_SECONDS,
     DiscoveredState,
     DiscoveryReport,
+    DiscoveryRoot,
     ExecutorRegistration,
     NodeAnnouncement,
     PolicyLevel,
@@ -59,7 +68,7 @@ from shared.protocol import (
     TaskMode,
     TaskState,
 )
-from shared.security import hash_token
+from shared.security import hash_resource_key, hash_token
 
 
 # `entity_type` of every row the credential lifecycle writes, and the only rows
@@ -609,24 +618,34 @@ async def record_discovery_report(
 
     Reconciliation, scoped to `(node.id, "project", report.root_path)` --
     everything this node has ever reported for THIS root, never another root
-    or another node's rows:
+    or another node's rows. Matched by `resource_path` (the candidate's raw
+    path), never by the `resource_key` column: since
+    `migrations/0013_discovery_resource_key_hash.sql`, `resource_key` is
+    `hash_resource_key(resource_path)` -- a fixed-width lookup key, not
+    identity itself. Matching on the hash would work too (it is
+    deterministic), but matching on the path is what lets a pre-0013 row --
+    whose `resource_key` the migration deliberately left as the old raw path,
+    see that file's own comment -- still be found and self-healed the first
+    time its node reports it again, rather than read as "new" and duplicated:
 
-    * a `resource_key` not seen before is INSERTed with
-      `state=DISCOVERED`, `first_seen_at=last_seen_at=now`;
-    * a `resource_key` already on file has its `evidence_json` and
-      `last_seen_at` refreshed, and its `state` is left exactly as it is --
-      a repeated observation is not a new operator decision, so an `ADOPTED`
-      or `AUTHORIZED` row must not regress to `DISCOVERED` just because the
-      node reconnected and reported the same directory again
-      (`docs/control-plane.md`);
+    * a `resource_path` not seen before is INSERTed with `state=DISCOVERED`,
+      `first_seen_at=last_seen_at=now`, `resource_key=hash_resource_key(path)`;
+    * a `resource_path` already on file has its `evidence_json`,
+      `last_seen_at` and `resource_key` refreshed (the last one is a no-op for
+      an already-migrated row and a repair for one that is not), and its
+      `state` is left exactly as it is -- a repeated observation is not a new
+      operator decision, so an `ADOPTED` or `AUTHORIZED` row must not regress
+      to `DISCOVERED` just because the node reconnected and reported the same
+      directory again (`docs/control-plane.md`);
     * a row for THIS root that is NOT in the current report, and whose state
       is not `DENIED`, becomes `STALE` -- last observed, not currently seen;
     * `DENIED` is a standing operator decision and is never written to by
       observation, in either direction: a denied candidate does not regress
       to the adoption queue on reconnect (`docs/control-plane.md`: "candidato
       recusado volta à fila de adoção a cada reconexão" is exactly the bug
-      this refusal prevents), and it does not have its evidence refreshed
-      either -- the row simply stops moving once an operator has decided;
+      this refusal prevents), and it does not have its evidence (or
+      `resource_key`) refreshed either -- the row simply stops moving once an
+      operator has decided;
     * a `STALE` row that reappears in a report does not default back to
       `DISCOVERED` if the operator's earlier decision on it is still on
       file -- see `_revive_stale_discovery_row`.
@@ -652,17 +671,17 @@ async def record_discovery_report(
             )
         ).scalars()
     )
-    by_key = {row.resource_key: row for row in existing}
-    reported_keys: set[str] = set()
+    by_path = {row.resource_path: row for row in existing if row.resource_path is not None}
+    reported_paths: set[str] = set()
 
     for candidate in report.candidates:
-        reported_keys.add(candidate.resource_key)
-        row = by_key.get(candidate.resource_key)
+        reported_paths.add(candidate.resource_key)
+        row = by_path.get(candidate.resource_key)
         if row is not None and row.state == DiscoveredState.DENIED.value:
             # A denial is the operator's decision, not a fact the node can
             # overwrite by continuing to see the directory. Skipped entirely
-            # -- not even evidence/last_seen_at move -- so a denied row stops
-            # changing the moment it is denied.
+            # -- not even evidence/last_seen_at/resource_key move -- so a
+            # denied row stops changing the moment it is denied.
             continue
 
         evidence = json.dumps(
@@ -682,7 +701,8 @@ async def record_discovery_report(
                     id=str(uuid4()),
                     node_id=node.id,
                     kind="project",
-                    resource_key=candidate.resource_key,
+                    resource_key=hash_resource_key(candidate.resource_key),
+                    resource_path=candidate.resource_key,
                     evidence_json=evidence,
                     state=DiscoveredState.DISCOVERED.value,
                     root_path=report.root_path,
@@ -694,13 +714,17 @@ async def record_discovery_report(
 
         row.evidence_json = evidence
         row.last_seen_at = now
+        # Self-heals a pre-0013 row (whose `resource_key` the migration left
+        # as the raw path) the moment its node reports it again -- a no-op
+        # assignment for a row already on the hash.
+        row.resource_key = hash_resource_key(candidate.resource_key)
         if row.state == DiscoveredState.STALE.value:
             await _revive_stale_discovery_row(session, row)
         # Any other state (DISCOVERED/ADOPTED/AUTHORIZED) stays exactly as it
         # is -- see this function's own docstring.
 
     for row in existing:
-        if row.resource_key in reported_keys:
+        if row.resource_path in reported_paths:
             continue
         if row.state == DiscoveredState.DENIED.value:
             continue
@@ -715,12 +739,11 @@ async def _revive_stale_discovery_row(session: AsyncSession, row: DiscoveredReso
     Not unconditionally `DISCOVERED`: if the operator had already adopted or
     authorized this resource before the node stopped reporting it, that
     decision must survive the gap, not be forgotten because the row briefly
-    went `STALE`. `row.project_id` is set by the adoption work that follows
-    this PR, never by anything in this file -- so this function's first
-    branch (`DISCOVERED`) is the only one reachable from code that exists
-    today. The rest is written now because the row it operates on already
-    exists today, and a row this function would get wrong later is a bug
-    nobody would think to test until it reappeared.
+    went `STALE`. `row.project_id` is set by `adopt_discovered_resource`
+    below, never by `record_discovery_report` or anything else this function
+    is reached from -- reporting a directory again cannot, by itself, make
+    this function's second branch (an active authorization) reachable; that
+    still requires the human adoption path to have run first.
     """
     if row.project_id is None:
         row.state = DiscoveredState.DISCOVERED.value
@@ -741,6 +764,387 @@ async def _revive_stale_discovery_row(session: AsyncSession, row: DiscoveredReso
     row.state = (
         DiscoveredState.AUTHORIZED.value if authorization is not None else DiscoveredState.ADOPTED.value
     )
+
+
+# --------------------------------------------------------------------------
+# Adoption: the node proposes (above), a human decides (below)
+# --------------------------------------------------------------------------
+#
+# Issue #73 Stage 3, adoption half (WK-20260902-gh73-discovery-adoption).
+# `record_discovery_report` above writes only `discovered_resources` -- by
+# construction, per its own docstring. Everything below is the other half:
+# the only code in this module that may turn a `discovered_resources` row
+# into a `ProjectModel`, a `WorkspaceBindingModel`, a `ScmAssociationModel`,
+# or a `ProjectAuthorizationModel`. Both functions are called exclusively
+# from `gateway/app/api/routes/discovery.py`'s `adopt`/`deny` routes, which
+# require `permissions.NODES_DISCOVERIES_DECIDE` -- an administrative scope
+# that only `gateway/app/api/auth.py:current_principal` can grant, and that
+# function resolves ONLY an OAuth access token (`store.get_oauth_access_token`).
+# The executor WebSocket (`gateway/app/main.py:agent_ws`) authenticates with a
+# `machine_token` instead, checked in `main.py` directly and never turned
+# into an `AuthenticatedPrincipal` -- there is no code path from a connected
+# node's credential to either function below. Issue #73: "a node cannot grant
+# itself project authorization merely by reporting a discovery" -- this is
+# where a human does, and only a human can reach it
+# (`tests/unit/test_discovery_store.py::
+# test_a_matching_auto_authorize_root_grants_nothing_from_a_report_alone`,
+# `tests/integration/test_discovery_routes.py::
+# test_a_principal_without_the_administrative_scope_cannot_adopt`).
+
+
+async def list_discovered_resources_page(
+    session: AsyncSession,
+    node_id: str,
+    *,
+    state: str | None = None,
+    after: str | None = None,
+    limit: int = 50,
+) -> list[DiscoveredResourceModel]:
+    """One node's discovered candidates, ordered by id, over-fetched by one.
+
+    Cursor-paginated -- unlike `list_nodes`, whose own docstring argues the
+    fleet is small and operator-curated. That argument does not extend here:
+    a single real operator root has reported 247 candidates in one scan
+    (`docs/control-plane.md`), which is exactly the case `list_nodes` does
+    not have to handle and this one must.
+
+    `id` (a uuid4 assigned at insert) is the cursor key for the same reason
+    `list_projects_page` cursors on `ProjectModel.id`: it is unique and
+    stable. `last_seen_at` was considered and rejected -- it moves every time
+    a node rescans, which would let a page boundary drift out from under a
+    client mid-list, the same hazard that ordering choice avoids elsewhere in
+    this module.
+    """
+    statement = select(DiscoveredResourceModel).where(DiscoveredResourceModel.node_id == node_id)
+    if state is not None:
+        statement = statement.where(DiscoveredResourceModel.state == state)
+    if after is not None:
+        statement = statement.where(DiscoveredResourceModel.id > after)
+    statement = statement.order_by(DiscoveredResourceModel.id.asc()).limit(limit + 1)
+    result = await session.execute(statement)
+    return list(result.scalars())
+
+
+async def get_discovered_resource(session: AsyncSession, resource_id: str) -> DiscoveredResourceModel | None:
+    return await session.get(DiscoveredResourceModel, resource_id)
+
+
+async def _matching_discovery_root(
+    session: AsyncSession, node_id: str, root_path: str | None
+) -> DiscoveryRoot | None:
+    """The operator's `DiscoveryRoot` entry for `root_path`, if this node's
+    executor registration names one.
+
+    Matched by exact string equality, never resolved -- `DiscoveryRoot`'s own
+    docstring: the gateway cannot see the node's disk, so it has no path to
+    canonicalize against. `None` covers every reason there is nothing to
+    grant: no executor bound to this node, no `discovery_roots` entry at all,
+    or an entry whose `path` string does not literally match `root_path`.
+    """
+    if root_path is None:
+        return None
+    executor = (
+        (await session.execute(select(ExecutorModel).where(ExecutorModel.node_id == node_id)))
+        .scalars()
+        .first()
+    )
+    if executor is None:
+        return None
+    registration = ExecutorRegistration.model_validate(json.loads(executor.metadata_json))
+    for root in registration.discovery_roots:
+        if root.path == root_path:
+            return root
+    return None
+
+
+async def _grant_project_authorization(
+    session: AsyncSession,
+    *,
+    node_id: str,
+    project_id: str,
+    capabilities: list[Capability],
+    origin: str,
+    now: datetime,
+) -> None:
+    """Merge `capabilities`, from `origin`, into the standing authorization
+    row for `(node_id, project_id)`.
+
+    `project_authorizations_node_project_idx` allows exactly one non-revoked
+    row per `(node_id, project_id)` -- so a discovery root's `auto_authorize`
+    and an operator's explicit `grant_capabilities`, both applying in the
+    same `adopt_discovered_resource` call, cannot become two rows; they merge
+    into one. `granted_by` is a `;`-joined set of origins for exactly that
+    reason: it is the only place provenance lives, and a single string
+    column must not silently lose one origin because the other also applied
+    in the same call (`docs/control-plane.md`: "granted_by distingue
+    root-config:<path> de operator:<user_id>" -- distinguishes, not
+    replaces). Capabilities only ever grow here; nothing in this function
+    revokes -- revocation has no caller in this PR.
+    """
+    if not capabilities:
+        return
+    existing = (
+        (
+            await session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == node_id,
+                    ProjectAuthorizationModel.project_id == project_id,
+                    ProjectAuthorizationModel.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    wanted = {capability.value for capability in capabilities}
+    if existing is None:
+        session.add(
+            ProjectAuthorizationModel(
+                id=str(uuid4()),
+                node_id=node_id,
+                project_id=project_id,
+                capabilities_json=json.dumps(sorted(wanted)),
+                granted_by=origin,
+                granted_at=now,
+            )
+        )
+        return
+    current = set(json.loads(existing.capabilities_json or "[]"))
+    existing.capabilities_json = json.dumps(sorted(current | wanted))
+    origins = set(existing.granted_by.split(";")) if existing.granted_by else set()
+    origins.add(origin)
+    existing.granted_by = ";".join(sorted(origins))
+
+
+async def adopt_discovered_resource(
+    session: AsyncSession,
+    resource_id: str,
+    *,
+    project_id: str | None,
+    new_project_id: str | None,
+    new_project_name: str | None,
+    grant_capabilities: list[Capability],
+    actor_user_id: str,
+    now: datetime | None = None,
+) -> DiscoveredResourceModel:
+    """Adopt one discovered candidate: bind it to a project and, when either
+
+    a matching `auto_authorize` discovery root or an explicit
+    `grant_capabilities` applies, grant capability too.
+
+    Exactly one of `project_id` (reuse an existing project) or
+    `new_project_id`/`new_project_name` (create one) must be given -- the
+    route layer's request model enforces "one of `project_id` or
+    `new_project`", so by the time this runs the pair is either both `None`
+    or both set. Re-checked here anyway (`DiscoveryAdoptionError`) because
+    the guard belongs on the operation, not the caller
+    (`gateway/app/services/issue_types.py:IssuePlanningError`'s own
+    docstring makes the same argument).
+
+    Only `row.state in DECIDABLE_DISCOVERY_STATES` (`DISCOVERED`/`STALE`) may
+    be adopted -- an already `ADOPTED`/`AUTHORIZED`/`DENIED` row is a
+    standing decision, and adopting it again would either silently duplicate
+    the `WorkspaceBindingModel`/`ScmAssociationModel` it already produced or
+    silently overwrite a `DENIED` an operator chose deliberately. Calling
+    this twice on the same row raises `ValueError("discovered_resource_not_
+    decidable")` on the second call, which is what actually keeps a
+    double-adopt from duplicating anything -- not a defensive check inside
+    the write itself.
+
+    Reusing `project_id` for a project this node has already bound (a second
+    candidate adopted into a project the first one already created here, or
+    literally the same candidate's earlier successful adoption) updates the
+    existing `WorkspaceBindingModel`/`ScmAssociationModel`/
+    `ProjectAuthorizationModel` rows rather than inserting siblings --
+    required by the unique indexes those tables already carry
+    (`workspace_bindings_node_project_idx`, `scm_associations_project_remote_
+    idx`, `project_authorizations_node_project_idx`), not merely convenient.
+
+    `ProjectModel.path`, for a NEWLY created project, is set to the
+    candidate's own `resource_path`: the field is deprecated as authoritative
+    the moment a `WorkspaceBindingModel` exists (`docs/control-plane.md`,
+    "O que a 0009 deliberadamente não faz"), but it is `NOT NULL` and a
+    project created by adoption has no `registry.json` entry to have set it
+    instead -- leaving it empty would be a gratuitous difference from every
+    project this codebase has created so far, for no reader's benefit.
+    """
+    now = now or datetime.now(timezone.utc)
+    row = await session.get(DiscoveredResourceModel, resource_id)
+    if row is None:
+        raise ValueError("discovered_resource_not_found")
+    if row.state not in DECIDABLE_DISCOVERY_STATES:
+        raise ValueError("discovered_resource_not_decidable")
+    if (project_id is None) == (new_project_id is None):
+        raise DiscoveryAdoptionError(
+            "project_id",
+            "exactly_one_required",
+            "Provide exactly one of project_id or new_project.",
+        )
+
+    if project_id is not None:
+        project = await session.get(ProjectModel, project_id)
+        if project is None:
+            raise DiscoveryAdoptionError(
+                "project_id", "not_found", f"No such project: {project_id!r}."
+            )
+    else:
+        conflict = await session.get(ProjectModel, new_project_id)
+        if conflict is not None:
+            raise DiscoveryAdoptionError(
+                "new_project.project_id",
+                "already_exists",
+                f"Project {new_project_id!r} already exists; pass project_id to reuse it.",
+            )
+        project = ProjectModel(
+            id=new_project_id,
+            name=new_project_name or new_project_id,
+            path=row.resource_path or "",
+            enabled=True,
+            config_json="{}",
+        )
+        session.add(project)
+
+    evidence = json.loads(row.evidence_json or "{}")
+    remote_url = evidence.get("remote_url")
+
+    binding = (
+        (
+            await session.execute(
+                select(WorkspaceBindingModel).where(
+                    WorkspaceBindingModel.node_id == row.node_id,
+                    WorkspaceBindingModel.project_id == project.id,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if binding is None:
+        session.add(
+            WorkspaceBindingModel(
+                id=str(uuid4()),
+                node_id=row.node_id,
+                project_id=project.id,
+                local_path=row.resource_path or "",
+                head=evidence.get("head"),
+                dirty=evidence.get("dirty"),
+                state=BindingState.ACTIVE.value,
+                last_scan_at=row.last_seen_at,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    else:
+        binding.local_path = row.resource_path or binding.local_path
+        binding.head = evidence.get("head")
+        binding.dirty = evidence.get("dirty")
+        binding.state = BindingState.ACTIVE.value
+        binding.last_scan_at = row.last_seen_at
+        binding.updated_at = now
+
+    if remote_url:
+        association = (
+            (
+                await session.execute(
+                    select(ScmAssociationModel).where(
+                        ScmAssociationModel.project_id == project.id,
+                        ScmAssociationModel.remote_url == remote_url,
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if association is None:
+            session.add(
+                ScmAssociationModel(
+                    id=str(uuid4()),
+                    project_id=project.id,
+                    provider="github",
+                    remote_url=remote_url,
+                    confidence="observed",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+    matched_root = await _matching_discovery_root(session, row.node_id, row.root_path)
+    if matched_root is not None and matched_root.auto_authorize:
+        await _grant_project_authorization(
+            session,
+            node_id=row.node_id,
+            project_id=project.id,
+            capabilities=matched_root.auto_authorize,
+            origin=f"root-config:{matched_root.path}",
+            now=now,
+        )
+    if grant_capabilities:
+        await _grant_project_authorization(
+            session,
+            node_id=row.node_id,
+            project_id=project.id,
+            capabilities=grant_capabilities,
+            origin=f"operator:{actor_user_id}",
+            now=now,
+        )
+
+    authorized = (
+        (
+            await session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == row.node_id,
+                    ProjectAuthorizationModel.project_id == project.id,
+                    ProjectAuthorizationModel.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    row.project_id = project.id
+    row.state = DiscoveredState.AUTHORIZED.value if authorized is not None else DiscoveredState.ADOPTED.value
+    row.decided_by = f"operator:{actor_user_id}"
+    row.decided_at = now
+
+    await record_event(
+        session,
+        "discovered_resource",
+        row.id,
+        "discovery.adopted",
+        {"actor_id": actor_user_id, "project_id": project.id, "node_id": row.node_id},
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def deny_discovered_resource(
+    session: AsyncSession,
+    resource_id: str,
+    *,
+    actor_user_id: str,
+    now: datetime | None = None,
+) -> DiscoveredResourceModel:
+    """Refuse one discovered candidate. See `DECIDABLE_DISCOVERY_STATES` --
+
+    only a `DISCOVERED`/`STALE` row may be denied; an already-decided row
+    (including an already-`DENIED` one) is a conflict, not a silent no-op.
+    """
+    now = now or datetime.now(timezone.utc)
+    row = await session.get(DiscoveredResourceModel, resource_id)
+    if row is None:
+        raise ValueError("discovered_resource_not_found")
+    if row.state not in DECIDABLE_DISCOVERY_STATES:
+        raise ValueError("discovered_resource_not_decidable")
+    row.state = DiscoveredState.DENIED.value
+    row.decided_by = f"operator:{actor_user_id}"
+    row.decided_at = now
+    await record_event(
+        session, "discovered_resource", row.id, "discovery.denied", {"actor_id": actor_user_id}
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
 
 
 async def list_nodes(session: AsyncSession) -> list[tuple[NodeModel, ExecutorModel | None]]:

--- a/migrations/0013_discovery_resource_key_hash.sql
+++ b/migrations/0013_discovery_resource_key_hash.sql
@@ -1,0 +1,60 @@
+-- WK-20260902-gh73-discovery-adoption / issue #73, Stage 3 (adoption half)
+--
+-- Fixes a defect the previous PR (Stage 3, discovery report) found and left
+-- for this one: `discovered_resources.resource_key` is `varchar(255)`
+-- (`0009_control_plane.sql`), sized when the column was still imagined as a
+-- short suggested id. The report work repurposed it to hold the candidate's
+-- absolute path on the node -- up to `DiscoveredCandidate.resource_key`'s own
+-- `max_length` of 2048. SQLite never enforces a column's declared width (type
+-- affinity, not a constraint), so the mismatch was silent there. `aiomysql`
+-- is a declared dependency, and MySQL DOES enforce it -- so the same insert
+-- is `Data too long for column 'resource_key'` on that target.
+--
+-- Widening the column is not the fix. `resource_key` anchors the composite
+-- unique index `discovered_resources_node_kind_key_idx (node_id, kind,
+-- resource_key)`, and MySQL's InnoDB index key limit (3072 bytes, ~767
+-- `utf8mb4` characters) is almost certainly what the original 255 was sized
+-- against. Widening `resource_key` to 2048 would trade today's silent
+-- failure for a different one on the same target the moment a long enough
+-- path arrived -- not a fix, a relocation.
+--
+-- The chosen shape: `resource_key` keeps its declared width and becomes a
+-- fixed-width lookup key -- `shared.security.hash_resource_key`, sha256 hex,
+-- always 64 characters, comfortably inside both the column and the MySQL
+-- index limit that likely sized it. The real path moves to a new, UNINDEXED
+-- column, `resource_path`, at the same 2048-character width the protocol
+-- already allows -- so no path is ever truncated, and the index the unique
+-- constraint depends on never has to bound an operator's filesystem layout.
+-- `gateway/app/services/store.py:record_discovery_report` matches incoming
+-- candidates against `resource_path`, not the hash, and writes both columns
+-- together going forward -- see that function's own docstring.
+--
+-- Backfill, not a rewrite of existing values: `resource_path` is populated
+-- by copying whatever `resource_key` already holds (the plain path, written
+-- by every row this table has ever received) -- a portable `UPDATE`, no
+-- hashing needed for a copy. `resource_key` itself is deliberately NOT
+-- rewritten to a hash here: sha256 has no portable expression across
+-- SQLite/PostgreSQL/MySQL in plain DDL (`0009_control_plane.sql`'s own
+-- precedent -- the `workspace_bindings` backfill from `executors.
+-- metadata_json` -- already established that a backfill "não exprimível em
+-- SQL portável" belongs in application code, not the migration file). A row
+-- whose `resource_key` still holds a raw path instead of a hash is
+-- self-healing: `record_discovery_report` matches by `resource_path` (which
+-- this migration DOES populate), and unconditionally rewrites
+-- `resource_key` to the hash on every match or insert -- so any pre-0013 row
+-- is repaired the next time its node reports it. A row that is never
+-- reported again keeps its old-format `resource_key` forever, but nothing
+-- reads that value as a lookup key from this migration on, and no NEW write
+-- can ever again exceed the column's width -- see `hash_resource_key`'s own
+-- docstring for why that is enough.
+--
+-- Portability: `alter table ... add column` (no default, nullable -- same
+-- shape as this table's own `root_path`) and one `update ... where ... is
+-- null`, both valid on SQLite, PostgreSQL and MySQL. No `alter column`, no
+-- index change: the existing unique index is left exactly as it is, because
+-- what it indexes (a 64-character hash from here on) already fits it.
+--
+-- Apply with `python3 scripts/apply_migrations.py`.
+alter table discovered_resources add column resource_path varchar(2048);
+
+update discovered_resources set resource_path = resource_key where resource_path is null;

--- a/shared/security.py
+++ b/shared/security.py
@@ -22,6 +22,42 @@ def hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
 
 
+def hash_resource_key(value: str) -> str:
+    """A fixed-width (64 hex chars), indexable stand-in for an unbounded string.
+
+    WK-20260902-gh73-discovery-adoption. `DiscoveredResourceModel.resource_key`
+    was written, since issue #73 Stage 3, as the candidate's absolute path on
+    the node -- up to `DiscoveredCandidate.resource_key`'s own `max_length`
+    2048 -- into a column declared `varchar(255)`. SQLite never enforces that
+    width (type affinity, not a constraint), so the defect was silent there;
+    `aiomysql` is a declared dependency, and MySQL does enforce it, so the
+    same write is a `Data too long for column` error on that target.
+
+    Widening the column is not the fix: it sits inside the composite unique
+    index `(node_id, kind, resource_key)`, and MySQL's InnoDB index key limit
+    (3072 bytes; ~767 characters at 4 bytes/char for `utf8mb4`) is almost
+    certainly what the original 255 was sized against, before issue #73 Stage
+    3 repurposed the column to hold a full path instead of a short suggested
+    id. Widening it to fit 2048 characters would trade one silent failure for
+    a different one on the same target.
+
+    Same shape as `hash_token` (sha256, hex) and deliberately a second
+    function rather than a shared call site: the two hash unrelated kinds of
+    string for unrelated reasons (secrecy at rest vs. a fixed-width index
+    key), and `docs/napkin-lessons.md`'s guidance against parallel concepts
+    is about vocabulary that means the same thing twice, not about two
+    one-line hashes that happen to use the same primitive.
+
+    The candidate's real path never disappears: `DiscoveredResourceModel.
+    resource_path` (added by `migrations/0013_discovery_resource_key_hash.
+    sql`) carries it, unindexed, at the same 2048-character width the
+    protocol already allows. `resource_key` is purely a lookup key from here
+    on -- see `gateway/app/services/store.py:record_discovery_report` for how
+    the two columns divide the work.
+    """
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
 def sanitize_log_line(line: str) -> str:
     redacted = line
     for pattern in SECRET_PATTERNS:

--- a/tests/integration/test_agent_ws_discovery.py
+++ b/tests/integration/test_agent_ws_discovery.py
@@ -145,7 +145,12 @@ async def test_a_discovery_report_is_recorded_for_the_authenticated_node(wired) 
 
     rows = await _discovered_rows(wired, VICTIM)
     assert len(rows) == 1
-    assert rows[0].resource_key == "/root/hub"
+    # `resource_key` is a fixed-width hash from `migrations/0013_discovery_
+    # resource_key_hash.sql` on -- `resource_path` is where the real path lives.
+    from shared.security import hash_resource_key
+
+    assert rows[0].resource_path == "/root/hub"
+    assert rows[0].resource_key == hash_resource_key("/root/hub")
     assert rows[0].root_path == "/root"
 
 

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -30,6 +30,7 @@ from gateway.app.api import permissions
 from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import decisions as decisions_routes
+from gateway.app.api.routes import discovery as discovery_routes
 from gateway.app.api.routes import epics as epics_routes
 from gateway.app.api.routes import issues as issues_routes
 from gateway.app.api.routes import nodes as nodes_routes
@@ -166,6 +167,7 @@ async def api(users_file, monkeypatch):
     app.include_router(issues_routes.router)
     app.include_router(conversations_routes.router)
     app.include_router(nodes_routes.router)
+    app.include_router(discovery_routes.router)
 
     async def override():
         async with factory() as s:
@@ -1011,6 +1013,15 @@ async def test_me_separates_read_operational_and_administrative(api) -> None:
 # describes.
 ENDPOINT_FOR_ACTION = {
     "nodes.read": ("GET", "/api/v1/nodes"),
+    # `{id}` here is a `TaskModel.id` (see `make_task` below), not a real node
+    # id -- fine for this parity check, whose only claim is about the 403
+    # boundary: `require_action` runs before the route body ever looks a
+    # node/resource up, so a caller lacking the scope gets 403 regardless of
+    # what {id} resolves to, and one holding it gets whatever the (possibly
+    # 404) lookup produces -- never 403 either way. Same reasoning the
+    # `epics`/`issues` entries above already document.
+    "nodes.discoveries.read": ("GET", "/api/v1/nodes/{id}/discovered-resources"),
+    "nodes.discoveries.decide": ("POST", "/api/v1/discovered-resources/{id}/deny"),
     "sessions.read": ("GET", "/api/v1/sessions"),
     "sessions.readLogs": ("GET", "/api/v1/sessions/{id}/logs"),
     "sessions.explainError": ("POST", "/api/v1/sessions/{id}/explain-error"),

--- a/tests/integration/test_discovery_routes.py
+++ b/tests/integration/test_discovery_routes.py
@@ -1,0 +1,574 @@
+"""Discovered-resource adoption routes — issue #73 Stage 3 adoption half.
+
+WK-20260902-gh73-discovery-adoption. Fixture idiom copied from
+`test_nodes.py`: real FastAPI app, in-memory sqlite, `store.upsert_registry`
+seeding, OAuth tokens minted through `store.create_oauth_access_token`.
+
+Weighted toward the invariant this PR exists to prove: a node cannot reach
+`project_authorizations` through any REST surface this module adds, only a
+human with the administrative scope can, and adopting is the only door into
+`projects`/`workspace_bindings`/`scm_associations`/`project_authorizations`
+from a `discovered_resources` row. Every negative case is paired with a
+positive control in the same file (`docs/napkin-lessons.md`, 2026-09-01).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import discovery as discovery_routes
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.models.entities import (
+    DiscoveredResourceModel,
+    ProjectAuthorizationModel,
+    ProjectModel,
+    ScmAssociationModel,
+    WorkspaceBindingModel,
+)
+from gateway.app.services import store
+from shared.protocol import DiscoveredState, DiscoveryRoot, ExecutorRegistration, Capability
+
+
+ADMIN_TOKEN = "token-admin"      # roles=["admin"] -- may adopt/deny
+ALICE_TOKEN = "token-alice"      # authenticated, codexbridge.read only -- no fleet access
+NOSCOPE_TOKEN = "token-noscope"  # authenticated, no scopes at all
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "admin", "email": "admin@example.com", "password_hash": "x",
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "enabled": True,
+                    },
+                    {
+                        "user_id": "alice", "email": "alice@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read"], "enabled": True,
+                    },
+                    {
+                        "user_id": "noscope", "email": "noscope@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": [],
+                        "scopes": [], "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def api(users_file, monkeypatch):
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="E1", display_name="E1", machine_token="t",
+                    allowed_projects=[], enabled=True,
+                    discovery_roots=[DiscoveryRoot(path="/root", auto_authorize=[Capability.READ])],
+                ),
+                ExecutorRegistration(
+                    executor_id="E2", display_name="E2", machine_token="t2",
+                    allowed_projects=[], enabled=True,
+                ),
+            ],
+            projects=[],
+        )
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        for token, user_id, scopes in (
+            (ADMIN_TOKEN, "admin", ["codexbridge.admin"]),
+            (ALICE_TOKEN, "alice", ["codexbridge.read"]),
+            (NOSCOPE_TOKEN, "noscope", []),
+        ):
+            await store.create_oauth_access_token(
+                seed, token=token, client_id="c", user_id=user_id,
+                scopes=scopes, expires_at=future,
+            )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(discovery_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.factory = factory  # type: ignore[attr-defined]
+    yield client
+    await engine.dispose()
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def seed_resource(
+    factory,
+    *,
+    resource_id: str,
+    node_id: str = "E1",
+    root_path: str = "/root",
+    resource_path: str = "/root/hub",
+    state: str = DiscoveredState.DISCOVERED.value,
+    remote_url: str | None = None,
+    project_id: str | None = None,
+) -> None:
+    async with factory() as session:
+        session.add(
+            DiscoveredResourceModel(
+                id=resource_id,
+                node_id=node_id,
+                kind="project",
+                resource_key=f"hash-{resource_id}",
+                resource_path=resource_path,
+                project_id=project_id,
+                evidence_json=json.dumps(
+                    {
+                        "suggested_project_id": "hub",
+                        "suggested_name": "Hub",
+                        "remote_url": remote_url,
+                        "head": "abc123",
+                        "dirty": False,
+                    }
+                ),
+                state=state,
+                root_path=root_path,
+                first_seen_at=datetime.now(timezone.utc),
+                last_seen_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+
+# --------------------------------------------------------------------------
+# Authentication and authorization
+# --------------------------------------------------------------------------
+
+
+async def test_list_requires_a_token(api) -> None:
+    response = api.get("/api/v1/nodes/E1/discovered-resources")
+    assert response.status_code == 401
+
+
+async def test_list_without_the_admin_scope_is_forbidden(api) -> None:
+    response = api.get("/api/v1/nodes/E1/discovered-resources", headers=auth(ALICE_TOKEN))
+    assert response.status_code == 403
+    assert response.json()["code"] == "permission_denied"
+
+
+async def test_list_with_the_admin_scope_is_allowed(api) -> None:
+    """Positive control for the previous two: the scope alone is sufficient."""
+    response = api.get("/api/v1/nodes/E1/discovered-resources", headers=auth(ADMIN_TOKEN))
+    assert response.status_code == 200
+
+
+async def test_a_principal_without_the_administrative_scope_cannot_adopt(api) -> None:
+    await seed_resource(api.factory, resource_id="r1")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ALICE_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.status_code == 403
+    async with api.factory() as session:
+        row = await session.get(DiscoveredResourceModel, "r1")
+        assert row.state == DiscoveredState.DISCOVERED.value  # untouched
+
+
+async def test_a_principal_with_the_administrative_scope_can_adopt(api) -> None:
+    """Positive control for the previous test."""
+    await seed_resource(api.factory, resource_id="r1")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.status_code == 200
+
+
+async def test_a_token_with_no_scopes_cannot_deny(api) -> None:
+    await seed_resource(api.factory, resource_id="r1")
+    response = api.post("/api/v1/discovered-resources/r1/deny", headers=auth(NOSCOPE_TOKEN))
+    assert response.status_code == 403
+
+
+# --------------------------------------------------------------------------
+# List: pagination, filtering, node scope
+# --------------------------------------------------------------------------
+
+
+async def test_an_unknown_node_id_is_not_found(api) -> None:
+    response = api.get("/api/v1/nodes/does-not-exist/discovered-resources", headers=auth(ADMIN_TOKEN))
+    assert response.status_code == 404
+
+
+async def test_an_invalid_state_filter_is_rejected(api) -> None:
+    response = api.get(
+        "/api/v1/nodes/E1/discovered-resources", params={"state": "bogus"}, headers=auth(ADMIN_TOKEN)
+    )
+    assert response.status_code == 400
+
+
+async def test_the_state_filter_narrows_the_list(api) -> None:
+    await seed_resource(api.factory, resource_id="discovered-1", state=DiscoveredState.DISCOVERED.value)
+    await seed_resource(api.factory, resource_id="denied-1", state=DiscoveredState.DENIED.value)
+
+    response = api.get(
+        "/api/v1/nodes/E1/discovered-resources",
+        params={"state": "denied"},
+        headers=auth(ADMIN_TOKEN),
+    )
+    body = response.json()
+    assert [item["id"] for item in body["items"]] == ["denied-1"]
+
+    # Positive control: no filter returns both.
+    unfiltered = api.get("/api/v1/nodes/E1/discovered-resources", headers=auth(ADMIN_TOKEN)).json()
+    assert {item["id"] for item in unfiltered["items"]} == {"discovered-1", "denied-1"}
+
+
+async def test_a_resource_from_a_different_node_is_not_listed(api) -> None:
+    await seed_resource(api.factory, resource_id="on-e1", node_id="E1")
+    await seed_resource(api.factory, resource_id="on-e2", node_id="E2", resource_path="/root/other")
+
+    body = api.get("/api/v1/nodes/E1/discovered-resources", headers=auth(ADMIN_TOKEN)).json()
+    assert [item["id"] for item in body["items"]] == ["on-e1"]
+
+
+async def test_pagination_covers_more_candidates_than_one_page(api) -> None:
+    """The real-world case this PR names: 247 candidates from one root."""
+    for i in range(5):
+        await seed_resource(api.factory, resource_id=f"r{i:03d}", resource_path=f"/root/repo-{i}")
+
+    first = api.get(
+        "/api/v1/nodes/E1/discovered-resources", params={"limit": 2}, headers=auth(ADMIN_TOKEN)
+    ).json()
+    assert len(first["items"]) == 2
+    assert first["page"]["hasMore"] is True
+    assert first["page"]["nextCursor"] is not None
+
+    seen = list(first["items"])
+    cursor = first["page"]["nextCursor"]
+    while cursor:
+        page = api.get(
+            "/api/v1/nodes/E1/discovered-resources",
+            params={"limit": 2, "cursor": cursor},
+            headers=auth(ADMIN_TOKEN),
+        ).json()
+        seen.extend(page["items"])
+        cursor = page["page"]["nextCursor"]
+
+    assert {item["id"] for item in seen} == {f"r{i:03d}" for i in range(5)}
+    assert len(seen) == 5  # no duplicate across the page boundary
+
+
+async def test_the_dto_carries_the_sensitive_path_fields(api) -> None:
+    """This IS the pre-registered exception (`docs/control-plane.md`,
+
+    `docs/api/README.md`): only on this administrative endpoint.
+    """
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/root")
+    body = api.get("/api/v1/nodes/E1/discovered-resources", headers=auth(ADMIN_TOKEN)).json()
+    item = body["items"][0]
+    assert item["resourcePath"] == "/root/hub"
+    assert item["rootPath"] == "/root"
+
+
+# --------------------------------------------------------------------------
+# Adopt: project creation/reuse, binding, SCM association, state transition
+# --------------------------------------------------------------------------
+
+
+async def test_adopting_with_a_new_project_creates_project_binding_and_moves_state(api) -> None:
+    await seed_resource(
+        api.factory, resource_id="r1", resource_path="/root/hub", root_path="/other-root", remote_url="https://github.com/x/hub.git"
+    )
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["projectId"] == "hub"
+    assert body["state"] == "adopted"  # /other-root has no auto_authorize entry
+
+    async with api.factory() as session:
+        project = await session.get(ProjectModel, "hub")
+        assert project is not None and project.name == "Hub"
+
+        binding = (
+            (
+                await session.execute(
+                    select(WorkspaceBindingModel).where(
+                        WorkspaceBindingModel.node_id == "E1", WorkspaceBindingModel.project_id == "hub"
+                    )
+                )
+            )
+            .scalars()
+            .first()
+        )
+        assert binding is not None
+        assert binding.local_path == "/root/hub"
+
+        association = (
+            (await session.execute(select(ScmAssociationModel).where(ScmAssociationModel.project_id == "hub")))
+            .scalars()
+            .first()
+        )
+        assert association is not None
+        assert association.remote_url == "https://github.com/x/hub.git"
+        assert association.confidence == "observed"
+
+
+async def test_adopting_without_a_remote_url_creates_no_scm_association(api) -> None:
+    """Positive control for the previous test's association assertion."""
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/other-root", remote_url=None)
+    api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    async with api.factory() as session:
+        associations = (await session.execute(select(ScmAssociationModel))).scalars().all()
+        assert associations == []
+
+
+async def test_adopting_into_an_existing_project_reuses_it(api) -> None:
+    async with api.factory() as session:
+        session.add(ProjectModel(id="existing", name="Existing", path="/srv/existing", enabled=True, config_json="{}"))
+        await session.commit()
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/other-root")
+
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"projectId": "existing"},
+    )
+    assert response.status_code == 200
+    assert response.json()["projectId"] == "existing"
+
+    async with api.factory() as session:
+        projects = (await session.execute(select(ProjectModel))).scalars().all()
+        assert len(projects) == 1, "no duplicate project was created"
+
+
+async def test_adopting_twice_does_not_duplicate_the_binding(api) -> None:
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/other-root")
+    body = {"newProject": {"projectId": "hub", "name": "Hub"}}
+
+    first = api.post("/api/v1/discovered-resources/r1/adopt", headers=auth(ADMIN_TOKEN), json=body)
+    assert first.status_code == 200
+
+    second = api.post("/api/v1/discovered-resources/r1/adopt", headers=auth(ADMIN_TOKEN), json=body)
+    assert second.status_code == 409  # already decided -- not decidable again
+
+    async with api.factory() as session:
+        bindings = (await session.execute(select(WorkspaceBindingModel))).scalars().all()
+        assert len(bindings) == 1
+        projects = (await session.execute(select(ProjectModel))).scalars().all()
+        assert len(projects) == 1
+
+
+async def test_adopt_requires_exactly_one_of_project_id_or_new_project(api) -> None:
+    await seed_resource(api.factory, resource_id="r1")
+    neither = api.post("/api/v1/discovered-resources/r1/adopt", headers=auth(ADMIN_TOKEN), json={})
+    assert neither.status_code == 400
+
+    await seed_resource(api.factory, resource_id="r2", resource_path="/root/hub2")
+    async with api.factory() as session:
+        session.add(ProjectModel(id="existing", name="Existing", path="/srv/existing", enabled=True, config_json="{}"))
+        await session.commit()
+    both = api.post(
+        "/api/v1/discovered-resources/r2/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"projectId": "existing", "newProject": {"projectId": "hub2", "name": "Hub2"}},
+    )
+    assert both.status_code == 400
+
+
+async def test_adopting_an_unknown_resource_is_not_found(api) -> None:
+    response = api.post(
+        "/api/v1/discovered-resources/does-not-exist/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Auto-authorize: only when the root grants it, and never modify/deliver
+# --------------------------------------------------------------------------
+
+
+async def test_a_matching_auto_authorize_root_grants_read_on_adoption(api) -> None:
+    """`E1`'s registration grants `read` for exactly `/root` (see the `api` fixture)."""
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/root")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.json()["state"] == "authorized"
+
+    async with api.factory() as session:
+        authorizations = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert len(authorizations) == 1
+        assert authorizations[0].granted_by == "root-config:/root"
+        assert json.loads(authorizations[0].capabilities_json) == ["read"]
+
+
+async def test_a_non_matching_root_grants_nothing(api) -> None:
+    """Positive control: a candidate under a root E1 never registered grants nothing automatically."""
+    await seed_resource(api.factory, resource_id="r1", resource_path="/unregistered/hub", root_path="/unregistered")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.json()["state"] == "adopted"
+    async with api.factory() as session:
+        authorizations = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert authorizations == []
+
+
+async def test_operator_grant_capabilities_can_include_modify_and_deliver(api) -> None:
+    await seed_resource(api.factory, resource_id="r1", resource_path="/other-root/hub", root_path="/other-root")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={
+            "newProject": {"projectId": "hub", "name": "Hub"},
+            "grantCapabilities": ["modify", "deliver"],
+        },
+    )
+    assert response.status_code == 200
+    async with api.factory() as session:
+        authorizations = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert len(authorizations) == 1
+        assert authorizations[0].granted_by == "operator:admin"
+        assert set(json.loads(authorizations[0].capabilities_json)) == {"modify", "deliver"}
+
+
+async def test_root_config_and_operator_grants_coexist_in_one_call(api) -> None:
+    """Both origins apply in the same adopt call -- `/root` auto-grants `read`,
+
+    the operator additionally grants `modify`. One authorization row, both
+    capabilities, both origins recorded.
+    """
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/root")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(ADMIN_TOKEN),
+        json={"newProject": {"projectId": "hub", "name": "Hub"}, "grantCapabilities": ["modify"]},
+    )
+    assert response.status_code == 200
+    async with api.factory() as session:
+        authorizations = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert len(authorizations) == 1
+        row = authorizations[0]
+        assert set(row.granted_by.split(";")) == {"root-config:/root", "operator:admin"}
+        assert set(json.loads(row.capabilities_json)) == {"read", "modify"}
+
+
+async def test_auto_authorize_can_never_grant_modify_or_deliver(api) -> None:
+    """A malicious/misconfigured root cannot smuggle `modify`/`deliver` in --
+
+    `DiscoveryRoot`'s own validator already refuses to construct one at
+    registration time (`AUTO_AUTHORIZABLE_CAPABILITIES`), so this is really a
+    parse-time control; asserted here end-to-end through the registry.
+    """
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        DiscoveryRoot(path="/x", auto_authorize=[Capability.MODIFY])
+
+
+# --------------------------------------------------------------------------
+# Deny: state transition, and DENIED surviving a later report
+# --------------------------------------------------------------------------
+
+
+async def test_denying_moves_state_and_records_the_actor(api) -> None:
+    await seed_resource(api.factory, resource_id="r1")
+    response = api.post("/api/v1/discovered-resources/r1/deny", headers=auth(ADMIN_TOKEN))
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "denied"
+    assert body["decidedBy"] == "operator:admin"
+    assert body["decidedAt"] is not None
+
+
+async def test_denying_twice_is_a_conflict(api) -> None:
+    await seed_resource(api.factory, resource_id="r1")
+    first = api.post("/api/v1/discovered-resources/r1/deny", headers=auth(ADMIN_TOKEN))
+    assert first.status_code == 200
+    second = api.post("/api/v1/discovered-resources/r1/deny", headers=auth(ADMIN_TOKEN))
+    assert second.status_code == 409
+
+
+async def test_a_denied_resource_is_not_touched_by_a_later_report(api) -> None:
+    """The rule `docs/control-plane.md` names survives this PR: DENIED is
+
+    never regressed by observation, adoption route included.
+    """
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub", root_path="/root")
+    api.post("/api/v1/discovered-resources/r1/deny", headers=auth(ADMIN_TOKEN))
+
+    from shared.protocol import DiscoveredCandidate, DiscoveryReport
+
+    async with api.factory() as session:
+        from gateway.app.models.entities import ExecutorModel
+
+        executor = await session.get(ExecutorModel, "E1")
+        report = DiscoveryReport(
+            root_path="/root",
+            candidates=[
+                DiscoveredCandidate(
+                    resource_key="/root/hub",
+                    suggested_project_id="hub",
+                    suggested_name="Hub",
+                )
+            ],
+            scanned_at=datetime.now(timezone.utc),
+        )
+        await store.record_discovery_report(session, executor, report)
+
+    async with api.factory() as session:
+        row = await session.get(DiscoveredResourceModel, "r1")
+        assert row.state == DiscoveredState.DENIED.value
+
+    # Positive control: a fresh, non-denied candidate in the same report IS recorded.
+    async with api.factory() as session:
+        result = await session.execute(
+            select(DiscoveredResourceModel).where(DiscoveredResourceModel.resource_path == "/root/hub")
+        )
+        assert result.scalars().first() is not None

--- a/tests/unit/test_discovery_store.py
+++ b/tests/unit/test_discovery_store.py
@@ -30,7 +30,15 @@ from gateway.app.models.entities import (
     ProjectModel,
 )
 from gateway.app.services import store
-from shared.protocol import DiscoveredCandidate, DiscoveredState, DiscoveryReport, ExecutorRegistration
+from shared.protocol import (
+    Capability,
+    DiscoveredCandidate,
+    DiscoveredState,
+    DiscoveryReport,
+    DiscoveryRoot,
+    ExecutorRegistration,
+)
+from shared.security import hash_resource_key
 
 
 @pytest.fixture
@@ -44,7 +52,9 @@ async def db_session():
     await engine.dispose()
 
 
-async def _executor(session: AsyncSession, executor_id: str = "E1") -> ExecutorModel:
+async def _executor(
+    session: AsyncSession, executor_id: str = "E1", *, discovery_roots: list[DiscoveryRoot] | None = None
+) -> ExecutorModel:
     await store.upsert_registry(
         session,
         executors=[
@@ -53,6 +63,7 @@ async def _executor(session: AsyncSession, executor_id: str = "E1") -> ExecutorM
                 display_name=executor_id,
                 machine_token="t",
                 allowed_projects=[],
+                discovery_roots=discovery_roots or [],
             )
         ],
         projects=[],
@@ -77,11 +88,17 @@ def _report(root_path: str, candidates: list[DiscoveredCandidate], *, scanned_at
     return DiscoveryReport(root_path=root_path, candidates=candidates, scanned_at=scanned_at or datetime.now(timezone.utc))
 
 
-async def _row(session: AsyncSession, node_id: str, resource_key: str) -> DiscoveredResourceModel | None:
+async def _row(session: AsyncSession, node_id: str, path: str) -> DiscoveredResourceModel | None:
+    """The row for `path` on `node_id`, matched by `resource_path`.
+
+    Not `resource_key`: since `migrations/0013_discovery_resource_key_hash.
+    sql`, that column holds `hash_resource_key(path)`, a lookup key rather
+    than the path itself -- see that migration's own comment.
+    """
     result = await session.execute(
         select(DiscoveredResourceModel).where(
             DiscoveredResourceModel.node_id == node_id,
-            DiscoveredResourceModel.resource_key == resource_key,
+            DiscoveredResourceModel.resource_path == path,
         )
     )
     return result.scalars().first()
@@ -99,12 +116,21 @@ async def _seed_row(
     first_seen_at: datetime | None = None,
     last_seen_at: datetime | None = None,
 ) -> DiscoveredResourceModel:
+    """Seed a row as it would exist after adoption/report work has run.
+
+    `resource_key` here is the candidate's PATH, kept as the parameter name
+    across every call site below for a minimal diff -- the column itself
+    stores `hash_resource_key(resource_key)`, and the path lives in the new
+    `resource_path` column, exactly as `record_discovery_report` writes both
+    today.
+    """
     now = datetime.now(timezone.utc)
     row = DiscoveredResourceModel(
         id=f"row-{resource_key}",
         node_id=node_id,
         kind="project",
-        resource_key=resource_key,
+        resource_key=hash_resource_key(resource_key),
+        resource_path=resource_key,
         project_id=project_id,
         evidence_json=json.dumps(evidence or {"suggested_project_id": "x"}),
         state=state,
@@ -413,6 +439,114 @@ async def test_record_discovery_report_never_writes_authorization_or_projects(db
 
     assert projects_after_dump == projects_before_dump
     assert authorizations_after_dump == authorizations_before_dump
+
+
+async def test_a_matching_auto_authorize_root_grants_nothing_from_a_report_alone(db_session) -> None:
+    """The invariant this PR must not break: a node cannot authorize itself.
+
+    `E1`'s own registration names a `DiscoveryRoot` at `/root` with
+    `auto_authorize=[read]` -- exactly the configuration
+    `adopt_discovered_resource` reads to grant standing capability on
+    adoption. Reporting a candidate under that root is the ONLY thing this
+    test does; `record_discovery_report` never looks at `discovery_roots`
+    at all, so `project_authorizations` must still be empty afterward no
+    matter what the registration would have permitted, once a human adopts.
+
+    Positive control: the same setup, adopted through `store.
+    adopt_discovered_resource`, DOES grant -- proving the negative above is
+    "never reachable from a report", not "never reachable at all" (the
+    2026-09-01 lesson `docs/napkin-lessons.md` names).
+    """
+    executor = await _executor(
+        db_session, discovery_roots=[DiscoveryRoot(path="/root", auto_authorize=[Capability.READ])]
+    )
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+
+    await store.record_discovery_report(db_session, executor, report)
+
+    authorizations = (await db_session.execute(select(ProjectAuthorizationModel))).scalars().all()
+    assert authorizations == []
+
+    hub = await _row(db_session, "E1", "/root/hub")
+    adopted = await store.adopt_discovered_resource(
+        db_session,
+        hub.id,
+        project_id=None,
+        new_project_id="hub",
+        new_project_name="hub",
+        grant_capabilities=[],
+        actor_user_id="esteban",
+    )
+    assert adopted.state == DiscoveredState.AUTHORIZED.value
+    granted = (await db_session.execute(select(ProjectAuthorizationModel))).scalars().all()
+    assert len(granted) == 1
+    assert granted[0].granted_by == "root-config:/root"
+    assert json.loads(granted[0].capabilities_json) == ["read"]
+
+
+# --------------------------------------------------------------------------
+# resource_key / resource_path: the migration 0013 defect and its fix
+# --------------------------------------------------------------------------
+
+
+async def test_resource_key_is_a_fixed_width_hash_and_resource_path_carries_the_real_path(db_session) -> None:
+    """The defect this PR fixes: a MySQL `varchar(255)` cannot hold every
+
+    path `DiscoveredCandidate.resource_key` allows (up to 2048 characters).
+    A candidate at that width must still round-trip cleanly.
+    """
+    executor = await _executor(db_session)
+    long_path = "/root/" + ("a" * 2000)
+    report = _report(
+        "/root", [_candidate(long_path, suggested_project_id="deep", suggested_name="deep")]
+    )
+
+    await store.record_discovery_report(db_session, executor, report)
+
+    row = await _row(db_session, "E1", long_path)
+    assert row is not None
+    assert row.resource_path == long_path
+    assert row.resource_key == hash_resource_key(long_path)
+    assert len(row.resource_key) == 64  # sha256 hex -- comfortably under varchar(255)
+
+
+async def test_a_pre_migration_row_self_heals_its_resource_key_on_next_report(db_session) -> None:
+    """A row written before 0013 has `resource_key` = the raw path (the
+
+    migration's backfill copies it into `resource_path` and leaves
+    `resource_key` untouched -- see that file's own comment). The next time
+    its node reports the same path, `record_discovery_report` must still
+    recognise it (matched by `resource_path`, not `resource_key`) and repair
+    `resource_key` to the hash, rather than reading it as new and
+    duplicating the row.
+    """
+    executor = await _executor(db_session)
+    legacy = DiscoveredResourceModel(
+        id="legacy-row",
+        node_id="E1",
+        kind="project",
+        resource_key="/root/hub",  # pre-0013 shape: the raw path, unhashed
+        resource_path="/root/hub",  # what the migration's backfill sets
+        evidence_json=json.dumps({"suggested_project_id": "hub"}),
+        state=DiscoveredState.DISCOVERED.value,
+        root_path="/root",
+        first_seen_at=datetime.now(timezone.utc) - timedelta(days=1),
+        last_seen_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    db_session.add(legacy)
+    await db_session.commit()
+
+    report = _report("/root", [_candidate("/root/hub", suggested_project_id="hub", suggested_name="hub")])
+    await store.record_discovery_report(db_session, executor, report)
+
+    rows = (
+        (await db_session.execute(select(DiscoveredResourceModel).where(DiscoveredResourceModel.node_id == "E1")))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1, "the legacy row must be updated in place, never duplicated"
+    assert rows[0].resource_key == hash_resource_key("/root/hub")
+    assert rows[0].resource_path == "/root/hub"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Issue #73, Stage 3, adoption half — stacked on #91, review that first. Together they replace the current onboarding: a double allowlist on two hosts plus a restart of both services, which `docs/project-onboarding.md` itself calls "the most likely operational failure of this system".

## Three routes
`GET /api/v1/nodes/{nodeId}/discovered-resources` (cursor-paginated, `?state=`), `POST /api/v1/discovered-resources/{id}/adopt`, `POST .../{id}/deny`. Pagination is not ceremony here: `list_nodes` reads without it because the fleet is small and curated, and a real operator root holds **247 candidates** — this is exactly where that assumption stops holding.

Adoption creates or reuses the `ProjectModel`, creates the `WorkspaceBindingModel`, creates a `ScmAssociationModel` when the candidate's evidence carries a remote, and moves the row to `ADOPTED`. "Ignore" stays a UI filter — no sixth state was invented for a vocabulary that deliberately has five.

## The invariant, and how it is proved
A node cannot authorize itself. The discovery path (#91) writes only `discovered_resources`; these routes are the only writers of `project_authorizations`, and they require an OAuth principal with administrative scope — a class of credential a node's `machine_token` cannot become, since it authenticates a WebSocket and never resolves to a principal. Two tests pin it, each with a positive control: a report arriving with a matching `auto_authorize` root configured still leaves `project_authorizations` empty, and a principal without the scope cannot adopt.

Automatic grant is capped at `read`/`test` by `AUTO_AUTHORIZABLE_CAPABILITIES`, validated when `DiscoveryRoot` parses — `modify` and `deliver` are never obtainable by announcement, only by a grant that names a person. `granted_by` keeps `root-config:<path>` and `operator:<user_id>` distinguishable.

## The defect #91 found, fixed here (`migrations/0013`)
`discovered_resources.resource_key` was `varchar(255)`, sized when the column was still imagined as a short suggested id; the report work repurposed it to hold an absolute path up to 2048 characters. SQLite never enforces a declared width, so it was silent there — and `aiomysql` is a declared dependency, where the same insert is `Data too long`.

Widening it is not the fix: the column anchors the composite unique index, and MySQL's InnoDB key limit is almost certainly what the original 255 was sized against — widening would trade today's silent failure for a different one on the same target. So `resource_key` becomes a fixed-width sha256 hex key (64 chars, comfortably inside both the column and the index limit) and the real path moves to a new **unindexed** `resource_path` at 2048. The migration backfills `resource_path` by copying the existing value — a portable `UPDATE`; sha256 has no portable expression in plain DDL, which `0009`'s own precedent already established belongs in application code. Pre-migration rows self-heal: matching is by `resource_path`, and `resource_key` is rewritten to the hash the next time a node reports the candidate.

`docs/api/README.md`'s "fields that must never ship" now names `resource_path`, not `resource_key`, as the sensitive one — exposed only on these three administrative routes.

Contract 1.9.0 → **1.12.0**.

## Validation
`pytest -q`: **858 passed, 7 skipped, 0 failed** (baseline 829). `tests/contract/`: 26 passed. `test_apply_migrations.py` green, including 0013 applied to a legacy SQLite schema.

## Residual
Migration 0013 has not been run against a real MySQL this session (SQLite only), and no real node has adopted a real candidate through a live gateway end to end. Both recorded in the epic's RESUME.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw