### PR TITLE
feat(gh-73): authorization plane — a grant now actually gates a dispatch

### DIFF
--- a/agent/codex_bridge_agent/service.py
+++ b/agent/codex_bridge_agent/service.py
@@ -34,6 +34,7 @@ from shared.protocol import (
     TaskMode,
     TaskPriority,
     TaskState,
+    capabilities_to_modes,
 )
 from shared.security import ensure_within_root
 
@@ -76,6 +77,26 @@ BASE_PROMPT = (
     "Do not access parent directories, secrets, deployment targets, or other hosts. "
     "Do not push, deploy, migrate production, or modify infrastructure unless explicitly approved."
 )
+
+
+def _configured_capabilities(settings: AgentSettings) -> list[Capability]:
+    """The `Capability` values THIS machine's own configuration permits.
+
+    Issue #73 Stage 4. Factored out of `_build_announcement` so its `hello`
+    payload and `_handle_dispatch`'s own gate (below) compute the exact same
+    thing -- the docstring of `Capability` in `shared/protocol.py` names this
+    as one of the two places Stage 4 would touch. `READ`/`TEST` are always
+    offered (a node that connects at all can at least be inspected and
+    tested); `MODIFY` only when `allow_workspace_write` is on; `DELIVER` only
+    when `allow_git_delivery` is on -- the same two machine-level kill
+    switches `_sandbox_for` and `git_delivery.py` already gate on.
+    """
+    capabilities = [Capability.READ, Capability.TEST]
+    if settings.allow_workspace_write:
+        capabilities.append(Capability.MODIFY)
+    if settings.allow_git_delivery:
+        capabilities.append(Capability.DELIVER)
+    return capabilities
 
 
 def _sandbox_for(policy_level: PolicyLevel, *, allow_workspace_write: bool) -> str:
@@ -415,6 +436,32 @@ class AgentService:
                 run_when_available=True,
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
             )
