### PR TITLE
feat(gh-73): CodexBridge Control — the first server-rendered screens

### DIFF
--- a/deploy/nginx/frida-codex-bridge.conf
+++ b/deploy/nginx/frida-codex-bridge.conf
@@ -114,4 +114,29 @@ server {
         deny all;
         proxy_pass http://127.0.0.1:18080/metrics;
     }
+
+    # CodexBridge Control's server-rendered screens (issue #73 Stage 5,
+    # gateway/app/api/routes/control_ui.py). Not IP-restricted like /metrics
+    # above: this surface authenticates every request with HTTP Basic against
+    # the same password registry /oauth/authorize already checks, over the
+    # same TLS this vhost terminates for every other location — the operator
+    # is expected to reach it from an ordinary browser, not only from frida
+    # itself. Applying this block is the operator's own action (see
+    # docs/operations.md, "CodexBridge Control"); it is not applied by any
+    # automated step in this repository.
+    location = /control {
+        proxy_pass http://127.0.0.1:18080/control;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location /control/ {
+        proxy_pass http://127.0.0.1:18080/control/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
 }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -24,6 +24,7 @@ The gateway exposes several HTTP surfaces. Only one of them is this contract.
 | `GET /metrics` | no | Prometheus scrape format, operator-facing |
 | `GET /healthz` | no | pre-existing infrastructure probe, superseded for mobile by `/health` |
 | `WS /agent/ws` | no | reverse executor channel; contract is `docs/protocol.md` |
+| `GET /control/**` | no | CodexBridge Control's server-rendered screens (issue #73 Stage 5); HTML, gated by HTTP Basic, consuming this same contract's `/api/v1/**` endpoints from the browser — see `gateway/app/api/routes/control_ui.py`'s own docstring |
 | `/openapi.json`, `/docs`, `/docs/oauth2-redirect`, `/redoc` | **not served at all** | FastAPI's auto-generated description and its UIs, switched off — see below |
 
 `docs/chatgpt-oauth-rollout.md` is **not** the contract for the OAuth endpoints.
@@ -180,7 +181,13 @@ by the contract itself, not by a filter applied late:
   `WorkspaceBindingModel.local_path` has none yet (no endpoint returns it in
   this build); `DiscoveredResourceModel.resourcePath` is returned by
   `GET /api/v1/nodes/{nodeId}/discovered-resources` and the `adopt`/`deny`
-  responses ONLY — see "Discovered resources" above for why. Since 0013,
+  responses ONLY — see "Discovered resources" above for why. CodexBridge
+  Control's node-detail screen (issue #73 Stage 5, `GET
+  /control/nodes/{nodeId}`) renders that same JSON in HTML instead of
+  fetching it a second way — it is the identical, already-excepted
+  administrative surface, not a new exception, and the module's own
+  docstring names exactly where the path may and may not appear (the escaped
+  table body; never a `<title>`, a query string, or a log line). Since 0013,
   `DiscoveredResourceModel.resource_key` itself is no longer the sensitive
   field: it is `hash_resource_key(path)`, a fixed-width lookup key with no
   reversible relationship to the path it was computed from, and it is not

--- a/docs/api/codex-bridge.openapi.yaml
+++ b/docs/api/codex-bridge.openapi.yaml
@@ -2722,6 +2722,34 @@ x-contract-excluded-paths:
       OAuth 2.0 Protected Resource Metadata (RFC 9728), consumed by the MCP
       client during discovery.
 
+  - path: /control
+    methods: [GET]
+    reason: >-
+      CodexBridge Control's server-rendered fleet screen (issue #73 Stage 5,
+      gateway/app/api/routes/control_ui.py). Returns HTML for a browser, not a
+      contract JSON body, the same reason /oauth/authorize is excluded above;
+      it consumes GET /api/v1/nodes and the other endpoints this document
+      already describes rather than defining a shape of its own. Not part of
+      the CodexBridgeMobile contract.
+
+  - path: /control/nodes/{nodeId}
+    methods: [GET]
+    reason: >-
+      CodexBridge Control's node-detail screen. Same reasoning as /control
+      above: HTML, gated by HTTP Basic (see the module's own docstring for
+      why), driving the same /api/v1/nodes/{nodeId}, .../discovered-resources,
+      .../adopt, .../deny, .../authorize and .../revoke endpoints this
+      document already contracts.
+
+  - path: /control/invite
+    methods: [GET]
+    reason: >-
+      Placeholder screen. This build has no node-enrollment endpoint for it to
+      call — see gateway/app/api/routes/control_ui.py's module docstring,
+      "/control/invite" — so it renders an explanation, not a form. Excluded
+      for the same reason as the other two /control paths: HTML, not a
+      contract JSON body.
+
   # FastAPI's /openapi.json, /docs, /docs/oauth2-redirect and /redoc are NOT
   # listed here. They are not served at all — main.py passes openapi_url=None,
   # docs_url=None and redoc_url=None. An exclusion entry for a route the gateway

--- a/docs/codemap.md
+++ b/docs/codemap.md
@@ -1,12 +1,12 @@
 # Code Map · codex-bridge
 
-> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-authorization-plane`
-> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-authorization-plane map`
+> Generated: 2026-09-02 · Root: `/home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-control-ui`
+> Refresh: `governancekit --root /home/esteban/Sync/Projects/AI/CodexBridge--WK-20260902-gh73-control-ui map`
 
 ## Summary
 
-- 141 file(s) · 1373 symbol(s) indexed
-- Languages: config (2), python (137), shell (2)
+- 143 file(s) · 1406 symbol(s) indexed
+- Languages: config (2), python (139), shell (2)
 - Top-level areas: `.`, `agent`, `deploy`, `gateway`, `scripts`, `shared`, `tests`
 
 ## Governance
@@ -69,6 +69,7 @@ gateway/
         __init__.py  — "HTTP routers for the mobile contract surface."
         auth.py  — "Sign-in, renewal, revocation, and what the actor may actually do."
         authorizations.py  — "The explicit operator grant: `POST .../authorize` and `.../revoke`."
+        control_ui.py  — "CodexBridge Control — the first server-rendered screens (issue #73 Stage 5)."
         conversations.py  — "Conversations and contextual messaging — issue #10."
         decisions.py  — "Operational decisions: sensitive tasks held for a human to resolve — issue #6."
         discovery.py  — "Discovered resources: the panel's half of "the node proposes, the panel adopts"."
@@ -143,6 +144,7 @@ tests/
     test_authorization_routes.py  — "`POST .../authorize` and `.../revoke` -- issue #73 Stage 4."
     test_claude_runner_real_process.py  — "ClaudeRunner against a REAL `claude` subprocess — not the fakes used elsewhere."
     test_codex_runner_real_process.py  — "CodexRunner against a REAL `codex` subprocess — not the fake used everywhere else."
+    test_control_ui.py  — "CodexBridge Control's server-rendered screens — issue #73 Stage 5."
     test_conversations.py  — "Conversations and contextual messaging — issue #10."
     test_decisions.py  — "Operational decisions — issue #6."
     test_discovery_routes.py  — "Discovered-resource adoption routes — issue #73 Stage 3 adoption half."
@@ -414,6 +416,14 @@ tests/
 - **`AuthorizeNodeProjectRequest`** *(class)*
 - `authorize_node_project(node_id, project_id, payload, principal, session)` *(async function)* — "Grant `payload.capabilities` to `node_id` on `project_id`."
 - `revoke_node_project(node_id, project_id, principal, session)` *(async function)* — "Revoke the active authorization for `node_id` on `project_id`."
+
+### `gateway/app/api/routes/control_ui.py`
+
+> CodexBridge Control — the first server-rendered screens (issue #73 Stage 5).
+
+- `control_home(request, session)` *(async function)*
+- `control_node_detail(node_id, request, cursor, state, session)` *(async function)*
+- `control_invite(request)` *(async function)*
 
 ### `gateway/app/api/routes/conversations.py`
 
@@ -774,6 +784,9 @@ tests/
 - `deny_discovered_resource(session, resource_id)` *(async function)* — "Refuse one discovered candidate. See `DECIDABLE_DISCOVERY_STATES` --"
 - `list_nodes(session)` *(async function)* — "Every Bridge Node, ordered by id, paired with the executor bound to it."
 - `get_node(session, node_id)` *(async function)* — "One Bridge Node and its bound executor, or None if the node does not exist."
+- `count_decidable_discovered_resources(session, node_id)` *(async function)* — "How many of `node_id`'s discovered resources are awaiting an operator"
+- `list_active_authorizations_for_node(session, node_id)` *(async function)* — "Every non-revoked `project_authorizations` row for `node_id`."
+- `get_project_names(session, project_ids)` *(async function)* — "`{project_id: name}` for the given ids, silently dropping unknown ones."
 - `next_dispatchable_task(session, executor_id)` *(async function)*
 - `update_task_state(session, task_id, state, error)` *(async function)*
 - `append_log(session, task_id, offset, stream, line)` *(async function)*
@@ -1174,6 +1187,38 @@ tests/
 - `test_run_task_drives_a_real_codex_process_end_to_end(tmp_path)` *(async function)* — "A real `codex exec --json -C <dir> -o <file> <instruction>` subprocess,"
 - `test_run_task_actually_writes_when_dispatched_with_workspace_write_sandbox(tmp_path)` *(async function)* — "The override side of finding (3): the same scratch repo, still not"
 - `test_run_task_resume_actually_resumes_the_real_session(tmp_path)` *(async function)* — "Finding (2), now fixed, driven through `run_task` itself end to end:"
+
+### `tests/integration/test_control_ui.py`
+
+> CodexBridge Control's server-rendered screens — issue #73 Stage 5.
+
+- `basic(username, password)`
+- `users_file(tmp_path)`
+- `api(users_file, monkeypatch)` *(async function)*
+- `set_node_display_name(factory, node_id, display_name)` *(async function)*
+- `seed_resource(factory)` *(async function)*
+- `seed_project(factory)` *(async function)*
+- `grant(factory)` *(async function)*
+- `test_control_home_requires_a_credential(api)` *(async function)*
+- `test_control_home_with_a_wrong_password_is_refused(api)` *(async function)*
+- `test_control_home_without_the_admin_scope_is_forbidden(api)` *(async function)*
+- `test_control_home_with_the_admin_scope_is_allowed(api)` *(async function)* — "Positive control for the previous three: the credential and scope alone are sufficient."
+- `test_control_home_escapes_a_hostile_display_name(api)` *(async function)*
+- `test_control_home_counts_pending_candidates(api)` *(async function)*
+- `test_control_node_detail_requires_a_credential(api)` *(async function)*
+- `test_control_node_detail_unknown_node_is_404(api)` *(async function)*
+- `test_control_node_detail_renders_capabilities_for_an_admin(api)` *(async function)* — "Positive control for the previous two."
+- `test_control_node_detail_escapes_a_hostile_resource_path_and_suggested_name(api)` *(async function)*
+- `test_control_node_detail_shows_the_candidate_resource_path(api)` *(async function)* — "The one authorized surface `resourcePath` may appear on (docs/api/README.md)."
+- `test_control_node_detail_paginates_discovered_candidates(api)` *(async function)*
+- `test_control_node_detail_shows_a_grant_form_for_an_adopted_unauthorized_project(api)` *(async function)* — "`ADOPTED` with no capability grant yet has no `project_authorizations`"
+- `test_control_node_detail_shows_active_capabilities_and_a_revoke_form(api)` *(async function)*
+- `test_control_node_detail_warns_that_modify_and_deliver_need_more_than_admin_scope(api)` *(async function)*
+- `test_control_node_detail_mints_no_audit_event(api)` *(async function)* — "Reading a page, and the token minted for its own fetch() calls, are not audited."
+- `test_control_node_detail_embeds_a_real_bearer_token_for_its_own_fetch_calls(api)` *(async function)* — "The page-scoped token is an ordinary row in the same table `/api/v1/**` reads."
+- `test_control_invite_requires_a_credential(api)` *(async function)*
+- `test_control_invite_without_the_admin_scope_is_forbidden(api)` *(async function)*
+- `test_control_invite_explains_the_gap_honestly(api)` *(async function)* — "Positive control for the previous two, and the point of this screen today:"
 
 ### `tests/integration/test_conversations.py`
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -549,3 +549,118 @@ continua sendo consultada — esta PR não a remove nem a substitui.
 `allowed_modes`/allowlist local; nunca alarga. Ver
 `docs/project-onboarding.md` para o que muda no fluxo operacional de cadastro
 de projeto e o que continua manual.
+
+## Stage 5 — as primeiras telas do painel (issue #73, WK-20260902-gh73-control-ui)
+
+Até aqui a #73 só tinha API. Esta PR é o primeiro corte de **CodexBridge
+Control** como página, servida pelo próprio processo do gateway —
+`gateway/app/api/routes/control_ui.py`. Três telas funcionam de verdade
+(`GET /control`, `GET /control/nodes/{nodeId}`, `GET /control/invite`); uma
+delas, `/control/invite`, existe só para explicar honestamente por que não
+funciona ainda (seção própria abaixo).
+
+### HTML no próprio processo, o mesmo precedente de `/oauth/authorize`
+
+`gateway/app/main.py:oauth_authorize`/`oauth_authorize_submit` já respondiam a
+pergunta "como servir HTML sem framework de template novo" para este código:
+um f-string com `html.escape` em cada interpolação, `HTMLResponse` de dentro
+do mesmo `FastAPI app`. `control_ui.py` segue exatamente esse padrão — sem
+Jinja2, sem segundo deployable, sem build step. Quando a SPA completa da
+Stage 5 chegar, ela troca este template pela mesma API; é por isso que a
+casca fica fina de propósito.
+
+### Leitura é renderizada no servidor; escrita é `fetch()` contra a API real
+
+Duas regras diferentes, e confundi-las é exatamente o erro que este desenho
+evita:
+
+- **Leituras** (lista de nós, capacidades/engines de um nó, uma página de
+  candidatos descobertos, autorizações ativas) chamam as **mesmas funções**
+  que as rotas JSON chamam — `routes.nodes._node_dto`,
+  `routes.discovery._discovered_resource_dto`,
+  `routes.authorizations._authorization_dto`, `store.list_nodes`/`get_node`/
+  `list_discovered_resources_page`. Nada aqui recalcula saúde, capacidade ou
+  paginação; importa a definição única e imprime como HTML em vez de JSON.
+- **Escritas** (Adotar, Negar, Conceder, Revogar) são `fetch()` contra
+  `POST /api/v1/discovered-resources/{id}/adopt|deny` e
+  `POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize|revoke` — as
+  mesmas rotas que C3/C4 já entregaram. Um `403` ao conceder `modify`/
+  `deliver` sem `can_approve_sensitive`/admin (a escada de privilégio da
+  Stage 4, acima) é o `403` real da rota, mostrado como veio — a UI não tenta
+  adivinhar a regra e arrisca divergir dela.
+
+### Autenticação: HTTP Basic, reverificado a cada request, mintando um Bearer comum por render
+
+`current_principal` (`gateway/app/api/auth.py`) só lê `Authorization: Bearer`
+— e uma navegação de browser normal não anexa header nenhum. Exigir esse
+mesmo header em `GET /control` tornaria a tela inalcançável por um browser
+comum, o que não pode ser "o painel que o operador abre na frida". A solução
+adotada é **HTTP Basic**, reverificado a cada request contra a mesma
+`authenticate_async` (a checagem de senha de custo constante) que
+`/oauth/authorize` e `POST /api/v1/auth/sign-in` já usam — não uma segunda. O
+browser reenvia a credencial Basic sozinho em toda navegação subsequente
+(clique em link, paginação, reload) sem sessão no servidor, sem cookie, sem
+token em URL. Uma sessão de cookie foi deliberadamente descartada: exigiria
+sua própria defesa contra CSRF, um segundo mecanismo de credencial para
+manter correto ao lado do que a superfície JSON já tem — exatamente a forma
+que `docs/napkin-lessons.md` já alerta contra repetir.
+
+Toda rota do módulo passa por `_control_principal`, que resolve a credencial
+Basic, chama `authenticate_async`, deriva um `AuthenticatedPrincipal` e chama
+`permissions.is_allowed(principal, action)` — **o mesmo catálogo** que
+`require_action` aplica em `/api/v1/**`. Uma credencial ausente ou errada é
+`401` com `WWW-Authenticate: Basic`; uma credencial válida sem o escopo certo
+é `403` explícito, nomeando a ação exigida — nunca um redirecionamento
+silencioso, nunca uma página em branco. É isso que "recusar na porta"
+significa aqui: a recusa acontece antes de qualquer linha de dado da frota
+ser lida, não depois de um `fetch()` já ter chegado ao browser e falhado.
+
+O que Basic **não** resolve: as ações de escrita continuam exigindo
+`Authorization: Bearer`, porque é o único esquema que `/api/v1/**` aceita e
+esta PR não é o lugar para ensinar um segundo. Por isso `GET
+/control/nodes/{nodeId}` — a única tela com botões que escrevem — minta um
+token OAuth comum a cada render, pela mesma `store.create_oauth_access_token`
+que `POST /api/v1/auth/sign-in` usa, com o mesmo teto de escopo
+(`principal.scopes ∩ settings.oauth_scopes()`), caindo na mesma tabela
+`oauth_access_tokens` que `current_principal` lê. Embutido uma vez, inline,
+num `<script>` — nunca em URL, query string, log ou `audit_events` (mintar
+não chama `record_event`, do mesmo jeito que nenhuma outra leitura deste
+código é auditada; só as escritas que esse token depois habilita são).
+Custo: `authenticate_async` reverificada a cada clique é o preço de não ter
+estado de sessão nenhum — aceitável para um console de operador único; o
+limitador de taxa (`gateway/app/main.py`) cobre todo o router pela mesma
+razão que cobre o `POST /oauth/authorize`.
+
+### `resourcePath`/`rootPath`: a mesma exceção já registrada, não uma nova
+
+`docs/api/README.md` ("Fields that must never ship") e a seção acima
+("Caminho absoluto") nomeiam uma exceção só para o path de um candidato:
+`GET /api/v1/nodes/{nodeId}/discovered-resources` e as respostas de
+`adopt`/`deny`, gated pelo mesmo escopo administrativo. A tela de detalhe do
+nó é essa mesma superfície, renderizada em HTML em vez de JSON — não uma
+segunda exceção. O path pode aparecer na tabela escapada da página; não pode
+aparecer em `<title>`, em query string, nem em log nenhum (o módulo não
+loga).
+
+### `/control/invite`: o que esta tela não faz, e por quê
+
+O plano original desta PR descrevia `GET /control/invite` chamando `POST
+/api/v1/nodes/invite` e montando um comando `scripts/enroll_node.py` pronto
+para copiar. **Nenhum dos dois existe neste código.**
+`gateway/app/api/routes/nodes.py` só serve `GET /nodes` e `GET
+/nodes/{nodeId}`; `scripts/` não tem `enroll_node.py`; e
+`docs/project-onboarding.md` já documentava, antes desta PR, que registrar um
+nó é um procedimento manual em dois arquivos (`registry.json` no gateway,
+`projects.json`/allowlist local no executor) com reinício dos dois
+processos.
+
+Construir a tela descrita teria significado inventar, dentro de uma PR de
+UI, exatamente o que o próprio plano proíbe inventar aqui: lógica de negócio
+real (um endpoint que minta token, com postura de segurança própria — hash
+em repouso, trilha de auditoria, revogação — e um script novo) sem API
+nenhuma por trás. `/control/invite`, portanto, renderiza uma explicação
+honesta em vez de um formulário que posta para lugar nenhum: nomeia o
+endpoint e o script que faltam pelos nomes exatos que o plano previu, e
+aponta para o procedimento manual real em `docs/project-onboarding.md`. Um
+endpoint de convite de nó fica registrado aqui como trabalho pendente para
+uma PR própria, não como parte desta.

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -642,25 +642,23 @@ segunda exceção. O path pode aparecer na tabela escapada da página; não pode
 aparecer em `<title>`, em query string, nem em log nenhum (o módulo não
 loga).
 
-### `/control/invite`: o que esta tela não faz, e por quê
+### `/control/invite`: o que esta tela não faz nesta build, e por quê
 
-O plano original desta PR descrevia `GET /control/invite` chamando `POST
-/api/v1/nodes/invite` e montando um comando `scripts/enroll_node.py` pronto
-para copiar. **Nenhum dos dois existe neste código.**
-`gateway/app/api/routes/nodes.py` só serve `GET /nodes` e `GET
-/nodes/{nodeId}`; `scripts/` não tem `enroll_node.py`; e
-`docs/project-onboarding.md` já documentava, antes desta PR, que registrar um
-nó é um procedimento manual em dois arquivos (`registry.json` no gateway,
-`projects.json`/allowlist local no executor) com reinício dos dois
-processos.
+`GET /control/invite` chamaria `POST /api/v1/nodes/invite` e montaria um
+comando `scripts/enroll_node.py` pronto para copiar. **Os dois existem — são
+a PR #87, o corte mínimo da issue #76 — mas não estão nesta build**: vivem
+numa branch da qual esta não foi cortada, então o endpoint que a página
+precisa está genuinamente ausente do processo que a serve.
 
-Construir a tela descrita teria significado inventar, dentro de uma PR de
-UI, exatamente o que o próprio plano proíbe inventar aqui: lógica de negócio
-real (um endpoint que minta token, com postura de segurança própria — hash
-em repouso, trilha de auditoria, revogação — e um script novo) sem API
-nenhuma por trás. `/control/invite`, portanto, renderiza uma explicação
-honesta em vez de um formulário que posta para lugar nenhum: nomeia o
-endpoint e o script que faltam pelos nomes exatos que o plano previu, e
-aponta para o procedimento manual real em `docs/project-onboarding.md`. Um
-endpoint de convite de nó fica registrado aqui como trabalho pendente para
-uma PR própria, não como parte desta.
+A distinção importa e é a razão desta seção existir: a lacuna é de
+*linhagem*, não de capacidade. Nada aqui precisa ser desenhado de novo, e a
+tela acende sozinha quando aquele trabalho mergear. Construir um endpoint de
+convite dentro de uma PR de UI teria sido inventar lógica de negócio real
+(emissão de token, hash em repouso, trilha de auditoria, revogação) num lugar
+onde ela não pertence — e, pior, uma segunda vez, já existindo uma
+implementação revisada noutra branch.
+
+Por isso a tela renderiza uma explicação honesta em vez de um formulário que
+posta para lugar nenhum, nomeia o endpoint e o script pelos nomes exatos, e
+aponta para o procedimento manual de `docs/project-onboarding.md` enquanto o
+merge não acontece.

--- a/docs/issues/073-codexbridge-control/RESUME.md
+++ b/docs/issues/073-codexbridge-control/RESUME.md
@@ -1,122 +1,91 @@
-# RESUME — WK-20260902-gh73-authorization-plane (epic #73)
+# RESUME — WK-20260902-gh73-control-ui (epic #73)
 
-- work_id: WK-20260902-gh73-authorization-plane
+- work_id: WK-20260902-gh73-control-ui
 - data: 2026-09-02
-- Stage 1 (domain/contracts): **PR #74 merged** into `development` as `80e5d2f`.
-- Stage 2 (fleet visibility): merged onto this lineage (`2ed550f`).
-- Stage 3, report half (node proposes): merged onto this lineage (`a57a8d9`).
-- Stage 3, adoption half (panel decides): merged onto this lineage (`a1cf4d7`,
-  PRs #91/#92 — first real writes to `project_authorizations`).
-- Stage 4 (authorization plane enforcement): **this session**, branch
-  `feature/gh-73/authorization-plane`, worktree
-  `../CodexBridge--WK-20260902-gh73-authorization-plane`. Committed locally,
-  **not pushed, no PR opened** (out of this session's scope — commit and stop).
+- Stage 1 (domain/contracts): PR #74 merged into `development` as `80e5d2f`.
+- Stage 2 (fleet visibility), Stage 3 (discovery report + adoption), Stage 4
+  (authorization plane enforcement): merged onto this lineage before this
+  session (`2ed550f`, `a57a8d9`, `a1cf4d7`, `e450c85`, `ac79a47`).
+- Stage 5, first cut (this session): branch `feature/gh-73/control-ui`,
+  worktree `../CodexBridge--WK-20260902-gh73-control-ui`, base
+  `feature/gh-73/authorization-plane`. Committed locally, **not pushed, no PR
+  opened** (commit and stop, same as every prior stage in this lineage).
 
 ## Next Step (DO THIS FIRST)
 
-Open the PR for `feature/gh-73/authorization-plane` against
-`feature/gh-73/discovery-adoption`, get it reviewed — flag the `is_admin()`
-finding below explicitly in the PR description, it is a judgment call a
-reviewer should confirm, not rubber-stamp — then check the epic's own issue
-body for whatever Stage 5 (or the next unstarted stage) is.
+Open the PR for `feature/gh-73/control-ui`, get it reviewed, then decide with
+the operator whether the next stage is (a) a real `POST /api/v1/nodes/invite`
++ `scripts/enroll_node.py` (the gap this session found and did not build —
+see "Watch for" below), or (b) the epic's own Stage 6 (Missions/Decisions/
+Audit/Settings convergence).
 
 ## Current state
 
-- `store.effective_task_modes(session, executor, project)` is now the ONLY
-  place that decides which `TaskMode`s an executor may run against a
-  project — `store.create_task` calls it at the exact spot its old inline
-  `allowed_modes` check lived. A pair with no `workspace_bindings` row is
-  governed by `allowed_modes` alone, forever (not a grace period); a bound
-  pair is `allowed_modes` intersected with `capabilities_to_modes(...)` of
-  its active `project_authorizations` row.
-- `agent/codex_bridge_agent/service.py:_handle_dispatch` gained its own,
-  independent mirror: refuses a dispatch whose mode this node's own
-  configuration (`allow_workspace_write`/`allow_git_delivery`, via the new
-  `_configured_capabilities` helper shared with `_build_announcement`)
-  never offered, with a typed `capability_not_configured:<mode>` error —
-  defense in depth, not duplication (same reasoning `git_delivery.py`
-  already applies to the branch pattern).
-- `POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize` and
-  `.../revoke` — new `gateway/app/api/routes/authorizations.py`.
-  `store.grant_project_authorization` (get-or-create-or-reactivate,
-  OVERWRITES capabilities rather than merging — different from adoption's
-  own merge-only `_grant_project_authorization`) and `store.
-  revoke_project_authorization` (marks `revoked_at`, never deletes).
-- New administrative action `permissions.NODES_AUTHORIZATIONS_MANAGE`
-  (`codexbridge.admin`). Granting `modify`/`deliver` crosses a second gate
-  inside `permissions.is_allowed`: `principal.can_approve_sensitive or
-  "admin" in principal.roles`.
-- **Finding, not silently patched**: the plan asked for the same shape
-  `DECISIONS_DECIDE`'s second gate has —
-  `principal.can_approve_sensitive or principal.is_admin()`. Implemented
-  literally, that gate is TAUTOLOGICAL here: `NODES_AUTHORIZATIONS_MANAGE`'s
-  own base scope already IS `codexbridge.admin`, and `is_admin()` returns
-  `True` for ANY principal whose token merely carries that scope (`"admin"
-  in principal.roles or "codexbridge.admin" in principal.scopes`) — so
-  `has_scope(action.scope)` and `is_admin()` are the same predicate for
-  this one action, and `can_approve_sensitive` would never be the deciding
-  factor. `DECISIONS_DECIDE`'s own scope (`codexbridge.task.approve`) is
-  disjoint from `codexbridge.admin`, which is why the identical code is
-  meaningful THERE and not here. Fixed by checking `"admin" in
-  principal.roles` directly instead of calling `is_admin()` — documented at
-  length in `permissions.is_allowed`'s own docstring and in
-  `docs/napkin-lessons.md`'s 2026-09-02 entry. Proven by
-  `tests/integration/test_authorization_routes.py::
-  test_granting_modify_without_can_approve_sensitive_or_admin_role_is_refused`,
-  which fails against the naive `is_admin()` version.
-- **Pre-existing gap, NOT fixed by this PR (out of scope, flagged for the
-  operator)**: `POST /api/v1/discovered-resources/{id}/adopt`'s own
-  `grantCapabilities` (Stage 3, C3) can already grant `modify`/`deliver`
-  under `NODES_DISCOVERIES_DECIDE` with NO second gate at all — any
-  principal with the bare `codexbridge.admin` scope can grant sensitive
-  capability through the adoption route today, unrelated to whether this
-  PR's own `authorize` route enforces `can_approve_sensitive`. Worth a
-  follow-up if the operator wants the same ladder applied there.
-- Contract bumped **1.12.0 → 1.14.0** (`probes.API_CONTRACT_VERSION` and
-  `docs/api/codex-bridge.openapi.yaml`'s `info.version`) — skipping 1.13.0,
-  claimed by another not-yet-merged branch of this same orchestration.
+- `gateway/app/api/routes/control_ui.py` (new): three working screens —
+  `GET /control` (fleet), `GET /control/nodes/{nodeId}` (capabilities/
+  engines, paginated discovered candidates with Adopt/Deny, authorizations
+  with Grant/Revoke), `GET /control/invite` (explanation only — see below).
+  HTML in the gateway's own process, the `/oauth/authorize` precedent — no
+  template engine, no second deployable.
+- Reads call the exact DTO functions the JSON routes already use
+  (`routes.nodes._node_dto`, `routes.discovery._discovered_resource_dto`,
+  `routes.authorizations._authorization_dto`); writes are `fetch()` against
+  the real `/api/v1/**` routes. No business logic duplicated.
+- Auth: HTTP Basic, re-verified per request via the same `authenticate_async`
+  `/oauth/authorize` uses, gated by the same `permissions.is_allowed`
+  catalogue as `/api/v1/**`. A page that needs to write (node detail) mints
+  an ordinary, short-lived `oauth_access_tokens` row per render (same table,
+  same scope cap as mobile sign-in) embedded inline for that page's own
+  `fetch()` calls — never in a URL, never audited on mint. Full reasoning in
+  `control_ui.py`'s own module docstring and `docs/control-plane.md`'s
+  "Stage 5" section.
+- Three new `store.py` read-only helpers, used only by this module:
+  `count_decidable_discovered_resources`, `list_active_authorizations_for_node`,
+  `get_project_names` (name only, never `ProjectModel.path`).
+- **Finding, not silently patched**: the plan's fourth screen
+  (`GET /control/invite`) was specified to call `POST /api/v1/nodes/invite`
+  and print a `scripts/enroll_node.py` command. Neither exists in this
+  codebase — confirmed by grep and by `docs/project-onboarding.md`, which
+  already documented node registration as a manual two-file procedure. Built
+  as an honest explanation screen instead of a form that posts to nothing.
+  See `docs/napkin-lessons.md`'s 2026-09-02 "um plano de UI pode descrever um
+  endpoint que nunca foi construído" entry and `control_ui.py`'s own
+  docstring, "`/control/invite`".
+- `x-contract-excluded-paths` gained three entries (`/control`,
+  `/control/nodes/{nodeId}`, `/control/invite`) — HTML, not part of the
+  mobile contract, same posture as `/oauth/*`. `API_CONTRACT_VERSION` **not**
+  bumped: no `/api` route changed.
 
 ## Changed files
 
-`gateway/app/api/routes/authorizations.py` (new),
-`tests/unit/test_effective_task_modes.py` (new),
-`tests/integration/test_authorization_routes.py` (new),
-`gateway/app/services/store.py`, `gateway/app/api/permissions.py`,
-`gateway/app/api/routes/probes.py`, `gateway/app/main.py`,
-`agent/codex_bridge_agent/service.py` (`shared/protocol.py` untouched — its
-`Capability`/`CAPABILITY_MODES`/`capabilities_to_modes` from Stage 1 already
-had everything this PR needed),
-`tests/unit/test_agent_service.py`, `tests/integration/test_auth.py`,
+`gateway/app/api/routes/control_ui.py` (new),
+`tests/integration/test_control_ui.py` (new),
+`gateway/app/services/store.py`, `gateway/app/main.py`,
 `docs/api/README.md`, `docs/api/codex-bridge.openapi.yaml`,
-`docs/control-plane.md`, `docs/project-onboarding.md`, `docs/codemap.md`,
-`docs/napkin-lessons.md`.
+`docs/control-plane.md`, `docs/operations.md`, `docs/codemap.md`,
+`docs/napkin-lessons.md`, `deploy/nginx/frida-codex-bridge.conf`.
 
 ## Checks
 
-- `.venv/bin/python -m pytest -q` → **884 passed, 7 skipped, 0 failed**
-  (branch baseline before this PR: 858/7).
-- `tests/contract/` → all green (26 passed), including the OpenAPI
-  route/version-parity gates and the codemap freshness gate (regenerated
-  with `governancekit --root . map`).
-- Pytest collection needed the sibling `awt` `.env` moved aside first
-  (`Settings` uses `extra="forbid"`, per this session's own instructions —
-  restored immediately after the run, never committed, `.env` is
-  gitignored).
+- `.venv/bin/python -m pytest -q` → **906 passed, 7 skipped, 0 failed**
+  (branch baseline before this PR: 886/7).
+- `tests/contract/` → all green (26 passed), codemap regenerated with
+  `governancekit --root . map`.
+- Pytest collection needed the sibling `awt` `.env` moved aside first, same
+  as every prior session in this lineage — restored immediately after,
+  never committed.
 
 ## NOT validated
 
-No deploy, no real gateway/executor pair exercised end-to-end over a live
-WebSocket with a real `project_authorizations` grant in effect (all coverage
-is against an in-memory SQLite `AsyncSession` or a `DummyWebSocket`/fake
-runner). No MySQL run of this PR's own migrations — there are none; this PR
-adds no schema, only reads/writes the Stage 1 `project_authorizations` table
-that already exists.
+No deploy, no real browser exercised against a live gateway (all coverage is
+`TestClient` + in-memory SQLite). No manual check that the nginx block
+proposed in `docs/operations.md` actually reverse-proxies correctly on
+`frida` — applying it is the operator's own action, not done by this session.
 
 ## Watch for
 
-The `is_admin()` finding above is a judgment call this session made
-unilaterally (deviating from the plan's literal `principal.is_admin()`
-instruction) because implementing it literally would have shipped a gate
-that looks like a control but never binds. Flag it in the PR description
-explicitly rather than letting a reviewer discover the deviation from a
-diff alone.
+`GET /control/invite` does not do what its name promises — it explains why
+instead. Building the real flow (a token-issuing endpoint with its own
+security posture, plus `scripts/enroll_node.py`) is real backend work
+belonging to its own PR/stage, flagged here rather than fabricated inside a
+UI PR.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1402,34 +1402,35 @@ administrativo, deve voltar a usar `is_admin()`; quem copiar para uma ação
 cujo escopo base JÁ seja `codexbridge.admin` deve repetir esta checagem
 antes de confiar no copy-paste.
 
-## 2026-09-02 — um plano de UI pode descrever um endpoint que nunca foi construído
+## 2026-09-02 — uma branch não é o repositório, e `grep` só prova a primeira
 
 O plano da PR C5 (WK-20260902-gh73-control-ui, issue #73 Stage 5) descrevia a
 quarta tela — `GET /control/invite` — chamando `POST /api/v1/nodes/invite` e
-montando um comando `scripts/enroll_node.py` pronto para copiar. Nenhum dos
-dois existe: `gateway/app/api/routes/nodes.py` só serve `GET /nodes` e `GET
-/nodes/{nodeId}`; `scripts/` não tem `enroll_node.py`; e
-`docs/project-onboarding.md` já documentava, antes desta PR, que registrar um
-nó é um procedimento manual de dois arquivos (`registry.json` no gateway,
-allowlist local no executor) com reinício dos dois processos — nunca um
-fluxo HTTP.
+montando um comando `scripts/enroll_node.py` pronto para copiar. O agente
+verificou antes de escrever uma linha de UI (`grep -rn "invite"`, `ls
+scripts/`, leitura de `docs/project-onboarding.md`), não achou nenhum dos
+dois, e — corretamente — não inventou o endpoint: renderizou uma explicação
+no lugar da tela e reportou a lacuna.
 
-A confirmação foi puramente por busca (`grep -rn "invite"`, `ls scripts/`,
-leitura de `docs/project-onboarding.md`), antes de escrever uma linha de UI
-para essa tela — não por assumir que "C1-C4 já expõem os mesmos endpoints"
-(a frase literal do plano) valia para as quatro telas por igual só porque
-valia para as outras três.
+A verificação estava certa e a conclusão estava errada. Os dois existem: são
+a PR #87 (`feature/gh76/enrollment-minimal`), cortada da mesma base, no mesmo
+dia, em paralelo. O que faltava não era a capacidade — era a linhagem. C5 foi
+cortada de C4, e C1 é irmã de C4, não ancestral. O próprio plano dizia "base:
+C4 (+C1 mergeada)"; quem cortou o worktree (o orquestrador) leu só a primeira
+metade.
 
-Lição: um plano de UI que descreve "a tela chama o endpoint X" é uma
-afirmação sobre o código, não uma instrução que dispensa verificação — o
-mesmo nível de ceticismo que já se aplica a specs de negócio vale para specs
-de interface. Quando a verificação mostra que o endpoint não existe, a
-resposta certa não é inventar um (a lógica de negócio de um endpoint de
-convite — geração de token, hashing em repouso, trilha de auditoria,
-revogação — pertence à sua própria PR, com sua própria revisão de segurança)
-nem simplesmente pular a tela (o link ficaria quebrado e a lacuna, muda). A
-resposta que preserva confiança é renderizar uma explicação honesta no lugar
-exato onde a tela iria — nomeando o endpoint e o script que faltam pelos
-nomes exatos que o plano previu — e registrar o achado no relatório da PR
-como trabalho pendente para uma PR própria, nunca como algo silenciosamente
-resolvido "de outro jeito".
+Duas lições, e a segunda é a que custa:
+
+1. Num dia de várias branches em paralelo, `grep -rn` prova o que está
+   **neste checkout**, não o que está no repositório. A frase honesta é
+   "não existe nesta build", nunca "não existe neste código" — e antes de
+   escrever a segunda vale um `git log --all --oneline -S<símbolo>`.
+2. Uma instrução de base entre parênteses — "(+C1 mergeada)" — é
+   indistinguível de decoração na hora de rodar `awt new --base`. Dependência
+   de merge entre branches irmãs precisa ser um passo, não um adendo: ou o
+   merge acontece antes de cortar, ou a tela sai do escopo com o motivo
+   escrito.
+
+O comportamento do agente foi o certo em tudo que estava ao alcance dele:
+verificou, não fabricou, e reportou. O erro foi de sequenciamento, uma camada
+acima — e é por isso que ele aparece aqui, e não no relatório de uma PR.

--- a/docs/napkin-lessons.md
+++ b/docs/napkin-lessons.md
@@ -1401,3 +1401,35 @@ próprio docstring de `permissions.is_allowed` — quem copiar o padrão
 administrativo, deve voltar a usar `is_admin()`; quem copiar para uma ação
 cujo escopo base JÁ seja `codexbridge.admin` deve repetir esta checagem
 antes de confiar no copy-paste.
+
+## 2026-09-02 — um plano de UI pode descrever um endpoint que nunca foi construído
+
+O plano da PR C5 (WK-20260902-gh73-control-ui, issue #73 Stage 5) descrevia a
+quarta tela — `GET /control/invite` — chamando `POST /api/v1/nodes/invite` e
+montando um comando `scripts/enroll_node.py` pronto para copiar. Nenhum dos
+dois existe: `gateway/app/api/routes/nodes.py` só serve `GET /nodes` e `GET
+/nodes/{nodeId}`; `scripts/` não tem `enroll_node.py`; e
+`docs/project-onboarding.md` já documentava, antes desta PR, que registrar um
+nó é um procedimento manual de dois arquivos (`registry.json` no gateway,
+allowlist local no executor) com reinício dos dois processos — nunca um
+fluxo HTTP.
+
+A confirmação foi puramente por busca (`grep -rn "invite"`, `ls scripts/`,
+leitura de `docs/project-onboarding.md`), antes de escrever uma linha de UI
+para essa tela — não por assumir que "C1-C4 já expõem os mesmos endpoints"
+(a frase literal do plano) valia para as quatro telas por igual só porque
+valia para as outras três.
+
+Lição: um plano de UI que descreve "a tela chama o endpoint X" é uma
+afirmação sobre o código, não uma instrução que dispensa verificação — o
+mesmo nível de ceticismo que já se aplica a specs de negócio vale para specs
+de interface. Quando a verificação mostra que o endpoint não existe, a
+resposta certa não é inventar um (a lógica de negócio de um endpoint de
+convite — geração de token, hashing em repouso, trilha de auditoria,
+revogação — pertence à sua própria PR, com sua própria revisão de segurança)
+nem simplesmente pular a tela (o link ficaria quebrado e a lacuna, muda). A
+resposta que preserva confiança é renderizar uma explicação honesta no lugar
+exato onde a tela iria — nomeando o endpoint e o script que faltam pelos
+nomes exatos que o plano previu — e registrar o achado no relatório da PR
+como trabalho pendente para uma PR própria, nunca como algo silenciosamente
+resolvido "de outro jeito".

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -40,6 +40,56 @@ segundos, não uma falha única.
 * `cancel_codex_task` cancela em qualquer estado cancelável (fila, aprovação pendente, execução, pausa/retomada/reinício pendentes), marcando a tarefa `cancelled` de imediato; o `task.cancel` só é entregue ao agente na hora se ele estiver conectado, senão é reenviado na reconexão — limitado a `cancel_replay_max_age_seconds` (padrão 24h) desde o cancelamento; passado esse prazo não há novo reenvio;
 * no retorno do agente, o gateway reavalia e redispara a próxima tarefa elegível.
 
+## CodexBridge Control (issue #73 Stage 5)
+
+Três telas server-rendered: `GET /control` (frota), `GET
+/control/nodes/{nodeId}` (detalhe: capacidades/engines, candidatos
+descobertos, autorizações) e `GET /control/invite` (hoje só explica por que
+não funciona ainda — não há `POST /api/v1/nodes/invite` nem
+`scripts/enroll_node.py` neste build; ver `docs/control-plane.md`, seção
+"Stage 5"). Servidas pelo próprio processo do gateway, sem deployable novo.
+
+**Ação do operador — nginx.** O vhost `deploy/nginx/frida-codex-bridge.conf`
+é uma allowlist de `location`s sem catch-all: sem a entrada `/control`, o
+painel simplesmente não responde (404 na borda), mesmo funcionando na
+aplicação. O bloco já está no arquivo versionado do repositório desde esta
+PR; falta **aplicá-lo em produção** — copiar o trecho abaixo (ou o arquivo
+inteiro) para o nginx do `frida` e recarregar:
+
+```nginx
+location = /control {
+    proxy_pass http://127.0.0.1:18080/control;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+}
+
+location /control/ {
+    proxy_pass http://127.0.0.1:18080/control/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+}
+```
+
+Depois de copiar: `nginx -t` e `systemctl reload nginx` (ou equivalente) no
+`frida`. Nenhum passo deste trabalho aplica isso automaticamente — deploy
+autônomo é proibido neste projeto; aplicar em produção é sempre ação humana.
+
+**Credenciais.** Não é um mecanismo novo: o painel pede usuário/senha via o
+diálogo nativo de HTTP Basic do próprio browser, verificados contra o mesmo
+`users.json` que `/oauth/authorize` já usa. Qualquer conta com o escopo
+`codexbridge.admin` (`GET /api/v1/auth/me` confirma) enxerga a frota;
+conceder `modify`/`deliver` a um nó, na tela de detalhe, exige além disso
+`can_approve_sensitive` ou o papel `admin` — a mesma escada de privilégio da
+Stage 4 (`docs/control-plane.md`). Nenhuma conta nova precisa ser criada só
+para o painel.
+
+**Nada de migração.** Esta PR não adiciona schema; usa exatamente as tabelas
+que a Stage 1-4 já criaram.
+
 ## Ambiente atual levantado em 2026-07-28
 
 * `frida` responde por `ssh -p 2200 esteban@frida.inovacaosistemas.com.br`

--- a/gateway/app/api/routes/control_ui.py
+++ b/gateway/app/api/routes/control_ui.py
@@ -1,0 +1,815 @@
+"""CodexBridge Control — the first server-rendered screens (issue #73 Stage 5).
+
+Four routes, on purpose only four: `GET /control` (fleet), `GET
+/control/nodes/{nodeId}` (node detail: capabilities/engines, discovered
+candidates, authorizations), and `GET /control/invite` (see its own section
+below — this one does not do what its name promises yet). Missions,
+Decisions, Audit and Settings are Stage 6; the epic (#73) lists them as
+non-goals for this cycle.
+
+## HTML in the gateway's own process, not a second deployable
+
+`gateway/app/main.py:oauth_authorize`/`oauth_authorize_submit` already answer
+this question for this codebase: a form is an `HTMLResponse` built from an
+f-string with `html.escape` at every interpolation, served from the same
+FastAPI app, no template engine dependency. This module follows that
+precedent exactly rather than introducing Jinja2 (a new dependency for one
+screen) or a second deployable (a build step, a second set of secrets, a
+second thing to keep in sync with the JSON contract). When the real Stage 5
+SPA arrives, it replaces this shell against the *same* `/api/v1/**` surface —
+that is why the shell stays this thin.
+
+## Reads are server-rendered; writes are `fetch()` against the real API
+
+Two different rules for two different things, and conflating them is the
+mistake this module is written to avoid:
+
+- **Reads** (the node list, one node's capabilities/engines, a page of
+  discovered candidates, the active authorizations on a node) are rendered
+  server-side by calling the *exact same* functions the JSON routes call —
+  `gateway.app.api.routes.nodes._node_dto`,
+  `gateway.app.api.routes.discovery._discovered_resource_dto`,
+  `gateway.app.api.routes.authorizations._authorization_dto`, `store.
+  list_nodes`/`get_node`/`list_discovered_resources_page`. Nothing here
+  recomputes health, capability, or pagination logic — it imports the one
+  definition and prints it as HTML instead of JSON. This is also why HTML
+  escaping is directly testable with plain `pytest` + `TestClient`, no
+  browser needed: the escaped text is in the response body the test already
+  reads.
+- **Writes** (Adopt, Deny, Grant, Revoke) are `fetch()` calls from inline
+  `<script>` against `POST /api/v1/discovered-resources/{id}/adopt|deny` and
+  `POST /api/v1/nodes/{nodeId}/projects/{projectId}/authorize|revoke` — the
+  brief's own instruction ("as telas chamam os mesmos endpoints JSON que
+  C1/C3/C4 já expõem"), and the only way a `403` on granting `modify`/
+  `deliver` (`permissions.is_allowed`'s second gate, see
+  `docs/control-plane.md` Stage 4) is the *real* one instead of a guess this
+  module would have to keep in sync by hand. A write never touches `store.py`
+  directly from here.
+
+## Authentication: HTTP Basic, re-verified per request
+
+`current_principal` (`gateway/app/api/auth.py`) reads `Authorization: Bearer
+<token>` — and a plain browser navigation (typing the URL, clicking a link)
+cannot attach a custom header. Gating `GET /control` on that exact dependency
+the way `/api/v1/nodes` is gated would make the page unreachable by a normal
+browser, which cannot be "the panel the operator opens on `frida`" — so this
+had to be something else, and the brief allows exactly the honest fallback:
+"se a única forma honesta hoje for exigir um token colado, diga isso em vez
+de inventar sessão de cookie nova."
+
+What is used instead is **HTTP Basic**, verified on *every* request by the
+same `gateway.app.core.users.authenticate_async` that
+`oauth_authorize_submit` and `POST /api/v1/auth/sign-in` already call — the
+identical constant-cost, enumeration-safe password check, not a second one.
+Basic is the one standard HTTP credential a browser resends automatically on
+every subsequent request to this origin (plain link clicks, pagination,
+reloads) without any server-side session state, any cookie, or any token
+embedded in a URL or a hidden form field. It needs no CSRF defence — unlike a
+cookie session, nothing rides along on a *forged* cross-origin request,
+because the browser only ever attaches Basic credentials to requests to the
+realm it cached them against, which this deployment's operator establishes by
+typing a password into the browser's own native prompt (triggered by this
+module's `401` + `WWW-Authenticate: Basic`), never into a form this module
+renders. That is the whole reason a cookie session was rejected here: it
+would have been a *second* credential mechanism, with its own expiry and its
+own forgery surface, to keep correct forever next to the one the JSON surface
+already has — the exact shape `docs/napkin-lessons.md` keeps warning about.
+
+Every route in this module is therefore gated by `_control_principal`, which:
+
+1. parses `Authorization: Basic base64(user:pass)`, challenging with `401` +
+   `WWW-Authenticate` when it is absent or malformed — the browser's native
+   dialog, no HTML form of this module's own;
+2. calls `authenticate_async` against it — `401` again on a wrong password,
+   with the same opaque message every failed credential gets elsewhere on
+   this codebase;
+3. derives an `AuthenticatedPrincipal` from the resulting `GatewayUser` —
+   same shape `current_principal`/`oauth_authorize_submit` build, `auth_
+   scheme="basic"` so it is distinguishable if it ever needs to be;
+4. calls `permissions.is_allowed(principal, action)` — the *same* catalogue
+   `require_action` enforces on `/api/v1/**` — and refuses with an explicit
+   `403` naming the action, never a silent redirect or a blank page. This is
+   what "uma tela que recusa na porta" means in practice here: the refusal
+   happens before a single row of fleet data is read, not after a `fetch()`
+   already reached the browser and failed.
+
+Cost: `authenticate_async` is ~200-600ms of deliberate PBKDF2, and Basic
+re-supplies it on *every* click, including "next page". That is the price of
+"no server-side session state at all" and is judged acceptable for a
+single-operator admin console; `gateway/app/main.py`'s rate limiter is
+applied to this whole router in `gateway/app/main.py` (same bucket rule as
+`POST /oauth/authorize`) precisely because that repeated derivation is also
+the cheapest lever a guesser has against this surface.
+
+**One thing Basic does *not* solve**: the write actions still need a
+`Authorization: Bearer` token, because that is the only scheme `/api/v1/**`
+accepts and this PR is not the place to teach it a second one (out of scope,
+and the mobile/ChatGPT clients depend on Bearer meaning exactly what it means
+today). So `GET /control/nodes/{nodeId}` — the one screen with buttons that
+write — mints one ordinary, short-lived OAuth access token per render, via
+the *same* `store.create_oauth_access_token` call `POST /api/v1/auth/sign-in`
+uses, scoped the same way (`principal.scopes ∩ settings.oauth_scopes()`),
+landing in the *same* `oauth_access_tokens` table `current_principal` reads.
+It is embedded once, inline, in a `<script>` tag for this page's own
+`fetch()` calls — never in a URL, a query string, a log line, or
+`audit_events` (minting it calls no `record_event`, matching every other
+*read* path in this codebase, which is audited by nothing; only the writes
+this token goes on to make are audited, by the routes it calls). A fresh page
+load mints a fresh token; nothing here reuses or persists one.
+
+## `resourcePath`/`rootPath`: displayed, never leaked sideways
+
+`docs/api/README.md` ("Fields that must never ship") and `docs/control-
+plane.md` ("resource_key é dado sensível") name exactly one standing
+exception for a server filesystem path: the administrative discovery surface
+— `GET /api/v1/nodes/{nodeId}/discovered-resources` and the `adopt`/`deny`
+responses. This module's node-detail screen is that same authorized surface,
+rendered as HTML instead of JSON, so the path *may* appear in the escaped
+table body an operator with `nodes.discoveries.read` is looking at. It must
+not appear anywhere else this module writes: never in a `<title>`, never in a
+query string (pagination here cursors on the resource's opaque `id`, exactly
+like `routes/discovery.py`'s own cursor, never on the path), and this module
+calls no logger at any level — there is nothing for it to leak into.
+
+## `/control/invite`: what this screen cannot do yet, and why
+
+The brief for this PR describes `GET /control/invite` calling `POST
+/api/v1/nodes/invite` and printing a ready-to-copy `scripts/enroll_node.py`
+command. Neither exists in this codebase: `gateway/app/api/routes/nodes.py`
+serves only `GET /nodes` and `GET /nodes/{nodeId}`, no route registers a node
+or mints it a `machine_token`; `scripts/` holds `discover_projects.py`,
+`register_projects.py`, `apply_migrations.py`, `install.sh`, `diagnose.sh` —
+no `enroll_node.py`. `docs/project-onboarding.md`'s own "Schema de executor"
+section confirms this is by design so far: a node is registered today by
+hand-editing `registry.json` (`machine_token` included) on both sides and
+restarting the gateway, the same two-file, two-machine procedure that page
+documents in full for projects.
+
+Building the described screen would mean inventing, inside this UI PR, the
+one thing the brief itself forbids inventing here: real backend business
+logic (a token-minting endpoint with its own security posture — hashing at
+rest, an audit trail, a revocation story — and a new script) with no existing
+API to front. "Se uma tela precisa de um dado que a API não dá, a resposta
+certa é parar e relatar, não calcular no template" — this is exactly that
+case, at the level of an entire endpoint rather than one field. So this route
+renders an honest explanation instead of a form that posts to nothing: it
+names the missing endpoint and script by their exact expected names, and
+points at `docs/project-onboarding.md`'s real, current procedure. See this
+PR's own final report for the recommendation (a follow-up Stage 5 PR to
+design and build the invite endpoint) rather than silently shipping a button
+that 404s.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import html
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.app.api import pagination, permissions
+from gateway.app.api.errors import ApiError
+from gateway.app.api.permissions import Action
+from gateway.app.api.routes.authorizations import _authorization_dto
+from gateway.app.api.routes.discovery import _discovered_resource_dto
+from gateway.app.api.routes.nodes import _node_dto
+from gateway.app.core.config import settings
+from gateway.app.core.oauth import expires_in, generate_access_token
+from gateway.app.core.users import AuthenticatedPrincipal, authenticate_async
+from gateway.app.db.session import get_session
+from gateway.app.services import store
+from shared.protocol import Capability
+
+
+router = APIRouter(prefix="/control")
+
+# The client label recorded on a token this module mints — mirrors `routes/
+# auth.py`'s `MOBILE_CLIENT_ID`. Fixed, never taken from the request, for the
+# same reason: this is a first-party surface, and a caller-supplied label
+# would let a forged Basic credential (already rejected before this point,
+# but defence in depth costs nothing here) mislabel its own audit trail.
+CONTROL_CLIENT_ID = "codexbridge-control"
+
+# Rows per HTML page of discovered candidates. Smaller than `pagination.
+# DEFAULT_LIMIT` (50) on purpose -- an operator reading a table, not a client
+# paging through JSON, and `docs/control-plane.md` cites 247 real candidates
+# from one scan, so this list is worth keeping short per screen.
+CANDIDATES_PAGE_SIZE = 20
+
+
+# ---------------------------------------------------------------------------
+# Authentication and authorization -- see the module docstring for the design
+# ---------------------------------------------------------------------------
+
+
+def _basic_challenge(message: str = "Sign in with a CodexBridge account.") -> HTTPException:
+    return HTTPException(
+        status_code=401,
+        detail=message,
+        headers={"WWW-Authenticate": 'Basic realm="codexbridge-control"'},
+    )
+
+
+def _parse_basic_credentials(request: Request) -> tuple[str, str] | None:
+    """`(username, password)` from a well-formed `Authorization: Basic` header, else None.
+
+    Never raises: a malformed header is indistinguishable from an absent one
+    to the caller of this function, which always turns None into the same
+    `401` challenge `_control_principal` raises for "no credential at all".
+    """
+    header = request.headers.get("Authorization")
+    if not header or not header.startswith("Basic "):
+        return None
+    try:
+        decoded = base64.b64decode(header.removeprefix("Basic ").strip(), validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+    if ":" not in decoded:
+        return None
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+async def _control_principal(request: Request, action: Action) -> AuthenticatedPrincipal:
+    """Resolve, verify and authorize the operator for one `/control` request.
+
+    Raises the `401`/`403` this module's docstring describes; never returns a
+    principal that has not cleared `permissions.is_allowed(principal,
+    action)`.
+    """
+    credentials = _parse_basic_credentials(request)
+    if credentials is None:
+        raise _basic_challenge()
+    username, password = credentials
+    outcome = await authenticate_async(settings.user_registry_file, username, password)
+    if not outcome.ok or outcome.user is None:
+        raise _basic_challenge("Invalid username or password.")
+    user = outcome.user
+    principal = AuthenticatedPrincipal(
+        user_id=user.user_id,
+        email=user.email,
+        roles=user.roles,
+        allowed_projects=user.allowed_projects,
+        scopes=user.scopes,
+        can_approve_sensitive=user.can_approve_sensitive,
+        auth_scheme="basic",
+    )
+    if not permissions.is_allowed(principal, action):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Signed in as {user.user_id!r}, but this screen requires the "
+                f"{action.name!r} permission (scope {action.scope}). "
+                "GET /api/v1/auth/me reports what this account may do."
+            ),
+        )
+    return principal
+
+
+async def _mint_page_token(session: AsyncSession, principal: AuthenticatedPrincipal) -> str:
+    """A fresh, ordinary Bearer token for one render's own `fetch()` calls.
+
+    See the module docstring, "Authentication" -- same table, same scope cap,
+    as `POST /api/v1/auth/sign-in`. Commits: the token must be visible to the
+    very next request (this page's own `fetch()`, milliseconds later), and
+    this module holds no other reason to defer the commit.
+    """
+    token = generate_access_token()
+    scopes = sorted(set(principal.scopes) & settings.oauth_scopes())
+    await store.create_oauth_access_token(
+        session,
+        token=token,
+        client_id=CONTROL_CLIENT_ID,
+        user_id=principal.user_id,
+        scopes=scopes,
+        expires_at=expires_in(settings.oauth_access_token_ttl_seconds),
+    )
+    await session.commit()
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Rendering — plain f-strings + html.escape, exactly `oauth_authorize`'s idiom
+# ---------------------------------------------------------------------------
+
+
+def _e(value: object) -> str:
+    """`html.escape`, tolerant of None -- the one interpolation function this
+
+    module uses for every value that did not originate as a literal in this
+    file. A `display_name`, a `resourcePath`, a `health_reason` are all text
+    someone else wrote (an operator, a node's own hostname probe); none of
+    them may become markup.
+    """
+    if value is None:
+        return ""
+    return html.escape(str(value))
+
+
+_BASE_CSS = """
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; max-width: 64rem;
+       margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+h1 { font-size: 1.5rem; }
+h2 { font-size: 1.15rem; margin-top: 2rem; border-bottom: 1px solid #ddd; padding-bottom: .25rem; }
+table { border-collapse: collapse; width: 100%; margin: .75rem 0; }
+th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid #eee; font-size: .92rem; }
+th { color: #555; font-weight: 600; }
+code { background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; font-size: .88rem; }
+.tag { display: inline-block; padding: .1rem .5rem; border-radius: 999px; font-size: .8rem; }
+.tag-ok { background: #dcfce7; color: #166534; }
+.tag-degraded { background: #fef9c3; color: #854d0e; }
+.tag-offline { background: #fee2e2; color: #991b1b; }
+.tag-unknown { background: #e5e7eb; color: #374151; }
+.hint { color: #555; font-size: .92rem; }
+.error { color: #b91c1c; font-size: .9rem; margin: .25rem 0; }
+.notice { background: #eff6ff; border: 1px solid #bfdbfe; padding: .75rem 1rem; border-radius: 6px; }
+.warn { background: #fffbeb; border: 1px solid #fde68a; padding: .5rem .75rem; border-radius: 6px; font-size: .88rem; }
+form.inline { display: inline; }
+fieldset { border: 1px solid #ddd; border-radius: 6px; margin: .5rem 0; }
+nav a { margin-right: 1rem; }
+""".strip()
+
+# The node-detail page's write behaviour: Adopt/Deny/Grant/Revoke, each a
+# `fetch()` POST against the real `/api/v1/**` routes C1/C3/C4 already ship
+# (see the module docstring, "Reads are server-rendered; writes are
+# fetch()"). A plain string, never an f-string: every dynamic value it needs
+# (`CB_TOKEN`, `CB_NODE_ID`) is declared as a `const` by the two lines the
+# caller prepends via `json.dumps` (JS-literal-safe, unlike Python's `!r` —
+# see `_candidate_row`'s docstring on why operator-supplied text is never
+# spliced into a JS-call string), and every other dynamic value
+# (`resourceId`, `projectId`) is read back from a form's `dataset` — set via
+# HTML-escaped `data-*` attributes, never through inline `onsubmit=`.
+_CONTROL_JS = """
+function reportError(id, err) {
+  const el = document.getElementById(id);
+  if (el) { el.textContent = err; }
+}
+async function callApi(path, body) {
+  const resp = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "Authorization": "Bearer " + CB_TOKEN },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const data = await resp.json().catch(function () { return {}; });
+  if (!resp.ok) {
+    throw new Error((data && data.message) || (resp.status + " " + resp.statusText));
+  }
+  return data;
+}
+document.querySelectorAll(".control-adopt").forEach(function (form) {
+  form.addEventListener("submit", async function (evt) {
+    evt.preventDefault();
+    const resourceId = form.dataset.resourceId;
+    const caps = Array.from(form.querySelectorAll("input[name=cap]:checked")).map(function (el) { return el.value; });
+    const projectId = form.projectId.value.trim();
+    const newId = form.newProjectId.value.trim();
+    const newName = form.newProjectName.value.trim();
+    const body = { grantCapabilities: caps };
+    if (projectId) { body.projectId = projectId; }
+    else if (newId && newName) { body.newProject = { projectId: newId, name: newName }; }
+    else {
+      reportError("err-" + resourceId, "Provide an existing projectId or a new project id+name.");
+      return;
+    }
+    try {
+      await callApi("/api/v1/discovered-resources/" + encodeURIComponent(resourceId) + "/adopt", body);
+      location.reload();
+    } catch (e) { reportError("err-" + resourceId, e.message); }
+  });
+});
+document.querySelectorAll(".control-deny").forEach(function (form) {
+  form.addEventListener("submit", async function (evt) {
+    evt.preventDefault();
+    const resourceId = form.dataset.resourceId;
+    try {
+      await callApi("/api/v1/discovered-resources/" + encodeURIComponent(resourceId) + "/deny", undefined);
+      location.reload();
+    } catch (e) { reportError("err-" + resourceId, e.message); }
+  });
+});
+document.querySelectorAll(".control-grant").forEach(function (form) {
+  form.addEventListener("submit", async function (evt) {
+    evt.preventDefault();
+    const projectId = form.dataset.projectId;
+    const caps = Array.from(form.querySelectorAll("input[name=cap]:checked")).map(function (el) { return el.value; });
+    try {
+      await callApi(
+        "/api/v1/nodes/" + encodeURIComponent(CB_NODE_ID) + "/projects/" + encodeURIComponent(projectId) + "/authorize",
+        { capabilities: caps }
+      );
+      location.reload();
+    } catch (e) { reportError("err-auth-" + projectId, e.message); }
+  });
+});
+document.querySelectorAll(".control-revoke").forEach(function (form) {
+  form.addEventListener("submit", async function (evt) {
+    evt.preventDefault();
+    const projectId = form.dataset.projectId;
+    try {
+      await callApi(
+        "/api/v1/nodes/" + encodeURIComponent(CB_NODE_ID) + "/projects/" + encodeURIComponent(projectId) + "/revoke",
+        undefined
+      );
+      location.reload();
+    } catch (e) { reportError("err-auth-" + projectId, e.message); }
+  });
+});
+""".strip()
+
+
+def _health_tag(health: str) -> str:
+    return f'<span class="tag tag-{_e(health)}">{_e(health)}</span>'
+
+
+def _capability_checkboxes(*, checked: frozenset[Capability] = frozenset()) -> str:
+    """One `<label><input type=checkbox name=cap value=...>...` per `Capability`.
+
+    Reads the vocabulary from `shared.protocol.Capability` — the same
+    derived-from-`TaskMode` enum `CAPABILITY_MODES`/`AUTO_AUTHORIZABLE_
+    CAPABILITIES` already use — rather than four literal strings copy-pasted
+    at each call site, so a fifth capability (should one ever exist) shows up
+    here without a second place to remember to edit. Nothing here is
+    `disabled`: an operator may always uncheck a suggested default (e.g.
+    adopting with no grant at all, leaving a candidate `ADOPTED` but not yet
+    `AUTHORIZED` — see `docs/control-plane.md`, "Adoption does not
+    automatically grant every operational capability").
+    """
+    boxes = []
+    for capability in Capability:
+        attr = " checked" if capability in checked else ""
+        boxes.append(
+            f'<label><input type="checkbox" name="cap" value="{capability.value}"{attr} /> {capability.value}</label>'
+        )
+    return "\n      ".join(boxes)
+
+
+def _page(title: str, body: str) -> HTMLResponse:
+    """The one page skeleton every `/control` route renders through.
+
+    `title` must never carry `resourcePath`/`rootPath` -- see the module
+    docstring's "resourcePath/rootPath" section. Every caller in this module
+    passes a title built from static strings and, at most, a node's
+    `displayName`/id, which are not in that sensitive category.
+    """
+    return HTMLResponse(
+        f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{_e(title)}</title>
+    <style>{_BASE_CSS}</style>
+  </head>
+  <body>
+    <nav><a href="/control">Fleet</a><a href="/control/invite">Invite a node</a></nav>
+    {body}
+  </body>
+</html>"""
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /control — fleet list
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_class=HTMLResponse)
+async def control_home(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    principal = await _control_principal(request, permissions.NODES_READ)
+    rows = await store.list_nodes(session)
+
+    body_rows = []
+    for node, executor in rows:
+        dto = _node_dto(node, executor)
+        pending = await store.count_decidable_discovered_resources(session, node.id)
+        admission = "enabled" if dto["enabled"] else "disabled"
+        stale_note = ' <span class="hint">(stale)</span>' if dto["inventoryStale"] else ""
+        body_rows.append(
+            f"""<tr>
+  <td><a href="/control/nodes/{_e(node.id)}">{_e(dto['displayName'])}</a></td>
+  <td>{_health_tag(dto['health'])}{stale_note}</td>
+  <td>{_e(admission)}</td>
+  <td>{pending if pending else '&mdash;'}</td>
+  <td>{_e(dto['agentVersion']) or '&mdash;'}</td>
+</tr>"""
+        )
+
+    table = (
+        "<table><thead><tr><th>Node</th><th>Health</th><th>Admission</th>"
+        "<th>Pending candidates</th><th>Agent version</th></tr></thead>"
+        f"<tbody>{''.join(body_rows) or '<tr><td colspan=5>No Bridge Nodes registered.</td></tr>'}</tbody></table>"
+    )
+
+    body = f"""
+    <h1>CodexBridge Control &middot; Fleet</h1>
+    <p class="hint">Signed in as {_e(principal.user_id)}. {len(rows)} node(s).</p>
+    {table}
+    """
+    return _page("CodexBridge Control", body)
+
+
+# ---------------------------------------------------------------------------
+# GET /control/nodes/{node_id} — node detail
+# ---------------------------------------------------------------------------
+
+
+def _capabilities_section(dto: dict) -> str:
+    caps = ", ".join(_e(c) for c in dto.get("capabilities") or []) or "&mdash;"
+    engine_rows = []
+    for engine in dto.get("engines") or []:
+        engine_rows.append(
+            f"""<tr>
+  <td>{_e(engine.get('engine'))}</td>
+  <td>{'yes' if engine.get('implemented') else 'no'}</td>
+  <td>{'yes' if engine.get('available') else 'no'}</td>
+  <td>{_e(engine.get('version')) or '&mdash;'}</td>
+  <td>{_e(engine.get('detail')) or '&mdash;'}</td>
+</tr>"""
+        )
+    engines_table = (
+        "<table><thead><tr><th>Engine</th><th>Implemented</th><th>Available</th>"
+        "<th>Version</th><th>Detail</th></tr></thead>"
+        f"<tbody>{''.join(engine_rows) or '<tr><td colspan=5>No engines reported.</td></tr>'}</tbody></table>"
+    )
+    return f"""
+    <h2>Capabilities &amp; engines</h2>
+    <p>Announced capabilities: {caps}</p>
+    <p class="hint">OS: {_e(dto.get('os')) or '&mdash;'} &middot; Arch: {_e(dto.get('arch')) or '&mdash;'}
+       &middot; Max concurrent tasks: {_e(dto.get('maxConcurrentTasks')) or '&mdash;'}
+       &middot; Discovery roots configured: {_e(dto.get('discoveryRootCount')) if dto.get('discoveryRootCount') is not None else '&mdash;'}</p>
+    {engines_table}
+    """
+
+
+def _candidate_row(node_id: str, dto: dict, *, decidable: bool) -> str:
+    """One `<tr>` for the candidates table.
+
+    Every dynamic value a form needs to submit later (`resourceId`) travels as
+    an `data-*` attribute, HTML-escaped through `_e` like everything else on
+    this row -- never spliced into an inline `onsubmit="...(...)"` JS-call
+    string. `project_id`/`resourceId` are both operator- or node-supplied text
+    with no character allowlist enforced upstream (`shared.protocol.
+    NewProjectSpec.project_id` is a bare length-bounded `str`), so building a
+    JS argument list by Python string interpolation would be exactly the
+    injection `_e` exists to close for HTML text -- `data-*` plus a delegated
+    listener (`_CONTROL_JS` below) reads the value back through `dataset`, which
+    never re-parses it as code.
+    """
+    actions = ""
+    if decidable:
+        actions = f"""
+    <form class="control-adopt" data-resource-id="{_e(dto['id'])}">
+      <input type="text" name="projectId" placeholder="existing projectId (optional)" size="16" />
+      <input type="text" name="newProjectId" placeholder="new projectId" size="14" />
+      <input type="text" name="newProjectName" placeholder="new project name" size="16" />
+      {_capability_checkboxes(checked=frozenset({Capability.READ, Capability.TEST}))}
+      <button type="submit">Adopt</button>
+    </form>
+    <form class="control-deny" data-resource-id="{_e(dto['id'])}">
+      <button type="submit">Deny</button>
+    </form>
+    <div class="error" id="err-{_e(dto['id'])}"></div>
+    """
+    return f"""<tr>
+  <td><code>{_e(dto['id'])}</code></td>
+  <td>{_e(dto['state'])}</td>
+  <td>{_e(dto['suggestedName']) or '&mdash;'}</td>
+  <td><code>{_e(dto['resourcePath'])}</code></td>
+  <td><code>{_e(dto['rootPath'])}</code></td>
+  <td>{_e(dto['remoteUrl']) or '&mdash;'}</td>
+  <td>{actions}</td>
+</tr>"""
+
+
+def _authorization_section(
+    node_id: str,
+    *,
+    project_ids: list[str],
+    active: dict[str, dict],
+    names: dict[str, str],
+    can_manage: bool,
+) -> str:
+    """The authorization table for one node.
+
+    `project_ids` is every project this node has an adoption or an active
+    authorization for -- not just `active.keys()`. An `ADOPTED` project with
+    no capability grant yet has no `project_authorizations` row at all
+    (`docs/control-plane.md`, "Adoption does not automatically grant every
+    operational capability"), and that is exactly the project an operator
+    most needs a Grant form for; showing only rows that already have one
+    would hide the one action this section exists to offer.
+
+    Injection note: see `_candidate_row`'s docstring -- `project_id` is
+    operator-chosen text with no character allowlist, so it travels as an
+    escaped `data-project-id` attribute, never spliced into an inline
+    `onsubmit="...(...)"` call.
+    """
+    if not project_ids:
+        rows = "<tr><td colspan=4>No project has been adopted or authorized on this node yet.</td></tr>"
+    else:
+        rendered = []
+        for project_id in project_ids:
+            row = active.get(project_id)
+            caps = ", ".join(_e(c) for c in (row or {}).get("capabilities") or []) or "&mdash;"
+            granted_by = _e((row or {}).get("grantedBy")) or "&mdash;"
+            manage_controls = ""
+            if can_manage:
+                revoke_button = (
+                    f'<form class="control-revoke" data-project-id="{_e(project_id)}">'
+                    '<button type="submit">Revoke</button></form>'
+                    if row is not None
+                    else ""
+                )
+                manage_controls = f"""
+        <form class="control-grant" data-project-id="{_e(project_id)}">
+          {_capability_checkboxes()}
+          <button type="submit">Grant</button>
+        </form>
+        {revoke_button}
+        <div class="error" id="err-auth-{_e(project_id)}"></div>
+        """
+            rendered.append(
+                f"""<tr>
+  <td>{_e(names.get(project_id, project_id))} <span class="hint">({_e(project_id)})</span></td>
+  <td>{caps}</td>
+  <td>{granted_by}</td>
+  <td>{manage_controls}</td>
+</tr>"""
+            )
+        rows = "".join(rendered)
+
+    note = ""
+    if not can_manage:
+        note = (
+            '<p class="warn">This account can view authorizations but lacks '
+            "<code>nodes.authorizations.manage</code> — Grant/Revoke controls are hidden.</p>"
+        )
+    warn = (
+        '<p class="warn">Granting <code>modify</code> or <code>deliver</code> additionally requires '
+        "<code>can_approve_sensitive</code> or the <code>admin</code> role — a request without either "
+        "gets a real <code>403</code> from the server below, shown as reported, never a generic error.</p>"
+    )
+    return f"""
+    <h2>Authorizations</h2>
+    {note}
+    {warn}
+    <table><thead><tr><th>Project</th><th>Active capabilities</th><th>Granted by</th><th>Actions</th></tr></thead>
+    <tbody>{rows}</tbody></table>
+    """
+
+
+@router.get("/nodes/{node_id}", response_class=HTMLResponse)
+async def control_node_detail(
+    node_id: str,
+    request: Request,
+    cursor: str | None = Query(default=None),
+    state: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    principal = await _control_principal(request, permissions.NODES_READ)
+    row = await store.get_node(session, node_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="No such node.")
+    node, executor = row
+    dto = _node_dto(node, executor)
+
+    can_view_candidates = permissions.is_allowed(principal, permissions.NODES_DISCOVERIES_READ)
+    can_decide = permissions.is_allowed(principal, permissions.NODES_DISCOVERIES_DECIDE)
+    can_manage_auth = permissions.is_allowed(principal, permissions.NODES_AUTHORIZATIONS_MANAGE)
+
+    token = ""
+    if can_decide or can_manage_auth:
+        token = await _mint_page_token(session, principal)
+
+    candidates_section = ""
+    if can_view_candidates:
+        scope = pagination.scope_digest(f"/control/nodes/{node_id}/discovered-resources", {"state": state})
+        after_id = None
+        if cursor:
+            try:
+                after_id = pagination.decode_cursor(scope, cursor, expect={"id": str})["id"]
+            except ApiError as exc:
+                raise HTTPException(status_code=400, detail=exc.message) from exc
+        candidate_rows = await store.list_discovered_resources_page(
+            session, node_id, state=state, after=after_id, limit=CANDIDATES_PAGE_SIZE
+        )
+        page, info = pagination.paginate(
+            candidate_rows, limit=CANDIDATES_PAGE_SIZE, scope=scope, position_of=lambda r: {"id": r.id}
+        )
+        dtos = [_discovered_resource_dto(r) for r in page]
+        table_rows = "".join(
+            _candidate_row(node_id, d, decidable=can_decide and d["state"] in {"discovered", "stale"})
+            for d in dtos
+        )
+        next_link = ""
+        if info["hasMore"] and info["nextCursor"]:
+            state_qs = f"&state={_e(state)}" if state else ""
+            next_link = (
+                f'<p><a href="/control/nodes/{_e(node_id)}?cursor={_e(info["nextCursor"])}{state_qs}">'
+                "Next page &rarr;</a></p>"
+            )
+        candidates_section = f"""
+        <h2>Discovered candidates</h2>
+        <table><thead><tr><th>Id</th><th>State</th><th>Suggested name</th><th>Resource path</th>
+        <th>Root path</th><th>Remote</th><th>Actions</th></tr></thead>
+        <tbody>{table_rows or '<tr><td colspan=7>No discovered candidates.</td></tr>'}</tbody></table>
+        {next_link}
+        """
+        if not can_decide:
+            candidates_section += (
+                '<p class="warn">This account can view candidates but lacks '
+                "<code>nodes.discoveries.decide</code> — Adopt/Deny controls are hidden.</p>"
+            )
+    else:
+        candidates_section = (
+            '<h2>Discovered candidates</h2><p class="warn">This account lacks '
+            "<code>nodes.discoveries.read</code> — candidates are hidden.</p>"
+        )
+
+    authorization_section = ""
+    if can_view_candidates:
+        # Every project this node has an adoption or an active authorization
+        # for: the candidates just fetched contribute adopted-but-maybe-not-
+        # yet-authorized project ids (an `ADOPTED` row with no capability
+        # grant has no `project_authorizations` row at all -- see
+        # `_authorization_section`'s own docstring), and `list_active_
+        # authorizations_for_node` contributes the source of truth for what
+        # is actually granted. Neither alone is the full set an operator
+        # needs to see.
+        adopted_ids = {d["projectId"] for d in dtos if d.get("projectId")}
+        active_rows = await store.list_active_authorizations_for_node(session, node_id)
+        active = {row.project_id: _authorization_dto(row) for row in active_rows}
+        project_ids = sorted(adopted_ids | set(active.keys()))
+        names = await store.get_project_names(session, project_ids)
+        authorization_section = _authorization_section(
+            node_id, project_ids=project_ids, active=active, names=names, can_manage=can_manage_auth
+        )
+    else:
+        authorization_section = (
+            '<h2>Authorizations</h2><p class="warn">This account lacks '
+            "<code>nodes.discoveries.read</code> — authorizations are hidden.</p>"
+        )
+
+    script = ""
+    if token:
+        # `json.dumps`, not Python's `!r`: `token` is server-generated and
+        # already URL-safe, but `node_id` is operator-chosen text with no
+        # character allowlist (see `_candidate_row`'s docstring) -- `json.
+        # dumps` is the one function here guaranteed to produce a valid,
+        # correctly-escaped JS string literal for either.
+        script = (
+            "<script>\n"
+            f"const CB_TOKEN = {json.dumps(token)};\n"
+            f"const CB_NODE_ID = {json.dumps(node_id)};\n"
+            f"{_CONTROL_JS}\n"
+            "</script>"
+        )
+
+    body = f"""
+    <h1>Node: {_e(dto['displayName'])}</h1>
+    <p class="hint">{_health_tag(dto['health'])} &middot; id <code>{_e(node.id)}</code>
+    {' &middot; ' + _e(dto['healthReason']) if dto['healthReason'] else ''}</p>
+    {_capabilities_section(dto)}
+    {candidates_section}
+    {authorization_section}
+    {script}
+    """
+    return _page(f"CodexBridge Control · {dto['displayName']}", body)
+
+
+# ---------------------------------------------------------------------------
+# GET /control/invite — see module docstring, "/control/invite"
+# ---------------------------------------------------------------------------
+
+
+@router.get("/invite", response_class=HTMLResponse)
+async def control_invite(
+    request: Request,
+) -> HTMLResponse:
+    await _control_principal(request, permissions.NODES_READ)
+    body = """
+    <h1>Invite a node</h1>
+    <div class="notice">
+      <p><strong>Not available yet.</strong> This build has no
+      <code>POST /api/v1/nodes/invite</code> endpoint and no
+      <code>scripts/enroll_node.py</code> — this screen cannot mint a
+      one-time enrollment token because nothing in the gateway generates one.</p>
+      <p>Registering a Bridge Node today is a manual, two-machine procedure:
+      add the node's <code>machine_token</code> and <code>allowed_projects</code>
+      to <code>registry.json</code> on the gateway host, add the matching
+      project entries to the executor's own allowlist, and restart both
+      processes. The full walkthrough is
+      <code>docs/project-onboarding.md</code>, "Schema de executor".</p>
+      <p>Building the flow this screen implies — a token-issuing endpoint with
+      its own security posture (hashing at rest, an audit trail, revocation)
+      and an <code>enroll_node.py</code> to consume it — is real backend work
+      belonging to its own PR, not something this screen can fabricate.</p>
+    </div>
+    """
+    return _page("CodexBridge Control · Invite a node", body)

--- a/gateway/app/api/routes/control_ui.py
+++ b/gateway/app/api/routes/control_ui.py
@@ -796,20 +796,21 @@ async def control_invite(
     body = """
     <h1>Invite a node</h1>
     <div class="notice">
-      <p><strong>Not available yet.</strong> This build has no
-      <code>POST /api/v1/nodes/invite</code> endpoint and no
-      <code>scripts/enroll_node.py</code> — this screen cannot mint a
-      one-time enrollment token because nothing in the gateway generates one.</p>
-      <p>Registering a Bridge Node today is a manual, two-machine procedure:
-      add the node's <code>machine_token</code> and <code>allowed_projects</code>
-      to <code>registry.json</code> on the gateway host, add the matching
-      project entries to the executor's own allowlist, and restart both
-      processes. The full walkthrough is
+      <p><strong>Not available yet on this build.</strong> This screen would
+      call <code>POST /api/v1/nodes/invite</code> and hand you a one-time
+      token plus a ready <code>scripts/enroll_node.py</code> command. Both
+      exist — they are issue #76's minimal cut — but they are not in this
+      build: they live on a branch this one was not cut from, so the endpoint
+      this page needs is genuinely absent from the process serving it.</p>
+      <p>This screen lights up once that work merges. Nothing here needs to be
+      designed or built again; the gap is which commits this build contains,
+      not a missing capability.</p>
+      <p>Until then, registering a Bridge Node is the manual, two-machine
+      procedure it has always been: add the node's <code>machine_token</code>
+      and <code>allowed_projects</code> to <code>registry.json</code> on the
+      gateway host, add the matching project entries to the executor's own
+      allowlist, and restart both processes —
       <code>docs/project-onboarding.md</code>, "Schema de executor".</p>
-      <p>Building the flow this screen implies — a token-issuing endpoint with
-      its own security posture (hashing at rest, an audit trail, revocation)
-      and an <code>enroll_node.py</code> to consume it — is real backend work
-      belonging to its own PR, not something this screen can fabricate.</p>
     </div>
     """
     return _page("CodexBridge Control · Invite a node", body)

--- a/gateway/app/main.py
+++ b/gateway/app/main.py
@@ -15,6 +15,7 @@ from gateway.app.api.rate_limit import RateLimitDependency, client_key
 from gateway.app.api.routes import auth as auth_routes
 from gateway.app.api.routes import decisions, missions, nodes as nodes_routes, probes, projects, sessions
 from gateway.app.api.routes import authorizations as authorizations_routes
+from gateway.app.api.routes import control_ui as control_ui_routes
 from gateway.app.api.routes import conversations as conversations_routes
 from gateway.app.api.routes import discovery as discovery_routes
 from gateway.app.api.routes import epics as epics_routes
@@ -164,6 +165,17 @@ app.include_router(discovery_routes.router, dependencies=[Depends(RateLimitDepen
 # own second gate (granting `modify`/`deliver` needs `can_approve_sensitive`
 # or admin) lives inside `permissions.is_allowed`, not here.
 app.include_router(authorizations_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
+
+# CodexBridge Control's first server-rendered screens (issue #73 Stage 5,
+# `gateway/app/api/routes/control_ui.py`). Rate-limited like every other
+# route that touches a password: `control_ui.py`'s own auth re-derives the
+# HTTP Basic credential's PBKDF2 hash on *every* request, including plain
+# navigation and pagination, for the same "close the enumeration oracle"
+# reason `POST /oauth/authorize` carries this dependency. `/control` is
+# deliberately NOT under `/api/v1` -- it is not part of the mobile contract
+# (`tests/contract/test_openapi_document.py`), the same way `/oauth/*` and
+# `/mcp` sit outside it.
+app.include_router(control_ui_routes.router, dependencies=[Depends(RateLimitDependency(rate_limiter))])
 
 
 def oauth_www_authenticate_header() -> str:

--- a/gateway/app/services/store.py
+++ b/gateway/app/services/store.py
@@ -1398,6 +1398,70 @@ async def get_node(session: AsyncSession, node_id: str) -> tuple[NodeModel, Exec
     return node, executor
 
 
+async def count_decidable_discovered_resources(session: AsyncSession, node_id: str) -> int:
+    """How many of `node_id`'s discovered resources are awaiting an operator
+
+    decision right now -- issue #73 Stage 5 (CodexBridge Control), the
+    fleet list's "candidates pending decision" count. Reuses
+    `DECIDABLE_DISCOVERY_STATES` (`discovery_types.py`), the one place
+    "pending" is already defined for `adopt`/`deny` -- a second, ad hoc
+    definition in the UI layer is exactly the template-side recomputation
+    `docs/control-plane.md` and this PR's own brief warn against. A single
+    `COUNT`, not a fetch-and-len: the fleet list renders one row per node and
+    cannot afford `N` full row fetches to show `N` badges.
+    """
+    result = await session.execute(
+        select(func.count())
+        .select_from(DiscoveredResourceModel)
+        .where(
+            DiscoveredResourceModel.node_id == node_id,
+            DiscoveredResourceModel.state.in_(DECIDABLE_DISCOVERY_STATES),
+        )
+    )
+    return int(result.scalar_one())
+
+
+async def list_active_authorizations_for_node(
+    session: AsyncSession, node_id: str
+) -> list[ProjectAuthorizationModel]:
+    """Every non-revoked `project_authorizations` row for `node_id`.
+
+    Display-only, for the Control node-detail screen's authorization section
+    (issue #73 Stage 5): an operator deciding whether to grant or revoke a
+    capability needs to see what is granted today, the same way
+    `effective_task_modes` reads this table to decide what a dispatch may do
+    -- this is the read half of that table, never a second writer. Ordered by
+    `project_id` so repeated renders of the same node produce a stable list.
+    """
+    result = await session.execute(
+        select(ProjectAuthorizationModel)
+        .where(
+            ProjectAuthorizationModel.node_id == node_id,
+            ProjectAuthorizationModel.revoked_at.is_(None),
+        )
+        .order_by(ProjectAuthorizationModel.project_id)
+    )
+    return list(result.scalars().all())
+
+
+async def get_project_names(session: AsyncSession, project_ids: list[str]) -> dict[str, str]:
+    """`{project_id: name}` for the given ids, silently dropping unknown ones.
+
+    Display-only helper for Control (issue #73 Stage 5): a discovered
+    resource or an authorization row carries a `project_id`, never a name,
+    and `ProjectModel.name` is the only field of `ProjectModel` this surface
+    may show -- `ProjectModel.path` is the exact filesystem-path trap
+    `docs/api/README.md` ("Fields that must never ship") names, so this
+    selects `id`/`name` only, never the ORM row itself.
+    """
+    if not project_ids:
+        return {}
+    result = await session.execute(
+        select(ProjectModel.id, ProjectModel.name).where(ProjectModel.id.in_(project_ids))
+    )
+    return {row.id: row.name for row in result.all()}
+
+
 async def next_dispatchable_task(session: AsyncSession, executor_id: str) -> TaskModel | None:
     now = datetime.now(timezone.utc)
     result = await session.execute(

--- a/tests/integration/test_control_ui.py
+++ b/tests/integration/test_control_ui.py
@@ -400,12 +400,18 @@ async def test_control_invite_without_the_admin_scope_is_forbidden(api) -> None:
 async def test_control_invite_explains_the_gap_honestly(api) -> None:
     """Positive control for the previous two, and the point of this screen today:
 
-    it must say plainly that it cannot do what its name promises, never
-    present a form that posts to an endpoint this build does not serve.
+    it must say plainly that it cannot do what its name promises on THIS
+    build, and never present a form that posts to an endpoint this process
+    does not serve. It must also not claim the capability is unbuilt: the
+    endpoint and the script exist on the branch carrying issue #76's minimal
+    cut, and this page says so, because "missing from this build" and
+    "missing from this codebase" are different statements and only the first
+    one is true.
     """
     response = api.get("/control/invite", headers=basic("admin"))
     assert response.status_code == 200
-    assert "Not available yet" in response.text
+    assert "Not available yet on this build" in response.text
     assert "/api/v1/nodes/invite" in response.text
     assert "enroll_node.py" in response.text
+    assert "#76" in response.text
     assert "<form" not in response.text

--- a/tests/integration/test_control_ui.py
+++ b/tests/integration/test_control_ui.py
@@ -1,0 +1,411 @@
+"""CodexBridge Control's server-rendered screens — issue #73 Stage 5.
+
+WK-20260902-gh73-control-ui. Fixture idiom copied from `test_nodes.py`/
+`test_discovery_routes.py`: real FastAPI app, in-memory sqlite, `store.
+upsert_registry` seeding, rows inserted directly for the two models no seeding
+helper covers (`DiscoveredResourceModel`, `ProjectAuthorizationModel`).
+
+One thing this file's fixtures do differently from every sibling: authenticating
+against `gateway/app/api/routes/control_ui.py` means presenting a real HTTP
+Basic credential, verified by `authenticate_async` against an actual password
+hash — not an `Authorization: Bearer <token>` looked up in a pre-seeded table.
+`_hash` below is `tests/integration/test_auth.py`'s own helper, copied
+verbatim: cheap on purpose (1000 PBKDF2 iterations, not the production
+600000), because `verify_password` reads the cost from the hash itself.
+
+Weighted toward what this module's own docstring claims and this PR's brief
+requires: the door refuses before any fleet data renders (401/403, not a
+blank or half-loaded page), HTML escaping actually holds against a hostile
+`display_name`/project name/resource path, pagination actually walks a second
+page, and the invite screen honestly explains the gap instead of quietly
+mocking one up. Every negative case is paired with a positive control in this
+same file (`docs/napkin-lessons.md`, 2026-09-01).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.app.api.routes import control_ui as control_ui_routes
+from gateway.app.api.setup import install_api_conventions
+from gateway.app.db.base import Base
+from gateway.app.db.session import get_session
+from gateway.app.models.entities import (
+    AuditEventModel,
+    DiscoveredResourceModel,
+    ProjectAuthorizationModel,
+    ProjectModel,
+)
+from gateway.app.services import store
+from shared.protocol import DiscoveredState, ExecutorRegistration
+
+
+PASSWORD = "correct-horse-battery-staple"
+OTHER_PASSWORD = "not-the-password"
+
+
+def _hash(password: str, iterations: int = 1000) -> str:
+    """A registry hash, cheap on purpose — copied from `test_auth.py`'s own.
+
+    `verify_password` reads the iteration count out of the hash itself, so a
+    test fixture can cost a thousand iterations while production costs six
+    hundred thousand.
+    """
+    salt = b"codexbridge-test-salt"
+    digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations)
+    encode = lambda raw: base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")  # noqa: E731
+    return "$".join(("pbkdf2_sha256", str(iterations), encode(salt), encode(digest)))
+
+
+def basic(username: str, password: str = PASSWORD) -> dict:
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+@pytest.fixture
+def users_file(tmp_path):
+    path = tmp_path / "users.json"
+    path.write_text(
+        json.dumps(
+            {
+                "users": [
+                    {
+                        "user_id": "admin", "email": "admin@example.com",
+                        "password_hash": _hash(PASSWORD),
+                        "roles": ["admin"], "allowed_projects": [],
+                        "scopes": ["codexbridge.admin"], "can_approve_sensitive": False, "enabled": True,
+                    },
+                    {
+                        "user_id": "alice", "email": "alice@example.com",
+                        "password_hash": _hash(PASSWORD),
+                        "roles": [], "allowed_projects": ["p1"],
+                        "scopes": ["codexbridge.read"], "can_approve_sensitive": False, "enabled": True,
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+@pytest.fixture
+async def api(users_file, monkeypatch):
+    from gateway.app.core.config import settings
+
+    monkeypatch.setattr(settings, "user_registry_file", users_file)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with factory() as seed:
+        await store.upsert_registry(
+            seed,
+            executors=[
+                ExecutorRegistration(
+                    executor_id="E1", display_name="E1", machine_token="t",
+                    allowed_projects=[], enabled=True,
+                )
+            ],
+            projects=[],
+        )
+
+    app = FastAPI(openapi_url=None, docs_url=None, redoc_url=None)
+    install_api_conventions(app)
+    app.include_router(control_ui_routes.router)
+
+    async def override():
+        async with factory() as s:
+            yield s
+
+    app.dependency_overrides[get_session] = override
+
+    client = TestClient(app, raise_server_exceptions=False)
+    client.factory = factory  # type: ignore[attr-defined]
+    yield client
+    await engine.dispose()
+
+
+async def set_node_display_name(factory, node_id: str, display_name: str) -> None:
+    async with factory() as session:
+        from gateway.app.models.entities import NodeModel
+
+        node = await session.get(NodeModel, node_id)
+        node.display_name = display_name
+        await session.commit()
+
+
+async def seed_resource(
+    factory,
+    *,
+    resource_id: str,
+    node_id: str = "E1",
+    root_path: str = "/root",
+    resource_path: str = "/root/hub",
+    state: str = DiscoveredState.DISCOVERED.value,
+    project_id: str | None = None,
+    suggested_name: str = "Hub",
+) -> None:
+    async with factory() as session:
+        session.add(
+            DiscoveredResourceModel(
+                id=resource_id,
+                node_id=node_id,
+                kind="project",
+                resource_key=f"hash-{resource_id}",
+                resource_path=resource_path,
+                project_id=project_id,
+                evidence_json=json.dumps({"suggested_name": suggested_name}),
+                state=state,
+                root_path=root_path,
+                first_seen_at=datetime.now(timezone.utc),
+                last_seen_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+
+async def seed_project(factory, *, project_id: str, name: str) -> None:
+    async with factory() as session:
+        session.add(ProjectModel(id=project_id, name=name, path="/srv/irrelevant", enabled=True))
+        await session.commit()
+
+
+async def grant(factory, *, node_id: str = "E1", project_id: str, capabilities: list[str], granted_by: str = "operator:admin") -> None:
+    async with factory() as session:
+        session.add(
+            ProjectAuthorizationModel(
+                id=f"auth-{project_id}",
+                node_id=node_id,
+                project_id=project_id,
+                capabilities_json=json.dumps(capabilities),
+                granted_by=granted_by,
+                granted_at=datetime.now(timezone.utc),
+            )
+        )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /control — fleet list
+# ---------------------------------------------------------------------------
+
+
+async def test_control_home_requires_a_credential(api) -> None:
+    response = api.get("/control")
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"].startswith("Basic")
+
+
+async def test_control_home_with_a_wrong_password_is_refused(api) -> None:
+    response = api.get("/control", headers=basic("admin", OTHER_PASSWORD))
+    assert response.status_code == 401
+
+
+async def test_control_home_without_the_admin_scope_is_forbidden(api) -> None:
+    response = api.get("/control", headers=basic("alice"))
+    assert response.status_code == 403
+    assert "nodes.read" in response.text
+
+
+async def test_control_home_with_the_admin_scope_is_allowed(api) -> None:
+    """Positive control for the previous three: the credential and scope alone are sufficient."""
+    response = api.get("/control", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "E1" in response.text
+
+
+async def test_control_home_escapes_a_hostile_display_name(api) -> None:
+    await set_node_display_name(api.factory, "E1", "<script>alert(1)</script>")
+    response = api.get("/control", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "<script>alert(1)</script>" not in response.text
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in response.text
+
+
+async def test_control_home_counts_pending_candidates(api) -> None:
+    await seed_resource(api.factory, resource_id="r1", resource_path="/root/hub")
+    await seed_resource(api.factory, resource_id="r2", resource_path="/root/other")
+    response = api.get("/control", headers=basic("admin"))
+    assert response.status_code == 200
+    # Two DISCOVERED candidates for E1 -- the fleet row's pending-count cell.
+    assert ">2<" in response.text
+
+
+# ---------------------------------------------------------------------------
+# GET /control/nodes/{node_id} — node detail
+# ---------------------------------------------------------------------------
+
+
+async def test_control_node_detail_requires_a_credential(api) -> None:
+    response = api.get("/control/nodes/E1")
+    assert response.status_code == 401
+
+
+async def test_control_node_detail_unknown_node_is_404(api) -> None:
+    response = api.get("/control/nodes/does-not-exist", headers=basic("admin"))
+    assert response.status_code == 404
+
+
+async def test_control_node_detail_renders_capabilities_for_an_admin(api) -> None:
+    """Positive control for the previous two."""
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "Capabilities" in response.text
+
+
+async def test_control_node_detail_escapes_a_hostile_resource_path_and_suggested_name(api) -> None:
+    await seed_resource(
+        api.factory,
+        resource_id="r1",
+        resource_path="/tmp/<img src=x onerror=alert(1)>",
+        suggested_name="</code><script>alert(2)</script>",
+    )
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "<img src=x onerror=alert(1)>" not in response.text
+    assert "<script>alert(2)</script>" not in response.text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in response.text
+    assert "&lt;script&gt;alert(2)&lt;/script&gt;" in response.text
+
+
+async def test_control_node_detail_shows_the_candidate_resource_path(api) -> None:
+    """The one authorized surface `resourcePath` may appear on (docs/api/README.md).
+
+    Positive control for the escaping test above, and for the "never in a
+    title/query string" rule this module's docstring states: the path is in
+    the escaped table body, not in `<title>` and not appended to any `href`.
+    """
+    await seed_resource(api.factory, resource_id="r1", resource_path="/srv/projects/hub")
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "/srv/projects/hub" in response.text
+    title_line = response.text.split("<title>", 1)[1].split("</title>", 1)[0]
+    assert "/srv/projects/hub" not in title_line
+
+
+async def test_control_node_detail_paginates_discovered_candidates(api) -> None:
+    total = control_ui_routes.CANDIDATES_PAGE_SIZE + 5
+    for i in range(total):
+        await seed_resource(api.factory, resource_id=f"r{i:03d}", resource_path=f"/root/p{i:03d}")
+
+    first = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert first.status_code == 200
+    first_ids = {f"r{i:03d}" for i in range(total)}
+    shown_on_first = {rid for rid in first_ids if f">{rid}<" in first.text}
+    assert len(shown_on_first) == control_ui_routes.CANDIDATES_PAGE_SIZE
+    assert "Next page" in first.text
+
+    cursor = first.text.split("?cursor=", 1)[1].split('"', 1)[0]
+    second = api.get(f"/control/nodes/E1?cursor={cursor}", headers=basic("admin"))
+    assert second.status_code == 200
+    shown_on_second = {rid for rid in first_ids if f">{rid}<" in second.text}
+    assert len(shown_on_second) == total - control_ui_routes.CANDIDATES_PAGE_SIZE
+    assert shown_on_second.isdisjoint(shown_on_first)
+    assert "Next page" not in second.text
+
+
+async def test_control_node_detail_shows_a_grant_form_for_an_adopted_unauthorized_project(api) -> None:
+    """`ADOPTED` with no capability grant yet has no `project_authorizations`
+
+    row at all -- the exact case `_authorization_section`'s docstring names.
+    The Grant form must still appear so an operator can act on it.
+    """
+    await seed_project(api.factory, project_id="hub", name="Hub")
+    await seed_resource(
+        api.factory, resource_id="r1", resource_path="/root/hub",
+        state=DiscoveredState.ADOPTED.value, project_id="hub",
+    )
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    assert 'data-project-id="hub"' in response.text
+    assert "control-grant" in response.text
+
+
+async def test_control_node_detail_shows_active_capabilities_and_a_revoke_form(api) -> None:
+    await seed_project(api.factory, project_id="hub", name="Hub")
+    await grant(api.factory, project_id="hub", capabilities=["read", "test"])
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "read, test" in response.text
+    assert "control-revoke" in response.text
+
+
+async def test_control_node_detail_warns_that_modify_and_deliver_need_more_than_admin_scope(api) -> None:
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "can_approve_sensitive" in response.text
+    assert "admin" in response.text
+
+
+async def test_control_node_detail_mints_no_audit_event(api) -> None:
+    """Reading a page, and the token minted for its own fetch() calls, are not audited.
+
+    Matches every other *read* path in this codebase (only writes call
+    `record_event`) — see the module docstring, "Authentication".
+    """
+    await seed_resource(api.factory, resource_id="r1")
+    async with api.factory() as session:
+        before = (await session.execute(select(AuditEventModel))).scalars().all()
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    async with api.factory() as session:
+        after = (await session.execute(select(AuditEventModel))).scalars().all()
+    assert len(after) == len(before)
+
+
+async def test_control_node_detail_embeds_a_real_bearer_token_for_its_own_fetch_calls(api) -> None:
+    """The page-scoped token is an ordinary row in the same table `/api/v1/**` reads.
+
+    Confirms the module docstring's claim literally: the token embedded in
+    the rendered page's `<script>` resolves to a live `oauth_access_tokens`
+    row, the same table `current_principal` (`gateway/app/api/auth.py`)
+    looks up for every `/api/v1/**` request.
+    """
+    response = api.get("/control/nodes/E1", headers=basic("admin"))
+    assert response.status_code == 200
+    token = response.text.split("const CB_TOKEN = ", 1)[1].split(";", 1)[0].strip('"')
+    async with api.factory() as session:
+        row = await store.get_oauth_access_token(session, token)
+    assert row is not None
+    assert row.user_id == "admin"
+
+
+# ---------------------------------------------------------------------------
+# GET /control/invite — see control_ui.py's own docstring
+# ---------------------------------------------------------------------------
+
+
+async def test_control_invite_requires_a_credential(api) -> None:
+    response = api.get("/control/invite")
+    assert response.status_code == 401
+
+
+async def test_control_invite_without_the_admin_scope_is_forbidden(api) -> None:
+    response = api.get("/control/invite", headers=basic("alice"))
+    assert response.status_code == 403
+
+
+async def test_control_invite_explains_the_gap_honestly(api) -> None:
+    """Positive control for the previous two, and the point of this screen today:
+
+    it must say plainly that it cannot do what its name promises, never
+    present a form that posts to an endpoint this build does not serve.
+    """
+    response = api.get("/control/invite", headers=basic("admin"))
+    assert response.status_code == 200
+    assert "Not available yet" in response.text
+    assert "/api/v1/nodes/invite" in response.text
+    assert "enroll_node.py" in response.text
+    assert "<form" not in response.text


### PR DESCRIPTION
Issue #73, first cut of Stage 5 — stacked on #95, review that first. The panel the operator opens on `frida` to understand the fleet before entering a project.

## Form, and why
Server-rendered HTML from the gateway process itself — not a SPA, no build step, no second deployable. The precedent is exact: `/oauth/authorize` is already an HTML form served by `HTMLResponse` from `main.py`. Reads call the same DTO functions the JSON routes use; writes are `fetch()` against the real `/api/v1/**` routes from #87/#92/#95, so a 403 on granting `modify`/`deliver` is the real ladder answering, not a guess. When Stage 5's full SPA arrives it replaces the template against the same API.

## Authentication — the part that needed judgment
`current_principal` reads only `Authorization: Bearer`, which a browser cannot attach on navigation, so gating `/control` on it would make the page unreachable. The screens use **HTTP Basic**, re-verified per request against the same `authenticate_async` password check `/oauth/authorize` already uses, and gated by the same `permissions.is_allowed` catalogue as the JSON routes — no cookie session, no CSRF surface. Write actions still need a real Bearer token, so each page render mints an ordinary short-lived `oauth_access_tokens` row (same table, same scope cap as mobile sign-in), inline in the page's own `<script>`, never in a URL and never logged.

Cost, documented rather than hidden: Basic re-derives the PBKDF2 hash on every click, pagination included. Acceptable for a single-operator console; it would not be for a multi-user one.

## Three screens work, the fourth explains itself
`GET /control` (fleet: health, admission state, pending-candidate count) and `GET /control/nodes/{id}` (capabilities and engines, paginated candidates with Adopt/Deny, authorizations with Grant/Revoke).

`GET /control/invite` does **not** work on this build, and says so precisely. `POST /api/v1/nodes/invite` and `scripts/enroll_node.py` exist — they are #87 — but on a branch this one was not cut from, so the endpoint the page needs is genuinely absent from the process serving it. **The gap is lineage, not capability**: the screen lights up when #87 merges, and nothing needs designing again.

That distinction is itself a review fix on this PR. The screen, the docs and the napkin-lessons entry originally all claimed the endpoint and script did not exist anywhere. The verification behind it (`grep -rn`, `ls scripts/`) was sound and the conclusion was not: on a day with parallel branches, a checkout is not the repository. The cause is one layer up — the plan named this branch's base as "C4 (+C1 merged)" and the worktree was cut from C4 alone, C1 being C4's sibling rather than its ancestor. The lesson is rewritten around what is actually true.

Deliberately absent: Missions, Decisions, Audit, Settings (Stage 6), project editing, anything IDE-shaped — the non-goals #73 lists in writing.

## Validation
`pytest -q`: **906 passed, 7 skipped, 0 failed** (baseline 886). `tests/contract/`: 26 passed, including three `x-contract-excluded-paths` entries for `/control/**`; `API_CONTRACT_VERSION` untouched at 1.14.0 since no `/api` route changed. Escaping and pagination were verified by breaking them on purpose and watching the tests fail before reverting — a hostile `display_name` produces no script, and a candidate path never reaches a `<title>`, a query string or a log.

## To actually see it — your action
1. **nginx on `frida`**: the vhost is a `location` allowlist with **no catch-all**, so the panel 404s at the edge until the block from `docs/operations.md` (already applied to the repo's own `deploy/nginx/frida-codex-bridge.conf`) is copied into the live config, then `nginx -t && systemctl reload nginx`.
2. **No migration** — no schema changed.
3. **Credentials**: any `users.json` account with `codexbridge.admin`; the browser's native Basic dialog handles sign-in. Granting `modify`/`deliver` additionally needs `can_approve_sensitive` or the admin role, per #95's ladder.

## Not validated
No real browser against a live gateway, and the nginx block was never run through a real nginx.

https://claude.ai/code/session_01B1am3e7NdAaL2nxj8EkpJw