### PR TITLE
Promote development to main: session-close records for the six-PR merge

### DIFF
--- a/docs/issues/004-auth-and-mobile-sessions/RESUME.md
+++ b/docs/issues/004-auth-and-mobile-sessions/RESUME.md
@@ -3,13 +3,15 @@
 - work_id: WK-20260813-mobile-auth
 - data: 2026-08-13
 - branch: `feature/gh-4/define-authentication-authorization-and-mobile-s`
+- status: **merged** — the review fixes landed via **PR #59** (2026-09-02) and
+  are on `main`. Nothing is deployed.
 
 ## Next Step (DO THIS FIRST)
 
 ~~Adversarial review of this delivery~~ — **DONE 2026-08-26** (Squad E,
 WK-20260826-gh4-adversarial-review, branch
-`feature/gh-4/adversarial-review-fixes`, PR pending). See "Adversarial review
-2026-08-26" below. What remains is the **operator's**: the escalated findings in
+`feature/gh-4/adversarial-review-fixes`, **merged as PR #59**). See "Adversarial
+review 2026-08-26" below. What remains is the **operator's**: the escalated findings in
 `docs/security.md` ("Revisão adversarial da issue #4 — decisões pendentes do
 operador"), chiefly **S1** (a narrowed OAuth delegation still confers admin,
 ship-blocking) and the **rotation-race theft-policy** direction conflict.

--- a/docs/issues/011-artifacts-downloads-apk/RESUME.md
+++ b/docs/issues/011-artifacts-downloads-apk/RESUME.md
@@ -2,8 +2,13 @@
 
 - work_id: WK-20260826-gh11-artifacts
 - data: 2026-08-26
-- branch: `feature/gh-11/artifacts-downloads-apk-metadata` (worktree
-  `~/Sync/Projects/AI/CodexBridge--gh-11`; **not pushed, no PR**)
+- branch: `feature/gh-11/artifacts-downloads-apk-metadata`
+- status: **merged** via **PR #61** (2026-09-02), on `main`, contract `1.7.0`
+  published under `contract/1.7.0/`. Not deployed.
+- **the migration was renumbered on merge**: `0008_artifacts.sql` ->
+  **`0010_artifacts.sql`**. 0008 and 0009 were taken on `development` by the
+  time this landed, and git reports no conflict for two added files with
+  different names — so nothing flagged it. Every reference moved with it.
 
 ## Next Step (DO THIS FIRST)
 

--- a/docs/issues/013-mobile-event-stream/RESUME.md
+++ b/docs/issues/013-mobile-event-stream/RESUME.md
@@ -4,6 +4,34 @@
 - data: 2026-08-26
 - branch: `feature/gh-13/mobile-event-stream`
 - contract: 1.8.0 (`probes.API_CONTRACT_VERSION` matched)
+- status: **merged** via **PR #62** (2026-09-02), on `main`, `contract/1.8.0/`
+  published. Not deployed.
+- **the migration was renumbered on merge**: `0009_event_subscriptions.sql` ->
+  **`0011_event_subscriptions.sql`**. 0009 had been taken by #73's control plane,
+  and two added files with different names is not a merge conflict, so nothing
+  reported it.
+
+## Next Step (DO THIS FIRST)
+
+One **operator decision**, opened by the merge and deliberately not made in it.
+
+`gateway/app/services/event_types.py:NOT_DELIVERED` is new. This issue's guard
+(`test_every_audited_domain_event_type_is_translated`) fails on any
+`record_event` under a deliverable entity with no mobile mapping, and two
+writers already on `development` had none — `task.push_preauthorized` and
+`task.notification_failed`. Neither was visible from this branch or from
+`development` alone; they only met on merge day.
+
+Both are now **excluded on purpose**, with the reason written next to them: the
+first is already delivered as `decision.resolved` by the same call, and the
+second is an SMTP failure, which is an operator concern with an operator's
+channel. That is a judgement call about what the mobile client is owed.
+
+**If the client should hear either of them**, the answer is not an edit to that
+dict: it is a new `MobileEventType`, which `docs/api/README.md` counts as a
+breaking change, so it is a contract bump and a client migration. The guard also
+now fails on an exemption whose writer has disappeared, so the dict cannot rot
+quietly.
 
 ## What shipped
 

--- a/docs/issues/014-contract-integration-compat-tests/RESUME.md
+++ b/docs/issues/014-contract-integration-compat-tests/RESUME.md
@@ -3,14 +3,13 @@
 - work_id: WK-20260826-gh14-contract-tests
 - data: 2026-08-26
 - branch: `feature/gh-14/contract-integration-compat-tests`