+            # Issue #73 Stage 4: this node's OWN mirror of the gateway's
+            # `effective_task_modes` gate (`gateway/app/services/store.py`),
+            # not a duplicate of it. The gateway already decided the dispatch
+            # was allowed against `project_authorizations`; this re-derives
+            # what THIS machine's own configuration (`_configured_capabilities`
+            # above -- the exact same computation `_build_announcement`
+            # reported in `hello`) would permit and refuses independently when
+            # the two disagree. The point is defense in depth against a
+            # compromised or buggy gateway dispatching a mode this node never
+            # offered to run -- the same reasoning `git_delivery.py` already
+            # applies when it reconfirms the branch pattern the gateway
+            # already checked, per `Capability`'s own docstring anticipating
+            # Stage 4 touching two places.
+            configured_modes = capabilities_to_modes(_configured_capabilities(self.settings))
+            if request.mode not in configured_modes:
+                await websocket.send(
+                    self._envelope(
+                        AgentMessageType.TASK_RESULT,
+                        {
+                            "task_id": task_id,
+                            "final_state": TaskState.FAILED.value,
+                            "error": f"capability_not_configured:{request.mode.value}",
+                        },
+                    ).model_dump_json()
+                )
+                return
             decision = evaluate_task_policy(request)
             if not decision.approved and decision.level.value == "sensitive":
                 await websocket.send(
@@ -530,17 +577,12 @@ class AgentService:
         it can send.
         """
         try:
-            capabilities = [Capability.READ, Capability.TEST]
-            if self.settings.allow_workspace_write:
-                capabilities.append(Capability.MODIFY)
-            if self.settings.allow_git_delivery:
-                capabilities.append(Capability.DELIVER)
             return NodeAnnouncement(
                 agent_version=AGENT_VERSION,
                 os=platform.system(),
                 arch=platform.machine(),
                 engines=await self.runners.probe_all(),
-                capabilities=capabilities,
+                capabilities=_configured_capabilities(self.settings),
                 max_concurrent_tasks=self.settings.max_concurrent_tasks,
                 # See this method's own docstring: the node's own scan-root
                 # count, not `auto_project_root` (a different valve entirely).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1111,6 +1111,81 @@ protects a retry instead, the same shape `POST /api/v1/issues` established.
 
 ---
 
+## Authorizations (issue #73 Stage 4, WK-20260902-gh73-authorization-plane)
+
+`POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize` and
+`.../revoke`. The explicit-operator half of writing `project_authorizations`
+— separate from discovery adoption (previous section), which is the other
+place that table gets written. This is also the FIRST build whose
+enforcement actually reads that table: `store.effective_task_modes`, called
+from `store.create_task` at the exact spot its old inline `allowed_modes`
+check lived, and the executor's own independent mirror in
+`agent/codex_bridge_agent/service.py:_handle_dispatch`. A grant made through
+either surface takes effect the next time a task is submitted for that
+`(node, project)` pair — there is no cache and no side channel.
+
+### Enforcement narrows `allowed_modes`; it never replaces it
+
+A `(node, project)` pair with no `workspace_bindings` row — i.e. one that
+never went through discovery adoption — is governed by `allowed_modes` alone,
+exactly as before this stage existed, permanently (not a grace period). Once
+a binding exists, the effective mode set is `allowed_modes` intersected with
+`capabilities_to_modes(...)` of the pair's active `project_authorizations`
+row; no row at all intersects with the empty set. The intersection can only
+shrink what `allowed_modes` already permitted, per node — see
+`docs/control-plane.md`, "Stage 4", for the full walk-through.
+
+### The privilege ladder, and why it does not call `is_admin()`
+
+`nodes.authorizations.manage` is administrative (`codexbridge.admin`), same
+class as `nodes.read`/`nodes.discoveries.decide`. Granting `modify` or
+`deliver` crosses one more condition, evaluated inside
+`permissions.is_allowed` (never a second `if` inside the route):
+`principal.can_approve_sensitive or "admin" in principal.roles`.
+
+That condition deliberately does NOT read `principal.is_admin()`, unlike
+`decisions.decide`'s own second gate. `is_admin()` is `"admin" in
+principal.roles or "codexbridge.admin" in principal.scopes`. `decisions.
+decide`'s own scope (`codexbridge.task.approve`) is disjoint from
+`codexbridge.admin`, so `is_admin()` genuinely adds a condition there. But
+`nodes.authorizations.manage`'s own BASE scope already IS
+`codexbridge.admin` — so for this one action, `principal.has_scope(action.
+scope)` and `principal.is_admin()` collapse into the same predicate, and
+gating on `is_admin()` a second time after the base scope already required
+it would be tautological: `can_approve_sensitive` would never once be the
+deciding factor, and every `codexbridge.admin`-scoped principal could grant
+`modify`/`deliver` regardless of it — the exact escalation this gate exists
+to close. Checking the ROLE directly instead keeps the distinction real: a
+token can carry `codexbridge.admin` for fleet-visibility reasons
+(`nodes.read`) without its holder being trusted for `modify`/`deliver`.
+`tests/integration/test_authorization_routes.py::
+test_granting_modify_without_can_approve_sensitive_or_admin_role_is_refused`
+is the test that would have passed silently if this gate had been written
+the naive way.
+
+### `authorize` overwrites; `revoke` never deletes
+
+`POST .../authorize` OVERWRITES the pair's capability set and provenance
+rather than merging with whatever it held before — an operator calling this
+states the authorization they want NOW. A previously revoked row is
+reactivated in place (`revokedAt` cleared), never duplicated:
+`project_authorizations_node_project_idx` allows exactly one non-revoked row
+per pair. `POST .../revoke` marks the row revoked and never deletes it, so a
+later `authorize` call can reactivate the same row and its provenance
+survives the gap. Both endpoints record their own `audit_events` entry
+(`project_authorization.granted`/`.revoked`); the row itself holds only
+current state.
+
+### `revoke` carries no second gate
+
+Taking capability away is never the escalation `authorize`'s
+`can_approve_sensitive`/admin-role condition guards against, so `revoke`
+needs only the base `nodes.authorizations.manage` scope — a principal who
+could never have granted `modify` may still revoke a pair that already
+carries it.
+
+---
+
 ## Cross-cutting rules every endpoint inherits
 
 Implemented in `gateway/app/api/` (issue #12). An endpoint does not re-invent

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: CodexBridge Mobile API
   summary: Contract-first HTTP API consumed by CodexBridgeMobile.
-  version: 1.12.0
+  version: 1.14.0
   description: |
     Canonical contract for the public HTTP API that `EDortta/CodexBridgeMobile`
     consumes. For that API this document is the **source of truth**: an
@@ -725,6 +725,116 @@ paths:
         '403': {$ref: '#/components/responses/PermissionDenied'}
         '404': {$ref: '#/components/responses/NotFound'}
         '409': {$ref: '#/components/responses/Conflict'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/nodes/{nodeId}/projects/{projectId}/authorize:
+    post:
+      operationId: authorizeNodeProject
+      tags: [authorizations]
+      summary: Grant capabilities to a Bridge Node on a project
+      description: |
+        Issue #73 Stage 4. The explicit operator half of `project_
+        authorizations` -- separate from discovery adoption
+        (`POST /api/v1/discovered-resources/{resourceId}/adopt`), which is the
+        other place this table gets written. Neither reads the other; a pair
+        that never went through adoption may still be authorized directly
+        here, and vice versa.
+
+        Overwrites the pair's standing authorization rather than merging with
+        whatever it held before: an operator calling this states the
+        authorization they want NOW. A previously revoked row is reactivated
+        in place (not duplicated) -- at most one non-revoked row exists per
+        `(nodeId, projectId)`.
+
+        Requesting `modify` or `deliver` crosses a second gate on top of the
+        base `nodes.authorizations.manage` scope: the caller must also carry
+        `can_approve_sensitive` or be an admin, the same second gate
+        `POST /api/v1/decisions/{id}/approve` already applies. A caller with
+        only the base scope gets `403` for those two capabilities, even
+        though the same request granting only `read`/`test` would succeed.
+
+        This grant takes effect the next time a task is submitted for this
+        `(nodeId, projectId)` pair or the executor dispatches one -- there is
+        no cache and no other side channel; both the gateway's `create_task`
+        and the executor's own dispatch handler read `project_authorizations`
+        fresh.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/NodeId'
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProjectId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizeNodeProjectRequest'
+      responses:
+        '200':
+          description: The pair's authorization after the grant.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectAuthorization'
+        '400': {$ref: '#/components/responses/ValidationFailed'}
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '429': {$ref: '#/components/responses/RateLimited'}
+        '500': {$ref: '#/components/responses/InternalError'}
+
+  /api/v1/nodes/{nodeId}/projects/{projectId}/revoke:
+    post:
+      operationId: revokeNodeProject
+      tags: [authorizations]
+      summary: Revoke a Bridge Node's capabilities on a project
+      description: |
+        Issue #73 Stage 4. Marks the pair's active authorization row revoked
+        (`revokedAt` set) -- never deleted, so `POST .../authorize` can
+        reactivate the same row later and its provenance survives in between.
+
+        No second gate here: taking capability away is never the escalation
+        the `authorize` endpoint's extra `can_approve_sensitive`/admin check
+        guards against. `404` when there is no active authorization for this
+        pair to revoke.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/NodeId'
+        - name: projectId
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProjectId'
+      responses:
+        '200':
+          description: The pair's authorization after the revoke.
+          headers:
+            X-Request-Id:
+              $ref: '#/components/headers/XRequestId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectAuthorization'
+        '401': {$ref: '#/components/responses/Unauthenticated'}
+        '403': {$ref: '#/components/responses/PermissionDenied'}
+        '404': {$ref: '#/components/responses/NotFound'}
         '429': {$ref: '#/components/responses/RateLimited'}
         '500': {$ref: '#/components/responses/InternalError'}
 
@@ -3435,6 +3545,53 @@ components:
             `deliver` — unlike a discovery root's `autoAuthorize`, which never
             can. May coexist with a matching root's own grant in the same
             call; both merge into one authorization row.
+
+    AuthorizeNodeProjectRequest:
+      type: object
+      description: |
+        Issue #73 Stage 4. The capabilities to grant `nodeId` on `projectId`,
+        replacing whatever the pair's authorization held before — see
+        `POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize`'s own
+        description for why this overwrites rather than merges.
+      properties:
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Capability'
+          description: |
+            May include `modify`/`deliver`, unlike a discovery root's
+            `autoAuthorize` — but doing so requires the caller to also carry
+            `can_approve_sensitive` or be an admin (`403` otherwise), the
+            second gate this endpoint's own description names.
+
+    ProjectAuthorization:
+      type: object
+      description: |
+        The standing `(node, project)` authorization row issue #73's
+        authorization plane enforces against — what `nodeId` may actually do
+        to `projectId`, as opposed to `NodeStatus.capabilities` (what the
+        node's own configuration would merely permit) or `DiscoveredResource`
+        (what the node has merely seen). Returned by both `authorize` and
+        `revoke`, always reflecting the row's current state.
+      required: [nodeId, projectId, capabilities, grantedBy, grantedAt]
+      properties:
+        nodeId:
+          $ref: '#/components/schemas/NodeId'
+        projectId:
+          $ref: '#/components/schemas/ProjectId'
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/Capability'
+        grantedBy:
+          type: string
+          description: '`operator:<userId>` for a direct grant through this endpoint, or `root-config:<path>`/`operator:<userId>` (`;`-joined) when adoption also contributed.'
+        grantedAt:
+          $ref: '#/components/schemas/Timestamp'
+        revokedAt:
+          type: [string, 'null']
+          format: date-time
+          description: 'Set by `revoke`; `null` while the authorization is active.'
 
     Session:
       type: object

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-- 141 file(s) · 1371 symbol(s) indexed
+- 141 file(s) · 1373 symbol(s) indexed
 - Languages: config (2), python (137), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
@@ -1274,6 +1274,8 @@ tests/
 - `test_list_with_the_admin_scope_is_allowed(api)` *(async function)* — "Positive control for the previous two: the scope alone is sufficient."
 - `test_a_principal_without_the_administrative_scope_cannot_adopt(api)` *(async function)*
 - `test_a_principal_with_the_administrative_scope_can_adopt(api)` *(async function)* — "Positive control for the previous test."
+- `test_adoption_cannot_grant_modify_without_the_sensitive_ladder(api)` *(async function)* — "The second door to `modify`/`deliver`, closed."
+- `test_the_same_actor_may_adopt_when_it_asks_for_no_sensitive_capability(api)` *(async function)* — "Positive control: the ladder gates the capability, not the adoption."
 - `test_a_token_with_no_scopes_cannot_deny(api)` *(async function)*
 - `test_an_unknown_node_id_is_not_found(api)` *(async function)*
 - `test_an_invalid_state_filter_is_rejected(api)` *(async function)*

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-adoption`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-discovery-adoption map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-authorization-plane`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-authorization-plane map`
 
 ## Summary
 
-- 138 file(s) · 1335 symbol(s) indexed
-- Languages: config (2), python (134), shell (2)
+- 141 file(s) · 1371 symbol(s) indexed
+- Languages: config (2), python (137), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -68,6 +68,7 @@ gateway/
       routes/
         __init__.py  — "HTTP routers for the mobile contract surface."
         auth.py  — "Sign-in, renewal, revocation, and what the actor may actually do."
+        authorizations.py  — "The explicit operator grant: `POST .../authorize` and `.../revoke`."
         conversations.py  — "Conversations and contextual messaging — issue #10."
         decisions.py  — "Operational decisions: sensitive tasks held for a human to resolve — issue #6."
         discovery.py  — "Discovered resources: the panel's half of "the node proposes, the panel adopts"."
@@ -139,6 +140,7 @@ tests/
     test_agent_ws_identity.py  — "An envelope's `executor_id` is a claim; the handshake's is the fact."
     test_api_conventions.py  — "Representative-endpoint compliance for the cross-cutting API rules (issue #12)."
     test_auth.py  — "The mobile credential lifecycle — issue #4."
+    test_authorization_routes.py  — "`POST .../authorize` and `.../revoke` -- issue #73 Stage 4."
     test_claude_runner_real_process.py  — "ClaudeRunner against a REAL `claude` subprocess — not the fakes used elsewhere."
     test_codex_runner_real_process.py  — "CodexRunner against a REAL `codex` subprocess — not the fake used everywhere else."
     test_conversations.py  — "Conversations and contextual messaging — issue #10."
@@ -171,6 +173,7 @@ tests/
     test_config_settings.py  — "issue #17 council round 1, "the second caller": `cancel_replay_max_age_seconds`"
     test_discover_projects.py  — "`scripts/discover_projects.py` -- read-only repo discovery."
     test_discovery_store.py  — "`store.record_discovery_report` -- issue #73 Stage 3."
+    test_effective_task_modes.py  — "`store.effective_task_modes` -- issue #73 Stage 4, WK-20260902-gh73-authorization-plane."
     test_email_templates.py  — "`gateway.app.services.email_templates` -- pure rendering, no I/O."
     test_git_delivery.py  — "`git_delivery.deliver_changes` against real throwaway git repos."
     test_google_calendar.py  — "`gateway.app.services.google_calendar`, without ever touching Google."
@@ -403,6 +406,14 @@ tests/
 - `refresh(body, response, session)` *(async function)* — "Rotate a refresh token into a new pair."
 - `revoke(request, response, body, session)` *(async function)* — "Sign out: end the grant now rather than at expiry."
 - `current_actor(response, principal)` *(async function)* — "Who is calling, and what this build will let them do."
+
+### `gateway/app/api/routes/authorizations.py`
+
+> The explicit operator grant: `POST .../authorize` and `.../revoke`.
+
+- **`AuthorizeNodeProjectRequest`** *(class)*
+- `authorize_node_project(node_id, project_id, payload, principal, session)` *(async function)* — "Grant `payload.capabilities` to `node_id` on `project_id`."
+- `revoke_node_project(node_id, project_id, principal, session)` *(async function)* — "Revoke the active authorization for `node_id` on `project_id`."
 
 ### `gateway/app/api/routes/conversations.py`
 
@@ -748,6 +759,7 @@ tests/
 - `latest_project_activity_at(session, project_id)` *(async function)* — "The most recent task creation time for a project, or None if it has none."
 - `get_task(session, task_id)` *(async function)*
 - `list_recent_tasks(session, limit, states)` *(async function)* — "`states` narrows to a caller-given set of `TaskState` values."
+- `effective_task_modes(session, executor, project)` *(async function)* — "The task modes `executor` may actually run on `project`, right now."
 - `create_task(session, request, executor_online, continue_session_id, requested_by_user_id, requested_by_email, can_approve_push)` *(async function)*
 - `mark_executor_connected(session, executor_id, connected)` *(async function)*
 - `executor_is_live(executor)` — "Whether an executor should be presented as connected right now."
@@ -756,6 +768,8 @@ tests/
 - `record_discovery_report(session, executor, report)` *(async function)* — "Persist one root's `DiscoveryReport` into `discovered_resources` -- and nothing else."
 - `list_discovered_resources_page(session, node_id)` *(async function)* — "One node's discovered candidates, ordered by id, over-fetched by one."
 - `get_discovered_resource(session, resource_id)` *(async function)*
+- `grant_project_authorization(session)` *(async function)* — "Get-or-create the standing authorization row for `(node_id, project_id)`."
+- `revoke_project_authorization(session)` *(async function)* — "Revoke the ACTIVE authorization row for `(node_id, project_id)`, if any."
 - `adopt_discovered_resource(session, resource_id)` *(async function)* — "Adopt one discovered candidate: bind it to a project and, when either"
 - `deny_discovered_resource(session, resource_id)` *(async function)* — "Refuse one discovered candidate. See `DECIDABLE_DISCOVERY_STATES` --"
 - `list_nodes(session)` *(async function)* — "Every Bridge Node, ordered by id, paired with the executor bound to it."
@@ -1122,6 +1136,27 @@ tests/
 - `test_the_report_and_the_endpoints_agree(api, who)` *(async function)* — "The claim the whole endpoint exists for."
 - `test_the_administrative_action_describes_what_the_list_endpoint_does(api)` *(async function)* — "`sessions.readAllProjects` is administrative because it crosses projects."
 - `test_the_administrative_action_describes_what_the_missions_list_endpoint_does(api)` *(async function)* — "`missions.readAllProjects` mirrors `sessions.readAllProjects` — same widening."
+
+### `tests/integration/test_authorization_routes.py`
+
+> `POST .../authorize` and `.../revoke` -- issue #73 Stage 4.
+
+- `users_file(tmp_path)`
+- `api(users_file, monkeypatch)` *(async function)*
+- `auth(token)`
+- `test_authorize_requires_a_token(api)` *(async function)*
+- `test_authorize_without_the_admin_scope_is_forbidden(api)` *(async function)*
+- `test_authorize_read_with_the_admin_scope_is_allowed(api)` *(async function)* — "Positive control: the base scope alone is sufficient for `read`/`test`."
+- `test_granting_modify_without_can_approve_sensitive_or_admin_role_is_refused(api)` *(async function)* — "The scope alone (`codexbridge.admin`, no real admin role, no"
+- `test_granting_modify_with_can_approve_sensitive_is_allowed(api)` *(async function)* — "Positive control: the sensitive-approval flag alone is sufficient, no admin role needed."
+- `test_granting_deliver_with_a_real_admin_role_is_allowed(api)` *(async function)* — "Positive control: a real `"admin"` role alone is sufficient, no `can_approve_sensitive` needed."
+- `test_granting_read_and_modify_together_still_needs_the_second_gate(api)` *(async function)* — "Mixing a sensitive capability into an otherwise-plain request still trips the gate."
+- `test_authorize_overwrites_rather_than_merges_capabilities(api)` *(async function)*
+- `test_revoke_then_regrant_reuses_the_same_row_and_both_events_are_audited(api)` *(async function)*
+- `test_revoking_a_pair_with_no_active_authorization_is_not_found(api)` *(async function)*
+- `test_revoke_never_needs_the_sensitive_gate(api)` *(async function)* — "Positive control for the "no second gate on revoke" claim: the"
+- `test_authorizing_an_unknown_node_is_not_found(api)` *(async function)*
+- `test_authorizing_an_unknown_project_is_not_found(api)` *(async function)*
 
 ### `tests/integration/test_claude_runner_real_process.py`
 
@@ -1739,7 +1774,8 @@ tests/
 - `test_sandbox_for_machine_override_forces_read_only_even_for_write_levels()` — "`AgentSettings.allow_workspace_write=False` is the executor's own kill"
 - `test_handle_dispatch_sends_read_only_for_a_read_mode_task(tmp_path)` *(async function)*
 - `test_handle_dispatch_sends_workspace_write_for_a_write_mode_task(tmp_path)` *(async function)*
-- `test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_path)` *(async function)* — "A write-mode task still only gets `read-only` when this executor's own"
+- `test_handle_dispatch_refuses_a_write_mode_when_workspace_write_is_off(tmp_path)` *(async function)* — "WK-20260902-gh73-authorization-plane, issue #73 Stage 4."
+- `test_handle_dispatch_allows_a_write_mode_when_workspace_write_is_on(tmp_path)` *(async function)* — "Positive control for the refusal above, in the same file (napkin-lessons"
 
 ### `tests/unit/test_apply_migrations.py`
 
@@ -1859,6 +1895,24 @@ tests/
 - `test_resource_key_is_a_fixed_width_hash_and_resource_path_carries_the_real_path(db_session)` *(async function)* — "The defect this PR fixes: a MySQL `varchar(255)` cannot hold every"
 - `test_a_pre_migration_row_self_heals_its_resource_key_on_next_report(db_session)` *(async function)* — "A row written before 0013 has `resource_key` = the raw path (the"
 - `test_a_large_report_does_not_cost_one_round_trip_per_candidate(db_session)` *(async function)* — "247 candidates -- the real root that motivated this work, rounded up"
+
+### `tests/unit/test_effective_task_modes.py`
+
+> `store.effective_task_modes` -- issue #73 Stage 4, WK-20260902-gh73-authorization-plane.
+
+- `db_session()` *(async function)*
+- `test_no_binding_returns_the_project_base_unchanged(db_session)` *(async function)* — "Non-regression: a pair that never went through discovery adoption is"
+- `test_a_binding_with_no_authorization_permits_nothing(db_session)` *(async function)*
+- `test_a_binding_with_read_and_test_permits_exactly_those_modes(db_session)` *(async function)*
+- `test_a_revoked_authorization_permits_nothing(db_session)` *(async function)* — "Positive control for the "no authorization" case: an authorization row"
+- `test_authorization_never_widens_past_the_projects_own_allowed_modes(db_session)` *(async function)* — "A capability grant intersects with `allowed_modes`, it never adds to it:"
+- `test_create_task_for_an_unbound_pair_behaves_exactly_as_before_this_pr(db_session)` *(async function)* — "This is the test that would have passed before `effective_task_modes`"
+- `test_create_task_for_a_bound_but_unauthorized_pair_refuses_every_mode(db_session)` *(async function)*
+- `test_create_task_for_a_bound_and_partially_authorized_pair_allows_only_the_granted_modes(db_session)` *(async function)*
+- `test_granting_a_new_pair_creates_one_row(db_session)` *(async function)*
+- `test_granting_twice_overwrites_rather_than_merges(db_session)` *(async function)* — "Unlike adoption's own `_grant_project_authorization` (merge-only), this"
+- `test_revoke_then_regrant_reuses_the_same_row(db_session)` *(async function)*
+- `test_revoking_a_pair_with_no_active_authorization_returns_none(db_session)` *(async function)* — "Positive control for the revoke/regrant test: revoking nothing is a"
 
 ### `tests/unit/test_email_templates.py`
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -430,3 +430,122 @@ responde `409 conflict`. Isso não é um defensive check em cima da escrita: é
 o que impede uma segunda chamada de `adopt` de duplicar o
 `WorkspaceBindingModel`/`ScmAssociationModel` que a primeira já produziu —
 a segunda chamada nunca chega à escrita.
+
+## Stage 4 — o plano de autorização passa a valer (issue #73, WK-20260902-gh73-authorization-plane)
+
+Até aqui, `project_authorizations` só recebia escritas — Stage 1 criou a
+tabela e o vocabulário, Stage 3 fez a adoção gravar nela pela primeira vez.
+Nenhum código **lia** essa tabela para decidir o que um dispatch podia fazer:
+uma autorização concedida não mudava nada, na prática. Esta PR fecha esse
+buraco, em dois lugares — o gateway e o executor — sem criar um segundo ponto
+de verdade em nenhum dos dois.
+
+### O gate estreita `allowed_modes`, nunca o substitui
+
+O único enforcement de modo, hoje como antes, é um `if` em
+`gateway/app/services/store.py::create_task`. O que muda é que a lista
+consultada por esse `if` passa a ser calculada por
+`store.effective_task_modes(session, executor, project)`, em vez de ser lida
+direto de `project.config_json["allowed_modes"]`:
+
+1. `base` = os modos de `allowed_modes` do projeto — exatamente o que
+   `create_task` já lia antes desta PR;
+2. se o par `(executor.node_id, project.id)` **não tem** linha em
+   `workspace_bindings`, a resposta é `base`, sem mudança nenhuma. Isto não é
+   um período de graça: é permanente, para sempre, para qualquer par que
+   nunca passou pela adoção — a mesma garantia que a migração `0009` já
+   registrou por escrito ("access continues flowing through the pre-existing
+   `allowed_projects`"). Até esta PR, essa frase era só uma promessa em
+   comentário; `tests/unit/test_effective_task_modes.py::
+   test_no_binding_returns_the_project_base_unchanged` e `test_create_task_
+   for_an_unbound_pair_behaves_exactly_as_before_this_pr` são os primeiros
+   testes que a provam contra código de verdade;
+3. se tem binding, a resposta é `base` interseccionado com
+   `capabilities_to_modes(...)` da linha ATIVA (`revoked_at is null`) de
+   `project_authorizations` para aquele par. Nenhuma linha = nenhuma
+   capacidade = conjunto vazio — adoção sozinha não autoriza nada, exatamente
+   como a Stage 3 já dizia.
+
+A interseção nunca alarga o que `allowed_modes` já permitia — só pode
+estreitar. `project_authorizations` tira, nunca acrescenta, por nó.
+
+### A checagem espelhada no executor
+
+`agent/codex_bridge_agent/service.py::_handle_dispatch` ganha seu próprio
+gate, logo depois de montar o `SubmitTaskRequest` do dispatch: computa as
+`Capability` que a configuração DESTE executor permite
+(`_configured_capabilities`, o mesmo cálculo que `_build_announcement` já
+fazia para o `hello` — fatorado numa função só para as duas nunca divergirem),
+deriva `capabilities_to_modes(...)`, e recusa com
+`capability_not_configured:<mode>` se o modo do dispatch não estiver nesse
+conjunto.
+
+Isto não duplica o gate do gateway — protege contra um gateway comprometido
+ou com bug mandando um modo que este nó específico nunca se ofereceu para
+rodar, o mesmo raciocínio de defesa em profundidade que `git_delivery.py` já
+aplica reconferindo o padrão de branch que o gateway já validou. As duas
+checagens são independentes: `tests/unit/test_agent_service.py::
+test_handle_dispatch_refuses_a_write_mode_when_workspace_write_is_off` prova
+que o executor recusa um modo mesmo quando nada no payload do dispatch diz
+que o gateway não aprovou.
+
+### Conceder e revogar: `gateway/app/api/routes/authorizations.py`
+
+`POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize` (corpo
+`{capabilities: [...]}`) e `POST .../revoke` — a metade explícita, fora do
+fluxo de descoberta, de escrever `project_authorizations`. Separado de
+`routes/discovery.py` porque as duas são ações distintas com pré-condições
+distintas: adoção exige uma linha de `discovered_resources` para agir; isto
+exige só um nó e um projeto que já existam.
+
+`store.grant_project_authorization` faz get-or-create pelo par
+`(node_id, project_id)` — a constraint única já garante no máximo uma linha
+não revogada. Se a linha existir revogada, REATIVA (limpa `revoked_at`,
+sobrescreve `capabilities_json`/`granted_by`/`granted_at`) em vez de inserir
+uma segunda. Diferente de `_grant_project_authorization` (o helper interno da
+adoção, que só funde capacidades e nunca revoga), esta é a superfície do
+operador: uma chamada aqui declara a autorização que o operador quer AGORA,
+não soma ao que já havia. `store.revoke_project_authorization` marca
+`revoked_at`; a linha nunca é apagada, e um `grant` seguinte reativa a mesma
+linha. O histórico completo — cada concessão, cada revogação — vive em
+`audit_events` via `record_event`, como todo o resto deste sistema;
+`tests/unit/test_effective_task_modes.py::
+test_revoke_then_regrant_reuses_the_same_row` prova a linha única e os dois
+tipos de evento.
+
+### A escada de privilégio, e por que ela não pode reusar `principal.is_admin()`
+
+`permissions.NODES_AUTHORIZATIONS_MANAGE` é administrativa, `codexbridge.admin`
+— a mesma classe que `NODES_READ`/`NODES_DISCOVERIES_DECIDE` já usam. Conceder
+`modify` ou `deliver` exige uma condição a mais, aplicada dentro de
+`permissions.is_allowed` (nunca num `if` solto na rota): `principal.
+can_approve_sensitive or "admin" in principal.roles`.
+
+Note que essa condição NÃO chama `principal.is_admin()`, ao contrário do
+segundo portão de `DECISIONS_DECIDE` — e essa diferença é deliberada, não um
+descuido. `is_admin()` é `"admin" in principal.roles or "codexbridge.admin"
+in principal.scopes`. O escopo de `DECISIONS_DECIDE` é
+`codexbridge.task.approve`, disjunto de `codexbridge.admin`, então ali
+`is_admin()` acrescenta uma condição de verdade. Mas o escopo BASE de
+`NODES_AUTHORIZATIONS_MANAGE` já É `codexbridge.admin` — então, para esta
+ação, `principal.has_scope(action.scope)` e `principal.is_admin()` são O
+MESMO PREDICADO: qualquer principal que passa pelo portão de base já teria
+passado por um segundo portão baseado em `is_admin()`, tornando esse segundo
+portão tautológico e o `can_approve_sensitive` irrelevante — exatamente a
+escalada que este portão existe para fechar. `tests/integration/
+test_authorization_routes.py::
+test_granting_modify_without_can_approve_sensitive_or_admin_role_is_refused`
+prova isso com um principal que tem só o escopo `codexbridge.admin` (sem
+papel `admin`, sem `can_approve_sensitive`) sendo recusado; os dois testes de
+controle positivo ao lado provam que `can_approve_sensitive` sozinho e o
+papel `admin` sozinho, cada um isoladamente, já bastam.
+
+### O que ainda não muda
+
+A allowlist local do agente (`AgentSettings.allowed_projects_file`, ou o
+registro estático em `agent.codex_bridge_agent.config`) continua existindo e
+continua sendo consultada — esta PR não a remove nem a substitui.
+`project_authorizations` estreita o que já era permitido por
+`allowed_modes`/allowlist local; nunca alarga. Ver
+`docs/project-onboarding.md` para o que muda no fluxo operacional de cadastro
+de projeto e o que continua manual.

--- a/docs/issues/073-codexbridge-control/RESUME.md
+++ b/docs/issues/073-codexbridge-control/RESUME.md
@@ -1,103 +1,122 @@
-# RESUME — WK-20260902-gh73-discovery-adoption (epic #73)
+# RESUME — WK-20260902-gh73-authorization-plane (epic #73)
 
-- work_id: WK-20260902-gh73-discovery-adoption
+- work_id: WK-20260902-gh73-authorization-plane
 - data: 2026-09-02
 - Stage 1 (domain/contracts): **PR #74 merged** into `development` as `80e5d2f`.
 - Stage 2 (fleet visibility): merged onto this lineage (`2ed550f`).
-- Stage 3, report half (node proposes): merged onto this lineage (`a57a8d9`,
-  branch `feature/gh-73/discovery-report`).
-- Stage 3, adoption half (panel decides): **this session**, branch
-  `feature/gh-73/discovery-adoption`, worktree
-  `../CodexBridge--WK-20260902-gh73-discovery-adoption`. Committed locally,
+- Stage 3, report half (node proposes): merged onto this lineage (`a57a8d9`).
+- Stage 3, adoption half (panel decides): merged onto this lineage (`a1cf4d7`,
+  PRs #91/#92 — first real writes to `project_authorizations`).
+- Stage 4 (authorization plane enforcement): **this session**, branch
+  `feature/gh-73/authorization-plane`, worktree
+  `../CodexBridge--WK-20260902-gh73-authorization-plane`. Committed locally,
   **not pushed, no PR opened** (out of this session's scope — commit and stop).
 
 ## Next Step (DO THIS FIRST)
 
-Open the PR for `feature/gh-73/discovery-adoption` against
-`feature/gh-73/discovery-report` (or wherever the operator wants it based),
-get it reviewed, then start Stage 4 of the epic (whatever "fleet enable/disable
-and node lifecycle actions" or the next unstarted stage is — check the epic's
-own issue body, not this file, for the authoritative stage list).
+Open the PR for `feature/gh-73/authorization-plane` against
+`feature/gh-73/discovery-adoption`, get it reviewed — flag the `is_admin()`
+finding below explicitly in the PR description, it is a judgment call a
+reviewer should confirm, not rubber-stamp — then check the epic's own issue
+body for whatever Stage 5 (or the next unstarted stage) is.
 
 ## Current state
 
-- `GET /api/v1/nodes/{nodeId}/discovered-resources` (cursor-paginated,
-  `?state=` filter), `POST /api/v1/discovered-resources/{id}/adopt`,
-  `POST .../{id}/deny` — `gateway/app/api/routes/discovery.py`.
-- `store.adopt_discovered_resource`/`deny_discovered_resource` are the ONLY
-  functions with write access to `projects`/`workspace_bindings`/
-  `scm_associations`/`project_authorizations` starting from a
-  `discovered_resources` row. Both require `permissions.
-  NODES_DISCOVERIES_DECIDE` (`codexbridge.admin`), reachable only by an
-  OAuth-authenticated principal — never by a node's `machine_token`.
-- Auto-grant: a candidate whose `root_path` matches a `DiscoveryRoot` with
-  `auto_authorize` on the node's own `ExecutorRegistration` grants
-  automatically (`granted_by="root-config:<path>"`), capped to `read`/`test`
-  at parse time. An explicit `grantCapabilities` in the adopt body grants
-  with `granted_by="operator:<user_id>"` and may include `modify`/`deliver`.
-  Both can apply in the same call — merged into one `project_authorizations`
-  row (`;`-joined `granted_by`), since the table allows only one non-revoked
-  row per `(node_id, project_id)`.
-- **Defect fixed, found by the previous PR and left for this one**:
-  `discovered_resources.resource_key` was `varchar(255)` but held a path up
-  to 2048 chars — silent on SQLite, a hard failure on MySQL (`aiomysql` is a
-  declared dependency). `migrations/0013_discovery_resource_key_hash.sql`:
-  `resource_key` becomes `hash_resource_key(path)` (sha256 hex, 64 chars);
-  the real path moves to a new, unindexed `resource_path` column. A
-  pre-migration row self-heals its `resource_key` the next time its node
-  reports the same path (matched by `resource_path`, not `resource_key`).
-- Contract bumped **1.9.0 → 1.12.0** (`probes.API_CONTRACT_VERSION` and
-  `docs/api/codex-bridge.openapi.yaml`'s `info.version`) — skipping
-  1.10.0/1.11.0/1.13.0, claimed by other branches of this same orchestration
-  not yet merged onto this one.
-- `resourcePath`/`rootPath` are returned ONLY by the three routes above — the
-  one pre-registered exception to "no response exposes a server filesystem
-  path" (`docs/control-plane.md`, `docs/api/README.md`, `docs/threat-model.md`
-  all updated to say so explicitly).
+- `store.effective_task_modes(session, executor, project)` is now the ONLY
+  place that decides which `TaskMode`s an executor may run against a
+  project — `store.create_task` calls it at the exact spot its old inline
+  `allowed_modes` check lived. A pair with no `workspace_bindings` row is
+  governed by `allowed_modes` alone, forever (not a grace period); a bound
+  pair is `allowed_modes` intersected with `capabilities_to_modes(...)` of
+  its active `project_authorizations` row.
+- `agent/codex_bridge_agent/service.py:_handle_dispatch` gained its own,
+  independent mirror: refuses a dispatch whose mode this node's own
+  configuration (`allow_workspace_write`/`allow_git_delivery`, via the new
+  `_configured_capabilities` helper shared with `_build_announcement`)
+  never offered, with a typed `capability_not_configured:<mode>` error —
+  defense in depth, not duplication (same reasoning `git_delivery.py`
+  already applies to the branch pattern).
+- `POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize` and
+  `.../revoke` — new `gateway/app/api/routes/authorizations.py`.
+  `store.grant_project_authorization` (get-or-create-or-reactivate,
+  OVERWRITES capabilities rather than merging — different from adoption's
+  own merge-only `_grant_project_authorization`) and `store.
+  revoke_project_authorization` (marks `revoked_at`, never deletes).
+- New administrative action `permissions.NODES_AUTHORIZATIONS_MANAGE`
+  (`codexbridge.admin`). Granting `modify`/`deliver` crosses a second gate
+  inside `permissions.is_allowed`: `principal.can_approve_sensitive or
+  "admin" in principal.roles`.
+- **Finding, not silently patched**: the plan asked for the same shape
+  `DECISIONS_DECIDE`'s second gate has —
+  `principal.can_approve_sensitive or principal.is_admin()`. Implemented
+  literally, that gate is TAUTOLOGICAL here: `NODES_AUTHORIZATIONS_MANAGE`'s
+  own base scope already IS `codexbridge.admin`, and `is_admin()` returns
+  `True` for ANY principal whose token merely carries that scope (`"admin"
+  in principal.roles or "codexbridge.admin" in principal.scopes`) — so
+  `has_scope(action.scope)` and `is_admin()` are the same predicate for
+  this one action, and `can_approve_sensitive` would never be the deciding
+  factor. `DECISIONS_DECIDE`'s own scope (`codexbridge.task.approve`) is
+  disjoint from `codexbridge.admin`, which is why the identical code is
+  meaningful THERE and not here. Fixed by checking `"admin" in
+  principal.roles` directly instead of calling `is_admin()` — documented at
+  length in `permissions.is_allowed`'s own docstring and in
+  `docs/napkin-lessons.md`'s 2026-09-02 entry. Proven by
+  `tests/integration/test_authorization_routes.py::
+  test_granting_modify_without_can_approve_sensitive_or_admin_role_is_refused`,
+  which fails against the naive `is_admin()` version.
+- **Pre-existing gap, NOT fixed by this PR (out of scope, flagged for the
+  operator)**: `POST /api/v1/discovered-resources/{id}/adopt`'s own
+  `grantCapabilities` (Stage 3, C3) can already grant `modify`/`deliver`
+  under `NODES_DISCOVERIES_DECIDE` with NO second gate at all — any
+  principal with the bare `codexbridge.admin` scope can grant sensitive
+  capability through the adoption route today, unrelated to whether this
+  PR's own `authorize` route enforces `can_approve_sensitive`. Worth a
+  follow-up if the operator wants the same ladder applied there.
+- Contract bumped **1.12.0 → 1.14.0** (`probes.API_CONTRACT_VERSION` and
+  `docs/api/codex-bridge.openapi.yaml`'s `info.version`) — skipping 1.13.0,
+  claimed by another not-yet-merged branch of this same orchestration.
 
 ## Changed files
 
-`migrations/0013_discovery_resource_key_hash.sql` (new),
-`gateway/app/api/routes/discovery.py` (new),
-`gateway/app/services/discovery_types.py` (new),
-`tests/integration/test_discovery_routes.py` (new),
-`gateway/app/models/entities.py`, `gateway/app/services/store.py`,
-`gateway/app/api/permissions.py`, `gateway/app/api/routes/probes.py`,
-`gateway/app/db/schema_guard.py`, `gateway/app/main.py`, `shared/security.py`,
+`gateway/app/api/routes/authorizations.py` (new),
+`tests/unit/test_effective_task_modes.py` (new),
+`tests/integration/test_authorization_routes.py` (new),
+`gateway/app/services/store.py`, `gateway/app/api/permissions.py`,
+`gateway/app/api/routes/probes.py`, `gateway/app/main.py`,
+`agent/codex_bridge_agent/service.py` (`shared/protocol.py` untouched — its
+`Capability`/`CAPABILITY_MODES`/`capabilities_to_modes` from Stage 1 already
+had everything this PR needed),
+`tests/unit/test_agent_service.py`, `tests/integration/test_auth.py`,
 `docs/api/README.md`, `docs/api/codex-bridge.openapi.yaml`,
-`docs/control-plane.md`, `docs/threat-model.md`, `docs/codemap.md`,
-`tests/unit/test_discovery_store.py`, `tests/integration/test_agent_ws_discovery.py`,
-`tests/integration/test_auth.py`.
+`docs/control-plane.md`, `docs/project-onboarding.md`, `docs/codemap.md`,
+`docs/napkin-lessons.md`.
 
 ## Checks
 
-- `.venv/bin/python -m pytest -q` → **858 passed, 7 skipped, 0 failed**
-  (branch baseline before this PR: 829/7).
-- `tests/contract/` → all green (26 passed), including the OpenAPI route/
-  version-parity gates and the codemap freshness gate (regenerated with
-  `governancekit --root . map`).
-- `tests/unit/test_apply_migrations.py` → all green; `0013` applies cleanly
-  to a `0009`-shaped legacy SQLite database and self-heals a pre-0013 row on
-  next report (dedicated tests in `tests/unit/test_discovery_store.py`).
-- The local dev `codex_bridge.db` (gitignored) needed `scripts/
-  apply_migrations.py --mark-applied` for 0001–0009 (it was bootstrapped by
-  `create_all`, never tracked in the ledger) and a real run of `0013` before
-  `test_probes.py`'s real-app tests (which hit that file directly) went
-  green — noted here in case another agent's session hits the same
-  `SchemaOutOfDate` against the same file.
+- `.venv/bin/python -m pytest -q` → **884 passed, 7 skipped, 0 failed**
+  (branch baseline before this PR: 858/7).
+- `tests/contract/` → all green (26 passed), including the OpenAPI
+  route/version-parity gates and the codemap freshness gate (regenerated
+  with `governancekit --root . map`).
+- Pytest collection needed the sibling `awt` `.env` moved aside first
+  (`Settings` uses `extra="forbid"`, per this session's own instructions —
+  restored immediately after the run, never committed, `.env` is
+  gitignored).
 
 ## NOT validated
 
-No deploy, no real MySQL run of `0013` (only SQLite — same caveat `0009`'s own
-RESUME already carried; a throwaway Postgres/MySQL verification is worth doing
-before this ships to a MySQL-backed environment). No real node has adopted a
-real discovered resource end-to-end through a live gateway. `POST .../adopt`
-and `.../deny` carry no `revision`/`ETag` — reconsider if a future stage needs
-optimistic concurrency on `discovered_resources` beyond the decidable-state
-check already enforced.
+No deploy, no real gateway/executor pair exercised end-to-end over a live
+WebSocket with a real `project_authorizations` grant in effect (all coverage
+is against an in-memory SQLite `AsyncSession` or a `DummyWebSocket`/fake
+runner). No MySQL run of this PR's own migrations — there are none; this PR
+adds no schema, only reads/writes the Stage 1 `project_authorizations` table
+that already exists.
 
 ## Watch for
 
-Two subagents sharing one worktree caused a `git stash` incident on 2026-09-01
-(`docs/napkin-lessons.md`). This session ran in its own dedicated worktree
-with no sibling agent inside it — no repeat.
+The `is_admin()` finding above is a judgment call this session made
+unilaterally (deviating from the plan's literal `principal.is_admin()`
+instruction) because implementing it literally would have shipped a gate
+that looks like a control but never binds. Flag it in the PR description
+explicitly rather than letting a reviewer discover the deviation from a
+diff alone.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1362,3 +1362,42 @@ mesmo alvo. A saída foi separar "chave de busca" (hash de largura fixa) de
 "dado real" (path, em coluna nova, sem índice) — quando um valor precisa
 simultaneamente indexar barato E carregar um dado de tamanho não controlado,
 essas são duas responsabilidades, não uma.
+
+## 2026-09-02 — um segundo portão de privilégio que reusa `is_admin()` pode ser tautológico
+
+Stage 4 do #73 (WK-20260902-gh73-authorization-plane) pediu, por escrito, o
+mesmo formato do segundo portão que `DECISIONS_DECIDE` já tinha:
+`principal.can_approve_sensitive or principal.is_admin()`, aplicado depois de
+o escopo administrativo base já ter sido exigido. Copiado ao pé da letra para
+`NODES_AUTHORIZATIONS_MANAGE`, o portão não fazia nada: `is_admin()` é
+`"admin" in principal.roles or "codexbridge.admin" in principal.scopes`, e o
+escopo BASE da própria ação já É `codexbridge.admin`. Para qualquer ação cujo
+escopo seja exatamente esse, `principal.has_scope(action.scope)` e
+`principal.is_admin()` são o mesmo predicado — todo principal que passa pelo
+portão de entrada já teria passado pelo segundo, tornando `can_approve_
+sensitive` irrelevante e a condição inteira tautológica. Em `DECISIONS_DECIDE`
+o mesmo código funciona porque o escopo dessa ação (`codexbridge.task.
+approve`) é disjunto de `codexbridge.admin` — os dois predicados genuinamente
+diferem ali.
+
+A confirmação foi de duas linhas, antes de escrever qualquer teste:
+`AuthenticatedPrincipal(roles=[], scopes=['codexbridge.admin'],
+can_approve_sensitive=False).is_admin()` devolve `True`. Se a suíte tivesse
+só testado "com escopo admin, sem `can_approve_sensitive`, permitido" (o
+caminho que qualquer teste ingênuo escreveria primeiro), teria passado sem
+provar nada sobre o portão — de novo o padrão do achado de 2026-08-24 e do
+`test_agent_ws_discovery.py`: teste verde provando só que o caminho executou,
+não que ele decide certo.
+
+Lição: antes de reusar um predicado de "é admin" como segunda camada de um
+gate cujo PRIMEIRO portão já é o próprio escopo administrativo, verificar por
+código — não por analogia com outro gate — se as duas checagens realmente
+divergem para algum principal alcançável. Quando a segunda checagem é
+logicamente implicada pela primeira, ela não é defesa em profundidade: é
+decoração. O ajuste aqui foi checar o papel diretamente
+(`"admin" in principal.roles`), não `is_admin()`, e documentar POR QUE no
+próprio docstring de `permissions.is_allowed` — quem copiar o padrão
+`DECISIONS_DECIDE` de novo, para uma ação cujo escopo base não seja
+administrativo, deve voltar a usar `is_admin()`; quem copiar para uma ação
+cujo escopo base JÁ seja `codexbridge.admin` deve repetir esta checagem
+antes de confiar no copy-paste.

--- a/docs/project-onboarding.md
+++ b/docs/project-onboarding.md
@@ -95,6 +95,18 @@ somente-leitura/só-diff, sem allowlist automática:
 `["analyze", "review", "test"]` nunca recebe tarefa que modifique arquivo, porque
 `edit` e `implement` são recusados na submissão. **Cadastre o mínimo necessário.**
 
+**Desde issue #73 Stage 4 (WK-20260902-gh73-authorization-plane),
+`allowed_modes` deixou de ser a última palavra quando o PAR (nó, projeto) foi
+adotado via descoberta.** Se esse par tem linha em `workspace_bindings` — ou
+seja, se alguém rodou `POST /api/v1/discovered-resources/{id}/adopt` para
+ele — a lista de modos efetivamente permitida passa a ser `allowed_modes`
+interseccionado com o que `project_authorizations` concede àquele nó
+especificamente (`docs/control-plane.md`, seção "Stage 4"). **Um projeto
+cadastrado só pelo fluxo manual desta página, sem nunca passar por adoção,
+continua sendo controlado só por `allowed_modes` — sem mudança nenhuma, para
+sempre.** A intersecção só pode estreitar o que `allowed_modes` já permitia,
+nunca alargar.
+
 ## Schema de executor
 
 Apenas em `registry.json`, no `frida`.
@@ -147,6 +159,23 @@ Três campos existem no schema e **não têm nenhum efeito** no código atual:
 
 As camadas 1 a 6 rodam no `frida`. As 7 a 9 rodam no `devel3` e continuam valendo
 mesmo que o gateway esteja comprometido.
+
+**A camada 5 ganhou uma sub-camada em issue #73 Stage 4** (não numerada à
+parte para não deslocar a lista acima): quando o par (nó, projeto) tem linha
+em `workspace_bindings`, `allowed_modes` é interseccionado com
+`project_authorizations` daquele nó antes de decidir o modo — ver "Camadas de
+autorização" acima e `docs/control-plane.md`. Um projeto cadastrado só pelo
+fluxo manual desta página (sem nunca ter passado por adoção via descoberta)
+não tem linha em `workspace_bindings` e portanto não é afetado: continua
+valendo só `allowed_modes`, como sempre valeu. **A camada 8 também ganhou um
+espelho independente** (`agent/codex_bridge_agent/service.py:
+_handle_dispatch`): o agente recusa um modo que a sua própria configuração
+(`allow_workspace_write`/`allow_git_delivery`) não oferece, mesmo que o
+gateway já tenha aprovado o dispatch — defesa em profundidade contra um
+gateway comprometido, não uma segunda cópia da mesma regra. **Nada disto
+remove a allowlist local do agente** (camada 7, `allowed_projects_file`) — ela
+continua existindo, continua sendo consultada, e um `project_id` fora dela
+segue sendo recusado com `unknown_project` exatamente como antes desta PR.
 
 **A camada 7 tem uma válvula opt-in** (`CODEX_BRIDGE_AGENT_AUTO_PROJECT_ROOT`,
 WK-20260830-chatgpt-entry-provider-and-delivery): quando configurada, um

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -35,6 +35,9 @@ visible mistake rather than an invisible one.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable
+
+from shared.protocol import Capability
 
 
 READ_SCOPE = "codexbridge.read"
@@ -231,6 +234,35 @@ NODES_DISCOVERIES_DECIDE = Action(
     summary="Adopt or deny a discovered candidate.",
 )
 
+# Issue #73 Stage 4 (WK-20260902-gh73-authorization-plane): the explicit
+# operator grant/revoke of `project_authorizations`, behind `POST
+# .../authorize` and `.../revoke`. Administrative and fleet-wide, same
+# posture as `NODES_READ`/`NODES_DISCOVERIES_DECIDE`: a `(node, project)`
+# authorization pair is not scoped to any project the caller already sees by
+# `visible_projects` -- it is a fleet-level decision about what a NODE may do,
+# not a project-level one about what a session may do.
+#
+# `is_allowed` below carries this action's own second gate, the same shape
+# `DECISIONS_DECIDE` already has: granting `modify` or `deliver` additionally
+# requires `can_approve_sensitive` or `is_admin()`. Unlike `DECISIONS_DECIDE`'s
+# gate, this one depends on the REQUEST body (which capabilities are being
+# granted), which `require_action`'s dependency cannot see before the body is
+# parsed -- so the route calls `is_allowed` a second time, with `capabilities=
+# payload.capabilities`, after parsing it. Both calls still funnel through
+# this one function; nothing about the rule lives in the route.
+NODES_AUTHORIZATIONS_MANAGE = Action(
+    name="nodes.authorizations.manage",
+    category=ADMINISTRATIVE,
+    scope=ADMIN_SCOPE,
+    summary="Grant or revoke a Bridge Node's capabilities on a project.",
+)
+
+# `Capability` values whose grant requires the same second gate
+# `DECISIONS_DECIDE` already applies before a sensitive task can be approved
+# -- granting a node the power to write (`modify`) or push (`deliver`) is the
+# same class of decision, just aimed at a node instead of a task.
+_SENSITIVE_CAPABILITIES = frozenset({Capability.MODIFY, Capability.DELIVER})
+
 EPICS_READ = Action(
     name="epics.read",
     category=READ,
@@ -325,10 +357,16 @@ CATALOGUE: tuple[Action, ...] = (
     NODES_READ,
     NODES_DISCOVERIES_READ,
     NODES_DISCOVERIES_DECIDE,
+    NODES_AUTHORIZATIONS_MANAGE,
 )
 
 
-def is_allowed(principal, action: Action) -> bool:
+def is_allowed(
+    principal,
+    action: Action,
+    *,
+    capabilities: Iterable[Capability | str] | None = None,
+) -> bool:
     """Whether `principal` may perform `action`.
 
     Delegates to `AuthenticatedPrincipal.has_scope`, which is also what the
@@ -345,10 +383,57 @@ def is_allowed(principal, action: Action) -> bool:
     check inside the route: `GET /api/v1/auth/me` reports this same function, so
     a route that checked it separately would tell the client "you may" while the
     endpoint answered 403.
+
+    `nodes.authorizations.manage` carries the same-SHAPED second gate, but
+    only when `capabilities` names `modify` or `deliver` — granting a node
+    `read`/`test` needs only the base administrative scope, the same as
+    adoption's own `autoAuthorize` ceiling (`shared.protocol.
+    AUTO_AUTHORIZABLE_CAPABILITIES`). `capabilities=None` (the default, and
+    what `GET /api/v1/auth/me`'s `report_for` below always passes) skips this
+    half of the check: whether a given request's capability list crosses
+    into sensitive territory is a fact about that request, not about the
+    actor in the abstract, so the catalogue reports only the baseline "may
+    this actor ever manage authorizations at all" — the route re-calls this
+    function with the real `capabilities` once the request body is parsed,
+    for the answer that actually gates the write.
+
+    That second gate reads `"admin" in principal.roles` here, NOT
+    `principal.is_admin()` the way `decisions.decide` above reads it — a
+    deliberate, load-bearing difference, not a typo. `is_admin()` is
+    `"admin" in principal.roles or "codexbridge.admin" in principal.scopes`.
+    `decisions.decide`'s own scope is `codexbridge.task.approve`, disjoint
+    from `codexbridge.admin`, so for THAT action `is_admin()` genuinely adds
+    something `has_scope` did not already establish. `nodes.authorizations.
+    manage`'s own base scope IS `codexbridge.admin` (`ADMIN_SCOPE` — the
+    same administrative class `nodes.read`/`nodes.discoveries.decide` use,
+    per this PR's own brief). For an action whose scope already equals
+    `codexbridge.admin`, `principal.has_scope(action.scope)` and
+    `principal.is_admin()` are THE SAME PREDICATE (`has_scope` computes
+    `is_admin() or scope in scopes`, and here `scope IS "codexbridge.admin"`
+    — the `or` clause folds into the first). Gating on `is_admin()` a second
+    time after `allowed` already required it would make the whole condition
+    tautological: every principal who clears the base scope check would
+    automatically clear this one too, and `can_approve_sensitive` would
+    never once be the deciding factor — the exact escalation this gate
+    exists to close. Checking the ROLE directly keeps the two properties
+    `docs/control-plane.md`'s Stage 4 section names distinct: a principal's
+    token may carry `codexbridge.admin` for fleet-visibility reasons
+    (`nodes.read`, `nodes.discoveries.read`) without that principal being
+    trusted for `modify`/`deliver` — the same distinction `can_approve_
+    sensitive` already draws for `decisions.decide`.
     """
     allowed = principal.has_scope(action.scope)
     if action is DECISIONS_DECIDE:
         allowed = allowed and (principal.can_approve_sensitive or principal.is_admin())
+    if action is NODES_AUTHORIZATIONS_MANAGE and capabilities is not None:
+        requested = set()
+        for capability in capabilities:
+            try:
+                requested.add(capability if isinstance(capability, Capability) else Capability(capability))
+            except ValueError:
+                continue
+        if requested & _SENSITIVE_CAPABILITIES:
+            allowed = allowed and (principal.can_approve_sensitive or "admin" in principal.roles)
     return allowed
 
 

--- a/gateway/app/api/permissions.py
+++ b/gateway/app/api/permissions.py
@@ -361,6 +361,15 @@ CATALOGUE: tuple[Action, ...] = (
 )
 
 
+# Every action that can put a capability into `project_authorizations`, and
+# therefore every action the sensitive-capability ladder below has to cover.
+# `nodes.discoveries.decide` belongs here because adoption's own
+# `grantCapabilities` writes that table directly: gating only the dedicated
+# authorize route would leave a second door to `modify`/`deliver` standing
+# open, reachable by exactly the principal the ladder exists to stop.
+_CAPABILITY_GRANTING_ACTIONS = frozenset({NODES_AUTHORIZATIONS_MANAGE, NODES_DISCOVERIES_DECIDE})
+
+
 def is_allowed(
     principal,
     action: Action,
@@ -425,7 +434,7 @@ def is_allowed(
     allowed = principal.has_scope(action.scope)
     if action is DECISIONS_DECIDE:
         allowed = allowed and (principal.can_approve_sensitive or principal.is_admin())
-    if action is NODES_AUTHORIZATIONS_MANAGE and capabilities is not None:
+    if action in _CAPABILITY_GRANTING_ACTIONS and capabilities is not None:
         requested = set()
         for capability in capabilities:
             try:

--- a/gateway/app/api/routes/authorizations.py
+++ b/gateway/app/api/routes/authorizations.py
@@ -1,0 +1,177 @@
+"""The explicit operator grant: `POST .../authorize` and `.../revoke`.
+
+Issue #73 Stage 4 (WK-20260902-gh73-authorization-plane). Stage 3
+(`routes/discovery.py`) shipped the first real writes to
+`project_authorizations` -- adoption's own `autoAuthorize`/`grantCapabilities`
+paths. This module is the OTHER way that table gets written: a human,
+independent of any discovery flow, directly stating what capabilities one
+Bridge Node has on one project. Separated from `routes/discovery.py` rather
+than folded into it because the two are different operator actions with
+different preconditions -- adoption requires a `discovered_resources` row to
+act on; this requires only a node and a project that already exist.
+
+## Enforcement lives elsewhere, on purpose
+
+This module only WRITES the authorization. It never reads it back to decide
+whether a task may run -- that is `gateway/app/services/store.py:
+effective_task_modes`, called from `create_task` at the one spot that has
+always decided this, and (independently) the executor's own
+`agent/codex_bridge_agent/service.py:_handle_dispatch`. A grant recorded here
+takes effect the next time either of those reads `project_authorizations`;
+this module has no cache and no side channel to either of them.
+
+## The privilege ladder
+
+`NODES_AUTHORIZATIONS_MANAGE` (`permissions.py`) is the base administrative
+gate, same `codexbridge.admin` posture as `NODES_READ`/
+`NODES_DISCOVERIES_DECIDE`. Granting `modify` or `deliver` crosses a second
+gate -- `can_approve_sensitive` or `is_admin()`, the same shape
+`DECISIONS_DECIDE` already has -- but that second gate depends on WHICH
+capabilities the request names, a fact `require_action`'s dependency cannot
+see before the body is parsed. So `authorize_node_project` below calls
+`permissions.is_allowed` a SECOND time, after parsing the body, passing
+`capabilities=payload.capabilities` -- the rule itself still lives entirely
+inside `is_allowed`, never as a second `if` built here. See that function's
+own docstring.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.app.api import permissions, timestamps
+from gateway.app.api.auth import require_action
+from gateway.app.api.errors import NOT_FOUND, PERMISSION_DENIED, ApiError
+from gateway.app.core.users import AuthenticatedPrincipal
+from gateway.app.db.session import get_session
+from gateway.app.models.entities import ProjectModel
+from gateway.app.services import store
+from shared.protocol import Capability
+
+
+router = APIRouter(prefix="/api/v1")
+
+
+def _node_not_found(node_id: str) -> ApiError:
+    return ApiError(status_code=404, code=NOT_FOUND, message=f"No such node: {node_id!r}.")
+
+
+def _project_not_found(project_id: str) -> ApiError:
+    return ApiError(status_code=404, code=NOT_FOUND, message=f"No such project: {project_id!r}.")
+
+
+def _no_active_authorization(node_id: str, project_id: str) -> ApiError:
+    return ApiError(
+        status_code=404,
+        code=NOT_FOUND,
+        message=f"No active authorization for node {node_id!r} and project {project_id!r}.",
+    )
+
+
+def _sensitive_capability_denied() -> ApiError:
+    return ApiError(
+        status_code=403,
+        code=PERMISSION_DENIED,
+        message=(
+            "Granting 'modify' or 'deliver' requires can_approve_sensitive or "
+            "admin. GET /api/v1/auth/me reports what this actor may do."
+        ),
+    )
+
+
+class AuthorizeNodeProjectRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    capabilities: list[Capability] = Field(default_factory=list)
+
+
+def _authorization_dto(row) -> dict:
+    return {
+        "nodeId": row.node_id,
+        "projectId": row.project_id,
+        "capabilities": json.loads(row.capabilities_json or "[]"),
+        "grantedBy": row.granted_by,
+        "grantedAt": timestamps.utc_z(row.granted_at),
+        "revokedAt": timestamps.utc_z(row.revoked_at),
+    }
+
+
+async def _require_node_and_project(session: AsyncSession, node_id: str, project_id: str) -> None:
+    """404 before anything is written -- same "do not confirm what the caller
+
+    cannot see" posture `routes/nodes.py`/`routes/discovery.py` already
+    document. Checked here, once, rather than inside `store.grant_project_
+    authorization`/`revoke_project_authorization`, which trust their callers
+    the same way `adopt_discovered_resource`'s helpers trust theirs.
+    """
+    if await store.get_node(session, node_id) is None:
+        raise _node_not_found(node_id)
+    if await session.get(ProjectModel, project_id) is None:
+        raise _project_not_found(project_id)
+
+
+@router.post("/nodes/{node_id}/projects/{project_id}/authorize", tags=["authorizations"])
+async def authorize_node_project(
+    node_id: str,
+    project_id: str,
+    payload: AuthorizeNodeProjectRequest,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_AUTHORIZATIONS_MANAGE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Grant `payload.capabilities` to `node_id` on `project_id`.
+
+    Overwrites the pair's standing authorization rather than merging with
+    whatever it held before -- an operator calling this is stating the
+    authorization they want NOW (`store.grant_project_authorization`'s own
+    docstring). A previously revoked row is reactivated in place, never
+    duplicated: `project_authorizations_node_project_idx` allows only one
+    non-revoked row per pair.
+
+    Requesting `modify` or `deliver` crosses the second gate this module's
+    own docstring describes -- `403 permission_denied` for a principal
+    without `can_approve_sensitive`/admin, even though the base
+    `nodes.authorizations.manage` scope already let the request past
+    `require_action` above.
+    """
+    await _require_node_and_project(session, node_id, project_id)
+    if not permissions.is_allowed(
+        principal, permissions.NODES_AUTHORIZATIONS_MANAGE, capabilities=payload.capabilities
+    ):
+        raise _sensitive_capability_denied()
+
+    row = await store.grant_project_authorization(
+        session,
+        node_id=node_id,
+        project_id=project_id,
+        capabilities=payload.capabilities,
+        granted_by=f"operator:{principal.user_id}",
+    )
+    return _authorization_dto(row)
+
+
+@router.post("/nodes/{node_id}/projects/{project_id}/revoke", tags=["authorizations"])
+async def revoke_node_project(
+    node_id: str,
+    project_id: str,
+    principal: AuthenticatedPrincipal = Depends(require_action(permissions.NODES_AUTHORIZATIONS_MANAGE)),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Revoke the active authorization for `node_id` on `project_id`.
+
+    No second gate here -- taking capability AWAY is never the escalation
+    `is_allowed`'s extra condition guards against, only granting `modify`/
+    `deliver` is. `404` when there is no active row to revoke, the same
+    "nothing to confirm" posture the rest of this contract already applies to
+    an absent id.
+    """
+    await _require_node_and_project(session, node_id, project_id)
+    row = await store.revoke_project_authorization(
+        session, node_id=node_id, project_id=project_id, revoked_by=f"operator:{principal.user_id}"
+    )
+    if row is None:
+        raise _no_active_authorization(node_id, project_id)
+    return _authorization_dto(row)

--- a/gateway/app/api/routes/discovery.py
+++ b/gateway/app/api/routes/discovery.py
@@ -51,7 +51,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.app.api import idempotency, pagination, permissions, timestamps
 from gateway.app.api.auth import require_action
-from gateway.app.api.errors import CONFLICT, NOT_FOUND, VALIDATION_FAILED, ApiError
+from gateway.app.api.errors import CONFLICT, NOT_FOUND, PERMISSION_DENIED, VALIDATION_FAILED, ApiError
 from gateway.app.core.users import AuthenticatedPrincipal
 from gateway.app.db.session import get_session
 from gateway.app.services import store
@@ -198,6 +198,26 @@ async def adopt_discovered_resource(
     `grantCapabilities` is given, the resulting `project_authorizations` row
     is granted here -- never by the node itself (see the module docstring).
     """
+    # The same privilege ladder the dedicated authorize route applies
+    # (`routes/authorizations.py`). Adoption writes `project_authorizations`
+    # directly through `grantCapabilities`, so gating only that route would
+    # leave a second door to `modify`/`deliver` standing open, reachable by
+    # exactly the principal the ladder exists to stop: one whose token carries
+    # `codexbridge.admin` for fleet visibility without the account being
+    # trusted for a sensitive grant. Checked before the idempotency claim, so
+    # a refused request never consumes a key.
+    if not permissions.is_allowed(
+        principal, permissions.NODES_DISCOVERIES_DECIDE, capabilities=payload.grant_capabilities
+    ):
+        raise ApiError(
+            status_code=403,
+            code=PERMISSION_DENIED,
+            message=(
+                "Granting 'modify' or 'deliver' requires can_approve_sensitive or "
+                "admin. GET /api/v1/auth/me reports what this actor may do."
+            ),
+        )
+
     endpoint = f"{DISCOVERED_RESOURCES_ENDPOINT}/{{resourceId}}/adopt"
     fingerprint = idempotency.fingerprint(
         f"adopt:{resource_id}:{payload.project_id}:"

--- a/gateway/app/api/routes/probes.py
+++ b/gateway/app/api/routes/probes.py
@@ -78,7 +78,18 @@ version_router = APIRouter()
 # orchestration (issue #73's other Stage 3/4 tracks) not yet merged onto this
 # one; only one bump survives the eventual merge, same reasoning the 1.4.0
 # comment above already gives for four branches sharing one line.
-API_CONTRACT_VERSION = "1.12.0"
+#
+# 1.12.0 -> 1.14.0 (WK-20260902-gh73-authorization-plane, issue #73 Stage 4):
+# `POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize` and
+# `.../revoke` -- the explicit operator grant/revoke of `project_
+# authorizations`, and the first build whose enforcement actually reads that
+# table (`store.effective_task_modes`, wired into `create_task`, and the
+# executor's own mirrored gate). Additive only (two new endpoints, two new
+# schemas, no existing shape changed), so a minor bump -- jumping straight to
+# 1.14.0 rather than 1.13.0 for the same reason the paragraph above jumped
+# over 1.10.0/1.11.0: 1.13.0 is claimed by another not-yet-merged branch of
+# this same orchestration.
+API_CONTRACT_VERSION = "1.14.0"
 
 # Namespaces this build serves. `/api/version` reports all of them, which is the
 # obligation that keeps it outside the versioned namespace instead of making it a

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -14,6 +14,7 @@ from gateway.app.api.idempotency import purge_expired
 from gateway.app.api.rate_limit import RateLimitDependency, client_key
 from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import decisions, missions, nodes as nodes_routes, probes, projects, sessions
+from gateway.app.api.routes import authorizations as authorizations_routes
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import discovery as discovery_routes
 from gateway.app.api.routes import epics as epics_routes
@@ -156,6 +157,13 @@ app.include_router(nodes_routes.router, dependencies=[Depends(RateLimitDependenc
 # limiter, same administrative/fleet-wide posture as nodes.router above --
 # guarded by `NODES_DISCOVERIES_READ`/`NODES_DISCOVERIES_DECIDE`.
 app.include_router(discovery_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# The explicit operator grant/revoke of `project_authorizations` (issue #73,
+# Stage 4). Same limiter, same administrative/fleet-wide posture as
+# discovery_routes above -- guarded by `NODES_AUTHORIZATIONS_MANAGE`, whose
+# own second gate (granting `modify`/`deliver` needs `can_approve_sensitive`
+# or admin) lives inside `permissions.is_allowed`, not here.
+app.include_router(authorizations_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 
 
 def oauth_www_authenticate_header() -> str:

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -67,6 +67,7 @@ from shared.protocol import (
     SubmitTaskRequest,
     TaskMode,
     TaskState,
+    capabilities_to_modes,
 )
 from shared.security import hash_resource_key, hash_token
 
@@ -344,6 +345,83 @@ async def list_recent_tasks(session: AsyncSession, limit: int = 20, states: list
     return list(result.scalars())
 
 
+async def effective_task_modes(
+    session: AsyncSession, executor: ExecutorModel, project: ProjectModel
+) -> frozenset[TaskMode]:
+    """The task modes `executor` may actually run on `project`, right now.
+
+    Issue #73 Stage 4 (the authorization plane's enforcement half). This is
+    the ONLY place that decides the answer -- `create_task` calls it at
+    exactly the spot its own inline check used to live, and nothing else
+    replicates this rule. Three steps, in order:
+
+    1. `base` = `project.config_json["allowed_modes"]`, the pre-#73 project
+       setting, parsed exactly as `create_task` always parsed it (an unknown
+       string is ignored rather than raised on, the same forward-compatible
+       posture `capabilities_to_modes` takes on an unknown capability).
+    2. No row in `workspace_bindings` for `(executor.node_id, project.id)` --
+       this pair has never gone through discovery adoption -- returns `base`
+       unchanged. Not a grace period: a pair that never adopts stays exactly
+       as permissive as it always was, FOREVER. This is the same guarantee
+       `migrations/0009_control_plane.sql` wrote down in prose ("access
+       continues flowing through the pre-existing `allowed_projects`") and
+       Stage 3 relied on without ever having to enforce it -- Stage 4 is the
+       first code that actually reads `project_authorizations`, so this is
+       the first place that guarantee has to be code rather than a comment.
+    3. A binding exists: the answer narrows to `base & capabilities_to_modes(
+       ...)` of the pair's ACTIVE (`revoked_at is null`) `project_
+       authorizations` row. No row at all -- adopted but never authorized --
+       intersects with the empty set: adoption alone grants nothing (#73:
+       "adoption does not automatically grant every operational capability").
+
+    Never widens what `allowed_modes` already permits -- the intersection can
+    only shrink `base`, never grow past it. A project's own `allowed_modes`
+    stays the outer bound it always was; `project_authorizations` can only
+    take away from it, per node.
+    """
+    project_config = json.loads(project.config_json)
+    base: set[TaskMode] = set()
+    for value in project_config.get("allowed_modes", []):
+        try:
+            base.add(TaskMode(value))
+        except ValueError:
+            continue
+
+    binding = (
+        (
+            await session.execute(
+                select(WorkspaceBindingModel).where(
+                    WorkspaceBindingModel.node_id == executor.node_id,
+                    WorkspaceBindingModel.project_id == project.id,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if binding is None:
+        return frozenset(base)
+
+    authorization = (
+        (
+            await session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == executor.node_id,
+                    ProjectAuthorizationModel.project_id == project.id,
+                    ProjectAuthorizationModel.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if authorization is None:
+        return frozenset()
+
+    granted = capabilities_to_modes(json.loads(authorization.capabilities_json or "[]"))
+    return frozenset(base) & granted
+
+
 async def create_task(
     session: AsyncSession,
     request: SubmitTaskRequest,
@@ -363,7 +441,7 @@ async def create_task(
     if request.project_id not in executor_metadata.get("allowed_projects", []):
         raise ValueError("project_not_allowed_for_executor")
     project_config = json.loads(project.config_json)
-    if request.mode.value not in project_config.get("allowed_modes", []):
+    if request.mode not in await effective_task_modes(session, executor, project):
         raise ValueError("mode_not_allowed_for_project")
     if request.timeout_seconds > int(project_config.get("max_timeout_seconds", request.timeout_seconds)):
         raise ValueError("timeout_exceeds_project_limit")
@@ -914,6 +992,143 @@ async def _grant_project_authorization(
     origins = set(existing.granted_by.split(";")) if existing.granted_by else set()
     origins.add(origin)
     existing.granted_by = ";".join(sorted(origins))
+
+
+# --------------------------------------------------------------------------
+# The explicit operator surface: `POST .../authorize` and `.../revoke`
+# (issue #73 Stage 4, WK-20260902-gh73-authorization-plane). Unlike
+# `_grant_project_authorization` above -- adoption's own MERGE-only helper,
+# called with an `origin` that is itself provenance -- these two are the
+# route-level primitives behind a direct, explicit grant/revoke: an operator
+# stating the authorization they want *now*, not adding to whatever
+# accumulated from a discovery root or an earlier adoption. That is why
+# `grant_project_authorization` OVERWRITES `capabilities_json`/`granted_by`/
+# `granted_at` rather than merging them.
+# --------------------------------------------------------------------------
+
+
+async def grant_project_authorization(
+    session: AsyncSession,
+    *,
+    node_id: str,
+    project_id: str,
+    capabilities: list[Capability],
+    granted_by: str,
+    now: datetime | None = None,
+) -> ProjectAuthorizationModel:
+    """Get-or-create the standing authorization row for `(node_id, project_id)`.
+
+    `project_authorizations_node_project_idx` still allows exactly one
+    non-revoked row per pair, so a row that exists but is revoked is
+    REACTIVATED in place (`revoked_at` cleared, `capabilities_json`/
+    `granted_by`/`granted_at` overwritten) rather than a second row being
+    inserted -- the table holds the pair's CURRENT authorization, never a
+    history of grants. The full history of every grant and revoke lives in
+    `audit_events` via `record_event` (this function's own call below), the
+    same place every other lifecycle in this codebase keeps its history
+    instead of the row it acts on.
+
+    Does not validate that `node_id`/`project_id` exist -- the route layer
+    does that (404 before this is ever called), the same division of labor
+    `adopt_discovered_resource`'s own callers already follow.
+    """
+    now = now or datetime.now(timezone.utc)
+    existing = (
+        (
+            await session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == node_id,
+                    ProjectAuthorizationModel.project_id == project_id,
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    capability_values = sorted({capability.value for capability in capabilities})
+    if existing is None:
+        row = ProjectAuthorizationModel(
+            id=str(uuid4()),
+            node_id=node_id,
+            project_id=project_id,
+            capabilities_json=json.dumps(capability_values),
+            granted_by=granted_by,
+            granted_at=now,
+        )
+        session.add(row)
+    else:
+        row = existing
+        row.capabilities_json = json.dumps(capability_values)
+        row.granted_by = granted_by
+        row.granted_at = now
+        row.revoked_at = None
+    await record_event(
+        session,
+        "project_authorization",
+        row.id,
+        "project_authorization.granted",
+        {
+            "node_id": node_id,
+            "project_id": project_id,
+            "capabilities": capability_values,
+            "granted_by": granted_by,
+        },
+    )
+    await session.commit()
+    await session.refresh(row)
+    return row
+
+
+async def revoke_project_authorization(
+    session: AsyncSession,
+    *,
+    node_id: str,
+    project_id: str,
+    revoked_by: str,
+    now: datetime | None = None,
+) -> ProjectAuthorizationModel | None:
+    """Revoke the ACTIVE authorization row for `(node_id, project_id)`, if any.
+
+    Returns `None` when there is no active row to revoke -- the route layer
+    turns that into `404`, the same "do not confirm what the caller cannot
+    see" posture `routes/nodes.py` and `routes/discovery.py` already
+    document, extended here to "there is nothing to revoke" rather than "the
+    node/project themselves are unknown" (those are checked separately,
+    before this is ever called).
+
+    The row is marked revoked, never deleted -- `effective_task_modes`
+    (`gateway/app/services/store.py`) already treats `revoked_at is not
+    null` as "no capability", and `grant_project_authorization` above already
+    knows how to reactivate this exact row, so deleting it would only lose
+    the `granted_by`/`granted_at` provenance for no enforcement benefit.
+    """
+    now = now or datetime.now(timezone.utc)
+    existing = (
+        (
+            await session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == node_id,
+                    ProjectAuthorizationModel.project_id == project_id,
+                    ProjectAuthorizationModel.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if existing is None:
+        return None
+    existing.revoked_at = now
+    await record_event(
+        session,
+        "project_authorization",
+        existing.id,
+        "project_authorization.revoked",
+        {"node_id": node_id, "project_id": project_id, "revoked_by": revoked_by},
+    )
+    await session.commit()
+    await session.refresh(existing)
+    return existing
 
 
 async def adopt_discovered_resource(

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from gateway.app.api import permissions
 from gateway.app.api.routes import auth as auth_routes
+from gateway.app.api.routes import authorizations as authorizations_routes
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import decisions as decisions_routes
 from gateway.app.api.routes import discovery as discovery_routes
@@ -168,6 +169,7 @@ async def api(users_file, monkeypatch):
     app.include_router(conversations_routes.router)
     app.include_router(nodes_routes.router)
     app.include_router(discovery_routes.router)
+    app.include_router(authorizations_routes.router)
 
     async def override():
         async with factory() as s:
@@ -1022,6 +1024,14 @@ ENDPOINT_FOR_ACTION = {
     # `epics`/`issues` entries above already document.
     "nodes.discoveries.read": ("GET", "/api/v1/nodes/{id}/discovered-resources"),
     "nodes.discoveries.decide": ("POST", "/api/v1/discovered-resources/{id}/deny"),
+    # `revoke`, not `authorize`, for the same reason `nodes.discoveries.decide`
+    # above picks `deny` over `adopt`: `revoke` carries no request body, so a
+    # caller lacking the scope is refused by `require_action` before any body
+    # would even need to validate, keeping this parity check about the 403
+    # boundary alone. `{id}` fills both `{nodeId}` and `{projectId}` — neither
+    # resolves to a real row, which is fine here for the same reason the
+    # `{id}` comment above gives: this only asserts the 403/not-403 boundary.
+    "nodes.authorizations.manage": ("POST", "/api/v1/nodes/{id}/projects/{id}/revoke"),
     "sessions.read": ("GET", "/api/v1/sessions"),
     "sessions.readLogs": ("GET", "/api/v1/sessions/{id}/logs"),
     "sessions.explainError": ("POST", "/api/v1/sessions/{id}/explain-error"),

--- a/tests/integration/test_authorization_routes.py
+++ b/tests/integration/test_authorization_routes.py
@@ -1,0 +1,296 @@
+"""`POST .../authorize` and `.../revoke` -- issue #73 Stage 4.
+
+WK-20260902-gh73-authorization-plane. Fixture idiom copied from
+`test_discovery_routes.py`: real FastAPI app, in-memory sqlite, `store.
+upsert_registry` seeding, OAuth tokens minted through `store.
+create_oauth_access_token`.
+
+Weighted toward the privilege ladder this PR adds: granting `modify`/
+`deliver` requires `can_approve_sensitive` or a REAL `"admin"` role on top of
+the base `nodes.authorizations.manage` scope -- see `permissions.is_allowed`'s
+own docstring for why that second gate reads `"admin" in principal.roles`
+rather than `principal.is_admin()`. Every negative case is paired with a
+positive control in the same file (`docs/napkin-lessons.md`, 2026-09-01).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import authorizations as authorizations_routes
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.models.entities import AuditEventModel, ProjectAuthorizationModel, ProjectModel
+from gateway.app.services import store
+from shared.protocol import ExecutorRegistration
+
+
+# `codexbridge.admin` alone, no real admin role, no `can_approve_sensitive` --
+# enough for the base gate, never enough for `modify`/`deliver`.
+ADMIN_SCOPE_TOKEN = "token-admin-scope"
+# A real admin role -- clears both gates via the role check.
+ROLE_ADMIN_TOKEN = "token-role-admin"
+# `codexbridge.admin` plus `can_approve_sensitive`, no admin role -- clears
+# both gates via the sensitive-approval flag.
+SENSITIVE_APPROVER_TOKEN = "token-sensitive-approver"
+# Authenticated, no admin scope at all -- refused by the base gate itself.
+ALICE_TOKEN = "token-alice"
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "scoped-admin", "email": "scoped-admin@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "can_approve_sensitive": False, "enabled": True,
+                    },
+                    {
+                        "user_id": "role-admin", "email": "role-admin@example.com", "password_hash": "x",
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "can_approve_sensitive": False, "enabled": True,
+                    },
+                    {
+                        "user_id": "sensitive-approver", "email": "sensitive-approver@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "can_approve_sensitive": True, "enabled": True,
+                    },
+                    {
+                        "user_id": "alice", "email": "alice@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read"], "can_approve_sensitive": False, "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def api(users_file, monkeypatch):
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="E1", display_name="E1", machine_token="t", allowed_projects=[], enabled=True,
+                ),
+            ],
+            projects=[],
+        )
+        seed.add(ProjectModel(id="p1", name="P1", path="/srv/p1", enabled=True, config_json="{}"))
+        await seed.commit()
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        for token, user_id in (
+            (ADMIN_SCOPE_TOKEN, "scoped-admin"),
+            (ROLE_ADMIN_TOKEN, "role-admin"),
+            (SENSITIVE_APPROVER_TOKEN, "sensitive-approver"),
+            (ALICE_TOKEN, "alice"),
+        ):
+            await store.create_oauth_access_token(
+                seed, token=token, client_id="c", user_id=user_id,
+                scopes=["codexbridge.admin"] if user_id != "alice" else ["codexbridge.read"],
+                expires_at=future,
+            )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(authorizations_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.factory = factory  # type: ignore[attr-defined]
+    yield client
+    await engine.dispose()
+
+
+def auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# --------------------------------------------------------------------------
+# Authentication and the base administrative gate
+# --------------------------------------------------------------------------
+
+
+async def test_authorize_requires_a_token(api) -> None:
+    response = api.post("/api/v1/nodes/E1/projects/p1/authorize", json={"capabilities": ["read"]})
+    assert response.status_code == 401
+
+
+async def test_authorize_without_the_admin_scope_is_forbidden(api) -> None:
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ALICE_TOKEN), json={"capabilities": ["read"]}
+    )
+    assert response.status_code == 403
+
+
+async def test_authorize_read_with_the_admin_scope_is_allowed(api) -> None:
+    """Positive control: the base scope alone is sufficient for `read`/`test`."""
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["read"]}
+    )
+    assert response.status_code == 200
+    assert response.json()["capabilities"] == ["read"]
+
+
+# --------------------------------------------------------------------------
+# The privilege ladder: modify/deliver need a second gate
+# --------------------------------------------------------------------------
+
+
+async def test_granting_modify_without_can_approve_sensitive_or_admin_role_is_refused(api) -> None:
+    """The scope alone (`codexbridge.admin`, no real admin role, no
+
+    `can_approve_sensitive`) clears the base gate but not this one --
+    `permissions.is_allowed`'s own docstring explains why `is_admin()` would
+    have made this vacuous.
+    """
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["modify"]}
+    )
+    assert response.status_code == 403
+    assert response.json()["code"] == "permission_denied"
+    async with api.factory() as session:
+        rows = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert rows == []  # nothing was written
+
+
+async def test_granting_modify_with_can_approve_sensitive_is_allowed(api) -> None:
+    """Positive control: the sensitive-approval flag alone is sufficient, no admin role needed."""
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize",
+        headers=auth(SENSITIVE_APPROVER_TOKEN),
+        json={"capabilities": ["modify"]},
+    )
+    assert response.status_code == 200
+    assert response.json()["capabilities"] == ["modify"]
+
+
+async def test_granting_deliver_with_a_real_admin_role_is_allowed(api) -> None:
+    """Positive control: a real `"admin"` role alone is sufficient, no `can_approve_sensitive` needed."""
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ROLE_ADMIN_TOKEN), json={"capabilities": ["deliver"]}
+    )
+    assert response.status_code == 200
+    assert response.json()["capabilities"] == ["deliver"]
+
+
+async def test_granting_read_and_modify_together_still_needs_the_second_gate(api) -> None:
+    """Mixing a sensitive capability into an otherwise-plain request still trips the gate."""
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize",
+        headers=auth(ADMIN_SCOPE_TOKEN),
+        json={"capabilities": ["read", "modify"]},
+    )
+    assert response.status_code == 403
+
+
+# --------------------------------------------------------------------------
+# Grant/revoke semantics: same row, both events audited
+# --------------------------------------------------------------------------
+
+
+async def test_authorize_overwrites_rather_than_merges_capabilities(api) -> None:
+    api.post("/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["read", "test"]})
+    response = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["read"]}
+    )
+    assert response.status_code == 200
+    assert response.json()["capabilities"] == ["read"]
+
+    async with api.factory() as session:
+        rows = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert len(rows) == 1
+
+
+async def test_revoke_then_regrant_reuses_the_same_row_and_both_events_are_audited(api) -> None:
+    granted = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["read"]}
+    ).json()
+    assert granted["revokedAt"] is None
+
+    revoked = api.post("/api/v1/nodes/E1/projects/p1/revoke", headers=auth(ADMIN_SCOPE_TOKEN)).json()
+    assert revoked["revokedAt"] is not None
+
+    regranted = api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["test"]}
+    ).json()
+    assert regranted["revokedAt"] is None
+    assert regranted["capabilities"] == ["test"]
+
+    async with api.factory() as session:
+        rows = (await session.execute(select(ProjectAuthorizationModel))).scalars().all()
+        assert len(rows) == 1  # never a second row, even across revoke/regrant
+
+        events = (await session.execute(select(AuditEventModel))).scalars().all()
+        event_types = [event.event_type for event in events]
+        assert event_types.count("project_authorization.granted") == 2
+        assert event_types.count("project_authorization.revoked") == 1
+
+
+async def test_revoking_a_pair_with_no_active_authorization_is_not_found(api) -> None:
+    response = api.post("/api/v1/nodes/E1/projects/p1/revoke", headers=auth(ADMIN_SCOPE_TOKEN))
+    assert response.status_code == 404
+
+
+async def test_revoke_never_needs_the_sensitive_gate(api) -> None:
+    """Positive control for the "no second gate on revoke" claim: the
+
+    scope-only principal, who could never grant `modify`, can still revoke an
+    authorization that already carries it.
+    """
+    api.post(
+        "/api/v1/nodes/E1/projects/p1/authorize", headers=auth(SENSITIVE_APPROVER_TOKEN), json={"capabilities": ["modify"]}
+    )
+    response = api.post("/api/v1/nodes/E1/projects/p1/revoke", headers=auth(ADMIN_SCOPE_TOKEN))
+    assert response.status_code == 200
+    assert response.json()["revokedAt"] is not None
+
+
+# --------------------------------------------------------------------------
+# Unknown node/project
+# --------------------------------------------------------------------------
+
+
+async def test_authorizing_an_unknown_node_is_not_found(api) -> None:
+    response = api.post(
+        "/api/v1/nodes/does-not-exist/projects/p1/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["read"]}
+    )
+    assert response.status_code == 404
+
+
+async def test_authorizing_an_unknown_project_is_not_found(api) -> None:
+    response = api.post(
+        "/api/v1/nodes/E1/projects/does-not-exist/authorize", headers=auth(ADMIN_SCOPE_TOKEN), json={"capabilities": ["read"]}
+    )
+    assert response.status_code == 404

--- a/tests/integration/test_discovery_routes.py
+++ b/tests/integration/test_discovery_routes.py
@@ -39,6 +39,7 @@ from shared.protocol import DiscoveredState, DiscoveryRoot, ExecutorRegistration
 
 
 ADMIN_TOKEN = "token-admin"      # roles=["admin"] -- may adopt/deny
+FLEETWATCHER_TOKEN = "token-fleetwatcher"  # codexbridge.admin scope, no admin role
 ALICE_TOKEN = "token-alice"      # authenticated, codexbridge.read only -- no fleet access
 NOSCOPE_TOKEN = "token-noscope"  # authenticated, no scopes at all
 
@@ -64,6 +65,17 @@ def users_file(tmp_path):
                         "user_id": "noscope", "email": "noscope@example.com", "password_hash": "x",
                         "roles": [], "allowed_projects": [],
                         "scopes": [], "enabled": True,
+                    },
+                    {
+                        # Fleet visibility without the admin role and without
+                        # can_approve_sensitive: the exact actor the sensitive
+                        # capability ladder exists to stop from granting
+                        # modify/deliver. `codexbridge.admin` as a SCOPE is
+                        # what `nodes.discoveries.decide` requires; it must
+                        # not by itself buy a sensitive grant.
+                        "user_id": "fleetwatcher", "email": "fw@example.com", "password_hash": "x",
+                        "roles": [], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "enabled": True,
                     },
                 ]
             }
@@ -105,6 +117,7 @@ async def api(users_file, monkeypatch):
             (ADMIN_TOKEN, "admin", ["codexbridge.admin"]),
             (ALICE_TOKEN, "alice", ["codexbridge.read"]),
             (NOSCOPE_TOKEN, "noscope", []),
+            (FLEETWATCHER_TOKEN, "fleetwatcher", ["codexbridge.admin"]),
         ):
             await store.create_oauth_access_token(
                 seed, token=token, client_id="c", user_id=user_id,
@@ -211,6 +224,52 @@ async def test_a_principal_with_the_administrative_scope_can_adopt(api) -> None:
         "/api/v1/discovered-resources/r1/adopt",
         headers=auth(ADMIN_TOKEN),
         json={"newProject": {"projectId": "hub", "name": "Hub"}},
+    )
+    assert response.status_code == 200
+
+
+async def test_adoption_cannot_grant_modify_without_the_sensitive_ladder(api) -> None:
+    """The second door to `modify`/`deliver`, closed.
+
+    `POST .../authorize` applies a privilege ladder on top of its
+    administrative scope: granting `modify` or `deliver` also needs
+    `can_approve_sensitive` or the admin role. Adoption writes the same
+    `project_authorizations` table through `grantCapabilities`, so gating
+    only the dedicated route would leave this one open to exactly the
+    principal the ladder exists to stop -- a token carrying
+    `codexbridge.admin` for fleet visibility, for an account nobody trusted
+    with a sensitive grant.
+    """
+    await seed_resource(api.factory, resource_id="r1")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(FLEETWATCHER_TOKEN),
+        json={
+            "newProject": {"projectId": "hub", "name": "Hub"},
+            "grantCapabilities": ["modify"],
+        },
+    )
+    assert response.status_code == 403
+    async with api.factory() as session:
+        row = await session.get(DiscoveredResourceModel, "r1")
+        assert row.state == DiscoveredState.DISCOVERED.value  # nothing adopted either
+
+
+async def test_the_same_actor_may_adopt_when_it_asks_for_no_sensitive_capability(api) -> None:
+    """Positive control: the ladder gates the capability, not the adoption.
+
+    Without this, a bug that refused `fleetwatcher` every adoption would pass
+    the test above while breaking the read/test flow the operator actually
+    uses most.
+    """
+    await seed_resource(api.factory, resource_id="r1")
+    response = api.post(
+        "/api/v1/discovered-resources/r1/adopt",
+        headers=auth(FLEETWATCHER_TOKEN),
+        json={
+            "newProject": {"projectId": "hub", "name": "Hub"},
+            "grantCapabilities": ["read", "test"],
+        },
     )
     assert response.status_code == 200
 

--- a/tests/unit/test_agent_service.py
+++ b/tests/unit/test_agent_service.py
@@ -716,17 +716,58 @@ async def test_handle_dispatch_sends_workspace_write_for_a_write_mode_task(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_handle_dispatch_honours_the_machine_level_read_only_override(tmp_path: Path) -> None:
-    """A write-mode task still only gets `read-only` when this executor's own
-    `allow_workspace_write` is off — the override must reach `run_task`, not
-    just exist on `AgentSettings`."""
+async def test_handle_dispatch_refuses_a_write_mode_when_workspace_write_is_off(tmp_path: Path) -> None:
+    """WK-20260902-gh73-authorization-plane, issue #73 Stage 4.
+
+    Before the executor's own capability gate existed, this scenario reached
+    `run_task` and was merely sandboxed `read-only` (this test used to assert
+    exactly that, under the name `test_handle_dispatch_honours_the_machine_
+    level_read_only_override`). Stage 4 makes it an explicit, typed refusal
+    instead — `_handle_dispatch`'s own check, independent of anything the
+    gateway approved, since a compromised or buggy gateway must not be able
+    to make this node write when its own configuration never offered `modify`
+    (`allow_workspace_write=False` -> `_configured_capabilities` omits
+    `Capability.MODIFY` -> `implement` is not in `capabilities_to_modes(...)`).
+    The pure `_sandbox_for` override this test used to exercise indirectly is
+    still covered directly by `test_sandbox_for_machine_override_forces_
+    read_only_even_for_write_levels` below; that behaviour did not go away,
+    it simply becomes unreachable through `_handle_dispatch` once the gate
+    refuses the dispatch before sandbox selection ever runs.
+    """
     service = AgentService(AgentSettings(allow_workspace_write=False))
     runner = _SandboxRecordingRunner()
     service.runners._runners["codex"] = runner
     service.projects = {
         "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
     }
+    websocket = DummyWebSocket()
 
-    await service._handle_dispatch(DummyWebSocket(), _dispatch_envelope(task_id="t-locked", mode="implement"))
+    await service._handle_dispatch(websocket, _dispatch_envelope(task_id="t-locked", mode="implement"))
 
-    assert runner.sandboxes == ["read-only"]
+    assert runner.sandboxes == []
+    result = AgentEnvelope.model_validate_json(websocket.messages[-1])
+    assert result.payload["final_state"] == "failed"
+    assert result.payload["error"] == "capability_not_configured:implement"
+
+
+@pytest.mark.asyncio
+async def test_handle_dispatch_allows_a_write_mode_when_workspace_write_is_on(tmp_path: Path) -> None:
+    """Positive control for the refusal above, in the same file (napkin-lessons
+
+    2026-09-01: a purely negative assertion cannot tell "correctly refused"
+    apart from "never ran"). With the default `allow_workspace_write=True`,
+    the identical `implement` dispatch reaches the runner exactly as
+    `test_handle_dispatch_sends_workspace_write_for_a_write_mode_task` above
+    already proves for `edit` — this one pins `implement` specifically, since
+    that is the mode the negative test above refuses.
+    """
+    service = AgentService(AgentSettings(allow_workspace_write=True))
+    runner = _SandboxRecordingRunner()
+    service.runners._runners["codex"] = runner
+    service.projects = {
+        "codexbridge": ProjectRegistration(project_id="codexbridge", name="CodexBridge", path=str(tmp_path))
+    }
+
+    await service._handle_dispatch(DummyWebSocket(), _dispatch_envelope(task_id="t-unlocked", mode="implement"))
+
+    assert runner.sandboxes == ["workspace-write"]

--- a/tests/unit/test_effective_task_modes.py
+++ b/tests/unit/test_effective_task_modes.py
@@ -1,0 +1,370 @@
+"""`store.effective_task_modes` -- issue #73 Stage 4, WK-20260902-gh73-authorization-plane.
+
+The enforcement half of the authorization plane: the ONE place that decides
+which `TaskMode`s an executor may run against a project, replacing the inline
+`allowed_modes` membership check `create_task` used to do itself. Every rule
+below is proven at the `create_task` boundary, not just against the helper
+directly, because `create_task` is the thing that actually gates a real
+dispatch -- and every negative case carries a positive control in the same
+file (`docs/napkin-lessons.md`, 2026-09-01: "five green tests once proved
+only that the code they exercised was unreachable").
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.db.base import Base
+from gateway.app.models.entities import (
+    AuditEventModel,
+    ExecutorModel,
+    ProjectAuthorizationModel,
+    ProjectModel,
+    WorkspaceBindingModel,
+)
+from gateway.app.services import store
+from shared.protocol import (
+    BindingState,
+    Capability,
+    ExecutorRegistration,
+    ProjectRegistration,
+    SubmitTaskRequest,
+    TaskMode,
+    TaskPriority,
+)
+
+
+@pytest.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+async def _seed(
+    session: AsyncSession,
+    *,
+    executor_id: str = "E1",
+    project_id: str = "p1",
+    allowed_modes: list[TaskMode] | None = None,
+) -> tuple[ExecutorModel, ProjectModel]:
+    await store.upsert_registry(
+        session,
+        executors=[
+            ExecutorRegistration(
+                executor_id=executor_id,
+                display_name=executor_id,
+                machine_token="t",
+                allowed_projects=[project_id],
+            )
+        ],
+        projects=[
+            ProjectRegistration(
+                project_id=project_id,
+                name=project_id,
+                path=f"/srv/{project_id}",
+                allowed_modes=allowed_modes if allowed_modes is not None else list(TaskMode),
+                max_timeout_seconds=600,
+            )
+        ],
+    )
+    await session.commit()
+    executor = await session.get(ExecutorModel, executor_id)
+    project = await session.get(ProjectModel, project_id)
+    return executor, project
+
+
+async def _bind(session: AsyncSession, *, node_id: str, project_id: str) -> None:
+    session.add(
+        WorkspaceBindingModel(
+            id=f"binding-{node_id}-{project_id}",
+            node_id=node_id,
+            project_id=project_id,
+            local_path=f"/srv/{project_id}",
+            state=BindingState.ACTIVE.value,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.commit()
+
+
+async def _authorize(
+    session: AsyncSession, *, node_id: str, project_id: str, capabilities: list[Capability]
+) -> None:
+    session.add(
+        ProjectAuthorizationModel(
+            id=f"auth-{node_id}-{project_id}",
+            node_id=node_id,
+            project_id=project_id,
+            capabilities_json=json.dumps([c.value for c in capabilities]),
+            granted_by="operator:tester",
+            granted_at=datetime.now(timezone.utc),
+        )
+    )
+    await session.commit()
+
+
+def _submit(mode: TaskMode, *, executor_id: str = "E1", project_id: str = "p1") -> SubmitTaskRequest:
+    return SubmitTaskRequest(
+        executor_id=executor_id,
+        project_id=project_id,
+        instruction="do something",
+        mode=mode,
+        timeout_seconds=300,
+        priority=TaskPriority.NORMAL,
+        run_when_available=True,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+# --------------------------------------------------------------------------
+# `effective_task_modes` directly
+# --------------------------------------------------------------------------
+
+
+async def test_no_binding_returns_the_project_base_unchanged(db_session: AsyncSession) -> None:
+    """Non-regression: a pair that never went through discovery adoption is
+
+    exactly as permissive as `allowed_modes` always said, forever -- not a
+    grace period (migrations/0009_control_plane.sql: "access continues
+    flowing through the pre-existing allowed_projects"). This is the
+    property that would have passed BEFORE this PR's `create_task` change
+    existed, proven directly against the new helper.
+    """
+    executor, project = await _seed(db_session, allowed_modes=[TaskMode.ANALYZE, TaskMode.IMPLEMENT])
+    modes = await store.effective_task_modes(db_session, executor, project)
+    assert modes == frozenset({TaskMode.ANALYZE, TaskMode.IMPLEMENT})
+
+
+async def test_a_binding_with_no_authorization_permits_nothing(db_session: AsyncSession) -> None:
+    executor, project = await _seed(db_session, allowed_modes=list(TaskMode))
+    await _bind(db_session, node_id=executor.node_id, project_id=project.id)
+    modes = await store.effective_task_modes(db_session, executor, project)
+    assert modes == frozenset()
+
+
+async def test_a_binding_with_read_and_test_permits_exactly_those_modes(db_session: AsyncSession) -> None:
+    executor, project = await _seed(db_session, allowed_modes=list(TaskMode))
+    await _bind(db_session, node_id=executor.node_id, project_id=project.id)
+    await _authorize(
+        db_session, node_id=executor.node_id, project_id=project.id, capabilities=[Capability.READ, Capability.TEST]
+    )
+    modes = await store.effective_task_modes(db_session, executor, project)
+    assert modes == frozenset({TaskMode.ANALYZE, TaskMode.REVIEW, TaskMode.TEST})
+
+
+async def test_a_revoked_authorization_permits_nothing(db_session: AsyncSession) -> None:
+    """Positive control for the "no authorization" case: an authorization row
+
+    that EXISTS but is revoked must behave identically to no row at all.
+    """
+    executor, project = await _seed(db_session, allowed_modes=list(TaskMode))
+    await _bind(db_session, node_id=executor.node_id, project_id=project.id)
+    await _authorize(
+        db_session, node_id=executor.node_id, project_id=project.id, capabilities=[Capability.READ]
+    )
+    async with db_session.begin():
+        row = (
+            await db_session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == executor.node_id,
+                    ProjectAuthorizationModel.project_id == project.id,
+                )
+            )
+        ).scalars().first()
+        row.revoked_at = datetime.now(timezone.utc)
+    modes = await store.effective_task_modes(db_session, executor, project)
+    assert modes == frozenset()
+
+
+async def test_authorization_never_widens_past_the_projects_own_allowed_modes(db_session: AsyncSession) -> None:
+    """A capability grant intersects with `allowed_modes`, it never adds to it:
+
+    the project's own configuration stays the outer bound.
+    """
+    executor, project = await _seed(db_session, allowed_modes=[TaskMode.ANALYZE])  # project itself is read-only
+    await _bind(db_session, node_id=executor.node_id, project_id=project.id)
+    await _authorize(
+        db_session,
+        node_id=executor.node_id,
+        project_id=project.id,
+        capabilities=[Capability.READ, Capability.TEST, Capability.MODIFY],
+    )
+    modes = await store.effective_task_modes(db_session, executor, project)
+    # MODIFY/TEST are authorized, but the project's own allowed_modes never
+    # named `implement`/`edit`/`test` -- the intersection stays inside it.
+    assert modes == frozenset({TaskMode.ANALYZE})
+
+
+# --------------------------------------------------------------------------
+# `create_task` -- the real enforcement boundary
+# --------------------------------------------------------------------------
+
+
+async def test_create_task_for_an_unbound_pair_behaves_exactly_as_before_this_pr(db_session: AsyncSession) -> None:
+    """This is the test that would have passed before `effective_task_modes`
+
+    existed: an executor/project pair with no `workspace_bindings` row is
+    gated purely by `allowed_modes`, same as `create_task`'s old inline
+    check.
+    """
+    await _seed(db_session, allowed_modes=[TaskMode.ANALYZE])
+    task = await store.create_task(db_session, _submit(TaskMode.ANALYZE), executor_online=True)
+    assert task.mode == TaskMode.ANALYZE.value
+
+    with pytest.raises(ValueError, match="mode_not_allowed_for_project"):
+        await store.create_task(db_session, _submit(TaskMode.IMPLEMENT), executor_online=True)
+
+
+async def test_create_task_for_a_bound_but_unauthorized_pair_refuses_every_mode(db_session: AsyncSession) -> None:
+    executor, project = await _seed(db_session, allowed_modes=list(TaskMode))
+    await _bind(db_session, node_id=executor.node_id, project_id=project.id)
+    with pytest.raises(ValueError, match="mode_not_allowed_for_project"):
+        await store.create_task(db_session, _submit(TaskMode.ANALYZE), executor_online=True)
+
+
+async def test_create_task_for_a_bound_and_partially_authorized_pair_allows_only_the_granted_modes(
+    db_session: AsyncSession,
+) -> None:
+    executor, project = await _seed(db_session, allowed_modes=list(TaskMode))
+    await _bind(db_session, node_id=executor.node_id, project_id=project.id)
+    await _authorize(
+        db_session, node_id=executor.node_id, project_id=project.id, capabilities=[Capability.READ, Capability.TEST]
+    )
+
+    for mode in (TaskMode.ANALYZE, TaskMode.REVIEW, TaskMode.TEST):
+        task = await store.create_task(db_session, _submit(mode), executor_online=True)
+        assert task.mode == mode.value
+
+    with pytest.raises(ValueError, match="mode_not_allowed_for_project"):
+        await store.create_task(db_session, _submit(TaskMode.IMPLEMENT), executor_online=True)
+
+
+# --------------------------------------------------------------------------
+# `grant_project_authorization` / `revoke_project_authorization`
+# --------------------------------------------------------------------------
+
+
+async def test_granting_a_new_pair_creates_one_row(db_session: AsyncSession) -> None:
+    executor, project = await _seed(db_session)
+    row = await store.grant_project_authorization(
+        db_session,
+        node_id=executor.node_id,
+        project_id=project.id,
+        capabilities=[Capability.READ],
+        granted_by="operator:alice",
+    )
+    assert json.loads(row.capabilities_json) == ["read"]
+    assert row.granted_by == "operator:alice"
+    assert row.revoked_at is None
+
+
+async def test_granting_twice_overwrites_rather_than_merges(db_session: AsyncSession) -> None:
+    """Unlike adoption's own `_grant_project_authorization` (merge-only), this
+
+    is the explicit operator surface: a second grant call states what the
+    operator wants NOW, replacing the first grant's capabilities rather than
+    adding to them.
+    """
+    executor, project = await _seed(db_session)
+    await store.grant_project_authorization(
+        db_session,
+        node_id=executor.node_id,
+        project_id=project.id,
+        capabilities=[Capability.READ, Capability.TEST],
+        granted_by="operator:alice",
+    )
+    row = await store.grant_project_authorization(
+        db_session,
+        node_id=executor.node_id,
+        project_id=project.id,
+        capabilities=[Capability.READ],
+        granted_by="operator:bob",
+    )
+    assert json.loads(row.capabilities_json) == ["read"]  # not ["read", "test"]
+    assert row.granted_by == "operator:bob"
+
+    rows = (
+        (
+            await db_session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == executor.node_id,
+                    ProjectAuthorizationModel.project_id == project.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1  # never a second row
+
+
+async def test_revoke_then_regrant_reuses_the_same_row(db_session: AsyncSession) -> None:
+    executor, project = await _seed(db_session)
+    granted = await store.grant_project_authorization(
+        db_session, node_id=executor.node_id, project_id=project.id, capabilities=[Capability.READ], granted_by="operator:alice"
+    )
+    revoked = await store.revoke_project_authorization(
+        db_session, node_id=executor.node_id, project_id=project.id, revoked_by="operator:alice"
+    )
+    assert revoked.id == granted.id
+    assert revoked.revoked_at is not None
+
+    regranted = await store.grant_project_authorization(
+        db_session, node_id=executor.node_id, project_id=project.id, capabilities=[Capability.TEST], granted_by="operator:alice"
+    )
+    assert regranted.id == granted.id  # same row, reactivated
+    assert regranted.revoked_at is None
+    assert json.loads(regranted.capabilities_json) == ["test"]
+
+    rows = (
+        (
+            await db_session.execute(
+                select(ProjectAuthorizationModel).where(
+                    ProjectAuthorizationModel.node_id == executor.node_id,
+                    ProjectAuthorizationModel.project_id == project.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1  # never a second row, even across revoke/regrant
+
+    events = (
+        (
+            await db_session.execute(
+                select(AuditEventModel).where(AuditEventModel.entity_id == granted.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    event_types = [event.event_type for event in events]
+    assert event_types == [
+        "project_authorization.granted",
+        "project_authorization.revoked",
+        "project_authorization.granted",
+    ]
+
+
+async def test_revoking_a_pair_with_no_active_authorization_returns_none(db_session: AsyncSession) -> None:
+    """Positive control for the revoke/regrant test: revoking nothing is a
+
+    no-op the caller can detect, not a silent success against a phantom row.
+    """
+    executor, project = await _seed(db_session)
+    result = await store.revoke_project_authorization(
+        db_session, node_id=executor.node_id, project_id=project.id, revoked_by="operator:alice"
+    )
+    assert result is None


### PR DESCRIPTION
Issue #73, Stage 4 — stacked on #92, review that first. Until now `project_authorizations` was **written** (by adoption, #92) and **read by nobody**: a grant changed nothing about what a dispatch could do.

## The gate, without a second point of truth
`store.create_task` had one line deciding what a task may do — `mode not in project_config["allowed_modes"]`. It still has one line, in the same place; what changed is that the list it consults is now computed by `effective_task_modes(session, executor, project)`:

1. base = the project's `allowed_modes`, exactly as today;
2. a `(node, project)` pair with **no** `workspace_bindings` row gets the base back — every pair that never went through adoption behaves identically to before, **permanently**, not as a grace period. That is the guarantee migration `0009` already put in writing;
3. a bound pair gets the base intersected with `capabilities_to_modes()` of its active authorization. No row means no capability, not "unrestricted".

## The mirrored check on the executor is not duplication
`_handle_dispatch` now refuses a mode the machine's own configuration never offered (`capability_not_configured:<mode>`), derived from the same `_configured_capabilities` the announcement already reports. It protects against a compromised or buggy gateway sending a mode this node never volunteered for — the same defense-in-depth `git_delivery` already applies by re-checking a branch pattern the gateway validated.

## The finding worth more than the feature
Implementing the privilege ladder literally as specified — `can_approve_sensitive or is_admin()`, mirroring `DECISIONS_DECIDE` — would have shipped a **tautological control**. `is_admin()` is `"admin" in roles or "codexbridge.admin" in scopes`, and this action's own base scope **is** `codexbridge.admin`. For that action the two predicates collapse into one: every principal clearing the base check clears the second automatically, and `can_approve_sensitive` never once decides anything. `DECISIONS_DECIDE` is genuinely different — its scope, `codexbridge.task.approve`, is disjoint from admin.

The gate reads `"admin" in principal.roles` directly instead, keeping the two properties distinct: a token may carry `codexbridge.admin` for fleet visibility without that account being trusted for `modify`/`deliver`. A test fails against the naive version.

**Review fix on top of that**: the same PR's report named a second door and left it standing — adoption's `grantCapabilities` (#92) writes the same table under a different action with no ladder at all. A ladder guarding one of two doors is decoration, so the gate now keys off a set of capability-granting actions and the adopt route applies it too, before the idempotency claim so a refused request never burns a key. Proving it needed an actor this test file did not have: `codexbridge.admin` **scope**, no admin **role**. Its positive control shows the ladder gates the capability, not the adoption — that actor still adopts with `read`/`test`.

Contract → **1.14.0**.

## Validation
`pytest -q`: **886 passed, 7 skipped, 0 failed** (baseline 858). `tests/contract/`: 26 passed. The load-bearing test is the non-regression one: an unbound pair behaves exactly as it did before this PR.

## Not validated
No deploy, and no live gateway/executor pair over a real WebSocket with a real grant in effect — all coverage is in-memory SQLite and fakes.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw