### PR TITLE
chore: ignore backups/, where local database snapshots live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 .pytest_cache/
 .coverage
 codex_bridge.db
+# Local database snapshots. They carry real rows; see backups/README.md.
+backups/
 dist/
 build/
 *.egg-info/


### PR DESCRIPTION
One line of `.gitignore`, so `main` does not sit one commit behind over it.

A snapshot of `./codex_bridge.db` carries real rows, and the file it is copied
from is already ignored on line 5 — so without this entry the *copy* is the one
form of that database a `git add -A` would stage. `backups/README.md` (also
ignored) records what is in there and why.

Placed in the project's own section of the file: lines 12–60 belong to the
AI-Agents kit and are replaced on `--upgrade`.

https://claude.ai/code/session_01Jzq8HuSJTkm3ucSGVn6gTT