+- status: **merged** via **PR #60** (2026-09-02), on `main`. Not deployed.
 
 ## Next Step (DO THIS FIRST)
 
-Nothing is pushed and no PR exists. The branch is five commits ahead of
-`development` and the full suite is green.
-
-**Before merging, and before merging #11 or #13:** whoever merges a branch that
-changed `docs/api/codex-bridge.openapi.yaml` must run
+Nothing is pending on this issue. What it leaves behind is a **standing rule**,
+and it is the one thing a later session has to know: whoever merges a branch
+that changed `docs/api/codex-bridge.openapi.yaml` must run
 
 ```bash
 python3 scripts/publish_contract.py
@@ -18,7 +17,8 @@ python3 scripts/publish_contract.py
 
 and commit `contract/`. `pytest tests/contract` fails until they do and the
 message names the command — but the person seeing it will not have read this,
-so say it in the pull request.
+so say it in the pull request. Done for `1.7.0` (#11), `1.8.0` (#13) and
+`1.9.0` (#75); `contract/index.json` names `1.9.0` as latest.
 
 Verified against the real sibling branches, read-only: the compatibility gate
 reports **0 breaking changes** for both `feature/gh-11` (1.7.0) and
@@ -27,12 +27,12 @@ the command above fixes.
 
 ## Current state
 
-Committed on the branch, not pushed, not merged, not deployed. Nothing under
+Merged and on `main`; not deployed. Nothing under
 `gateway/`, `agent/`, `shared/` or `migrations/` was touched
 (`git diff --stat 2e18820..HEAD -- gateway/ agent/ shared/ migrations/` is
 empty), no endpoint was added, and `info.version` /
-`probes.API_CONTRACT_VERSION` are both still `1.6.0` — #11 and #13 own the
-version bumps.
+`probes.API_CONTRACT_VERSION` were both still `1.6.0` on this branch — #11, #13
+and #75 own the version bumps, and after the merges the pair reads `1.9.0`.
 
 The delivery is anti-drift **machinery**, and it iterates the contract's own
 paths dynamically. No test in it names an endpoint.

--- a/docs/issues/073-codexbridge-control/RESUME.md
+++ b/docs/issues/073-codexbridge-control/RESUME.md
@@ -3,14 +3,15 @@
 - work_id: WK-20260901-gh73-fleet-visibility
 - data: 2026-09-01
 - Stage 1: **PR #74 merged** into `development` as `80e5d2f`.
-- Stage 2: branch `feature/gh-73/fleet-visibility` (commit `2ed550f`), worktree
-  `../CodexBridge--gh-73-control`. Pushed; **PR #75** open. NOT merged.
+- Stage 2: **PR #75 merged** into `development` on 2026-09-02, and on `main`.
+  Contract `1.9.0`. Not deployed.
 
 ## Next Step (DO THIS FIRST)
 
 Start Stage 3 (project discovery and adoption: scan the configured roots,
 correlate candidates, write `discovered_resources`, and the adopt/ignore
-decision) on a branch cut from `feature/gh-73/fleet-visibility`. Stage 2 left
+decision) on a branch cut from **`development`** — Stage 2 is merged, so cutting
+from `feature/gh-73/fleet-visibility` would now branch from behind. Stage 2 left
 the node reporting only a `discovery_root_count`; Stage 3 is what makes the
 roots produce rows.
 


### PR DESCRIPTION
Docs only. Carries `576f3ea`, the session-close records for the six-PR merge
already on `main` (PR #88).

`main` currently holds RESUMEs that describe the world before that merge — the
#73 one still reads *"PR #75 open. NOT merged"*, and #11's and #13's still name
the migration numbers they were renumbered away from. This corrects them on the
branch the deploy is cut from.

- each merged issue's RESUME names the PR it landed through
- #11 and #13 record the renumbering (`0010_artifacts.sql`,
  `0011_event_subscriptions.sql`) and why nothing reported the collision
- #13 gains the `Next Step (DO THIS FIRST)` it had never had: whether the mobile
  client should hear `task.push_preauthorized` / `task.notification_failed`,
  which is a new `MobileEventType` and a contract bump, not an edit to
  `event_types.NOT_DELIVERED`
- #73 Stage 3 now says to cut from `development`; its old base is merged

No code, no contract, no migration. Still nothing deployed.

https://claude.ai/code/session_01Jzq8HuSJTkm3ucSGVn6gTT